### PR TITLE
docs: sync README dependency versions with current releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ Add the packages you need to your `pubspec.yaml`:
 ```yaml
 dependencies:
   # Core ERC-4337 functionality
-  permissionless: ^0.1.2
+  permissionless: ^0.3.0
 
   # Optional: WebAuthn/Passkeys support
-  permissionless_passkeys: ^0.1.0
+  permissionless_passkeys: ^0.1.1
 ```
 
 ### Basic Usage

--- a/packages/permissionless/README.md
+++ b/packages/permissionless/README.md
@@ -52,7 +52,7 @@ Add to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  permissionless: ^0.1.0
+  permissionless: ^0.3.0
 ```
 
 Then run:

--- a/packages/permissionless_passkeys/README.md
+++ b/packages/permissionless_passkeys/README.md
@@ -25,8 +25,8 @@ Add to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  permissionless_passkeys: ^0.1.0
-  permissionless: ^0.2.0  # Required peer dependency
+  permissionless_passkeys: ^0.1.1
+  permissionless: ^0.3.0  # Required peer dependency
 ```
 
 Then run:


### PR DESCRIPTION
- permissionless: ^0.1.2 / ^0.1.0 -> ^0.3.0
- permissionless_passkeys: ^0.1.0 -> ^0.1.1
- permissionless (peer dep in passkeys README): ^0.2.0 -> ^0.3.0