### PR TITLE
ci: harden workflows (SHA-pin actions, permissions, concurrency)

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -29,7 +29,7 @@ jobs:
           - permissionless_passkeys
     steps:
       - name: Clone repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Install dependencies
         uses: ./.github/actions/install-dependencies

--- a/.github/workflows/on-push-to-main.yml
+++ b/.github/workflows/on-push-to-main.yml
@@ -24,7 +24,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Clone repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 
@@ -53,7 +53,7 @@ jobs:
       - name: Create or update version PR
         id: cpr
         if: steps.detect.outputs.has_changesets == 'true'
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: version-packages
@@ -97,7 +97,7 @@ jobs:
       contents: write  # required to push tags
     steps:
       - name: Clone repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           # Full history: the version-PR merge may be a merge commit with
           # multiple parents, and we need to resolve HEAD~1 reliably.

--- a/.github/workflows/publish-permissionless-passkeys.yml
+++ b/.github/workflows/publish-permissionless-passkeys.yml
@@ -8,11 +8,20 @@ on:
     tags:
       - 'permissionless_passkeys-v[0-9]+.[0-9]+.[0-9]+*'
 
+permissions:
+  contents: read
+
+concurrency:
+  # Never cancel an in-flight pub.dev publish — a half-run release would be
+  # worse than a delayed one. Serialize releases by group instead.
+  group: publish-permissionless-passkeys
+  cancel-in-progress: false
+
 jobs:
   publish:
     permissions:
       id-token: write  # required for OIDC trusted publishing
-    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@65eb853c7ba17dde3be364c3d2858773e7144260  # v1.7.2
     with:
       environment: release
       working-directory: packages/permissionless_passkeys

--- a/.github/workflows/publish-permissionless.yml
+++ b/.github/workflows/publish-permissionless.yml
@@ -8,11 +8,20 @@ on:
     tags:
       - 'permissionless-v[0-9]+.[0-9]+.[0-9]+*'
 
+permissions:
+  contents: read
+
+concurrency:
+  # Never cancel an in-flight pub.dev publish — a half-run release would be
+  # worse than a delayed one. Serialize releases by group instead.
+  group: publish-permissionless
+  cancel-in-progress: false
+
 jobs:
   publish:
     permissions:
       id-token: write  # required for OIDC trusted publishing
-    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@65eb853c7ba17dde3be364c3d2858773e7144260  # v1.7.2
     with:
       environment: release
       working-directory: packages/permissionless

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -19,7 +19,7 @@ jobs:
       contents: write
     steps:
       - name: Clone repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           # Check out the PR branch directly (not the merge commit) so
           # git-auto-commit-action can push format fixes back to it.
@@ -39,7 +39,7 @@ jobs:
         run: make check-readme
 
       - name: Commit format fixes
-        uses: stefanzweifel/git-auto-commit-action@v7
+        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9  # v7.1.0
         with:
           commit_message: 'chore: format'
           commit_user_name: 'github-actions[bot]'
@@ -51,7 +51,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Clone repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Install dependencies
         uses: ./.github/actions/install-dependencies


### PR DESCRIPTION
## Summary
- SHA-pin every third-party GitHub Action reference (`actions/checkout`, `peter-evans/create-pull-request`, `stefanzweifel/git-auto-commit-action`, `dart-lang/setup-dart`).
- Add top-level `permissions: contents: read` and a `concurrency:` block to both publish workflows (previously ungated — back-to-back tag pushes could race `pub publish`).
- Publish concurrency uses `cancel-in-progress: false` so an in-flight publish is never killed.

## Why
- A rewritten float tag (e.g. `@v8` → new commit) would otherwise execute attacker-controlled code with `contents: write`, `pull-requests: write`, or pub.dev OIDC credentials. Pinning to SHAs fixes this. The Dependabot `github-actions` entry at `/` keeps the SHAs fresh by reading the trailing `# vX.Y.Z` comment.
- Publish workflows currently have no top-level permissions, so `GITHUB_TOKEN` falls back to repo-default scopes; now narrowed to `contents: read`.

## Pinned refs (resolved via `gh release view` + `gh api repos/.../git/refs/tags`)
| Action | Tag | Commit SHA |
|---|---|---|
| `actions/checkout` | v6.0.2 | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` |
| `peter-evans/create-pull-request` | v8.1.1 | `5f6978faf089d4d20b00c7766989d076bb2fc7f1` |
| `stefanzweifel/git-auto-commit-action` | v7.1.0 | `04702edda442b2e678b25b537cec683a1493fcb9` |
| `dart-lang/setup-dart` (reusable workflow) | v1.7.2 | `65eb853c7ba17dde3be364c3d2858773e7144260` |

## Test plan
- [ ] Pull request workflow passes on this PR (verify + publish dry-run jobs).
- [ ] `node .a5c/processes/ci-health-audit/scripts/check-action-pins.mjs .github/workflows` passes locally (it does).
- [ ] YAML parses for all 5 edited files (it does).
- [ ] After merge: Dependabot's `github-actions` entry at `/` still proposes SHA bumps by reading the `# vX` trailing comments.

## Files changed
- `.github/workflows/on-pull-request.yml` — pin `actions/checkout`
- `.github/workflows/on-push-to-main.yml` — pin 2× `actions/checkout`, 1× `peter-evans/create-pull-request`
- `.github/workflows/publish-permissionless.yml` — pin `dart-lang/setup-dart` reusable + add top-level `permissions` and `concurrency`
- `.github/workflows/publish-permissionless-passkeys.yml` — same as above
- `.github/workflows/verify.yml` — pin 2× `actions/checkout`, 1× `stefanzweifel/git-auto-commit-action`

🤖 Generated as part of the CI health audit run.
