### PR TITLE
ci: auto-sync README dependency versions with pubspec.yaml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,13 +8,27 @@ changeset:
 .PHONY: version
 version:
 	dart run tool/changeset_version.dart
+	dart run tool/changeset_readme_sync.dart --write
 
 .PHONY: changelog
 changelog:
 	dart run tool/changeset_changelog.dart
 
-# Prepare release by updating versions and changelogs. Does not publish.
+# Rewrite README dependency versions to match packages/*/pubspec.yaml.
+.PHONY: sync-readme
+sync-readme:
+	dart run tool/changeset_readme_sync.dart --write
+
+# Fail if any README dependency version is out of sync with pubspec.yaml.
+# Intended for CI gating.
+.PHONY: check-readme
+check-readme:
+	dart run tool/changeset_readme_sync.dart --check
+
+# Prepare release by updating versions (+ syncing READMEs) and changelogs.
+# Does not publish.
 .PHONY: prepare-release
 prepare-release:
 	dart run tool/changeset_version.dart
+	dart run tool/changeset_readme_sync.dart --write
 	dart run tool/changeset_changelog.dart

--- a/tool/changeset_readme_sync.dart
+++ b/tool/changeset_readme_sync.dart
@@ -1,0 +1,120 @@
+// tool/changeset_readme_sync.dart
+//
+// Syncs `<package>: ^X.Y.Z` references in README files with the current
+// version declared in each package's pubspec.yaml.
+//
+// Modes:
+//   --write   Mutate README files to match current pubspec versions (default).
+//   --check   Do not mutate; exit 1 if any README is out of sync.
+//
+// Scope: rewrites only pubspec-style lines (e.g. `  permissionless: ^0.3.0`)
+// anchored to the start of a line. Narrative prose and import statements are
+// left alone because the package name must be the first non-whitespace token
+// on the line and must be immediately followed by a colon.
+
+import 'dart:io';
+
+import 'changeset_lib.dart';
+
+const _defaultReadmes = [
+  'README.md',
+  'packages/permissionless/README.md',
+  'packages/permissionless_passkeys/README.md',
+];
+
+enum _Mode { write, check }
+
+void main(List<String> args) {
+  final mode = _parseMode(args);
+  try {
+    exitCode = _run(mode);
+  } catch (e, st) {
+    stderr
+      ..writeln('error: $e')
+      ..writeln(st);
+    exitCode = 1;
+  }
+}
+
+_Mode _parseMode(List<String> args) {
+  final hasWrite = args.contains('--write');
+  final hasCheck = args.contains('--check');
+  if (hasWrite && hasCheck) {
+    stderr.writeln('error: --write and --check are mutually exclusive');
+    exit(2);
+  }
+  if (hasCheck) return _Mode.check;
+  return _Mode.write;
+}
+
+int _run(_Mode mode) {
+  final packages = discoverPackages();
+  if (packages.isEmpty) {
+    throw Exception('no packages discovered under $packagesRootDirName/');
+  }
+
+  final versions = <String, String>{
+    for (final p in packages) p.name: readPubspecVersion(p.pubspecPath),
+  };
+
+  var anyDrift = false;
+
+  for (final path in _defaultReadmes) {
+    final file = File(path);
+    if (!file.existsSync()) {
+      stderr.writeln('warning: README not found: $path');
+      continue;
+    }
+    final original = file.readAsStringSync();
+    final updated = rewriteReadme(original, versions);
+    if (updated == original) continue;
+
+    anyDrift = true;
+    if (mode == _Mode.check) {
+      stderr.writeln('DRIFT: $path has stale version reference(s)');
+    } else {
+      file.writeAsStringSync(updated);
+      stdout.writeln('updated: $path');
+    }
+  }
+
+  if (mode == _Mode.check) {
+    if (anyDrift) {
+      stderr
+        ..writeln('')
+        ..writeln(
+            'README version references are out of sync with pubspec.yaml.')
+        ..writeln('Run: dart run tool/changeset_readme_sync.dart --write');
+      return 1;
+    }
+    stdout.writeln('README versions match pubspec.yaml.');
+    return 0;
+  }
+
+  if (!anyDrift) {
+    stdout.writeln('No README updates needed.');
+  }
+  return 0;
+}
+
+/// Rewrites every pubspec-style `<name>: <version>` line in [input] whose name
+/// matches a key in [versions], replacing the existing version with the
+/// corresponding value. Anchors the match to the start of a line so narrative
+/// prose is left alone. Exposed at library scope for unit testing.
+String rewriteReadme(String input, Map<String, String> versions) {
+  var out = input;
+  for (final entry in versions.entries) {
+    final escapedName = RegExp.escape(entry.key);
+    final target = entry.value;
+    final pattern = RegExp(
+      '^(\\s*$escapedName\\s*:\\s*\\^?)(\\d+\\.\\d+\\.\\d+[\\w.-]*)(.*)\$',
+      multiLine: true,
+    );
+    out = out.replaceAllMapped(pattern, (m) {
+      final prefix = m.group(1)!;
+      final trailing = m.group(3)!;
+      return '$prefix$target$trailing';
+    });
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary

- Adds `tool/changeset_readme_sync.dart` that rewrites `<package>: ^X.Y.Z` references in README files to match current `packages/*/pubspec.yaml` versions.
- Wires into `make version` and `make prepare-release` so README install snippets stay in lockstep with each release.
- New standalone Make targets: `make sync-readme` (mutating) and `make check-readme` (gating, exits 1 on drift).

## Why

On this branch's parent (main), the 3 README files all reference stale versions (`permissionless ^0.1.0–^0.1.2`, `permissionless_passkeys ^0.1.0`) while published packages are `permissionless 0.3.0` and `permissionless_passkeys 0.1.1`. PR #9 fixes the drift manually; this PR prevents it from recurring.

## How it matches

Line-anchored regex `^(\s*<name>\s*:\s*\^?)(\d+\.\d+\.\d+[\w.-]*)(.*)$` in multiline mode. Because it requires the package name to be the first non-whitespace token on a line followed immediately by a colon, it:
- **Matches**: pubspec-style install snippets like `  permissionless: ^0.3.0  # comment`
- **Ignores**: narrative prose (`"Released permissionless 0.1.0 in Q1"`), import statements, anchor text, etc.
- **Is safe against name-prefix overlap**: a rule for `permissionless` will not match a line for `permissionless_passkeys` because the char after `permissionless` would be `_`, not `\s*:`.

## Test plan

- [x] Ran `dart run tool/changeset_readme_sync.dart --check` against main — correctly flagged all 3 stale READMEs and exited 1
- [x] Ran `--write` — rewrote exactly the 5 known drifted lines, no false positives, same diff as PR #9
- [x] `dart analyze` passes on new file
- [x] `dart format --set-exit-if-changed` passes on new file

## Follow-ups (not in this PR)

- Add `make check-readme` as a CI gate step in `.github/workflows/verify.yml` after PR #8 merges (otherwise conflicts with that PR). It's a single `- name: Check README sync / run: make check-readme` step under the `lint` job.

## Merge order with #8 and #9

Any order works. This PR doesn't touch `.github/` or the 3 README files, so no conflicts with either open PR.