### PR TITLE
ci: fail on format drift instead of auto-committing fixes

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -15,35 +15,21 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    permissions:
-      contents: write
     steps:
       - name: Clone repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          # Check out the PR branch directly (not the merge commit) so
-          # git-auto-commit-action can push format fixes back to it.
-          # Falls back to github.ref for workflow_dispatch / push triggers.
-          ref: ${{ github.head_ref || github.ref }}
 
       - name: Install dependencies
         uses: ./.github/actions/install-dependencies
 
-      - name: Format
-        run: dart format .
+      - name: Format check
+        run: dart format --set-exit-if-changed .
 
       - name: Analyze
         run: dart analyze
 
       - name: Check README versions match pubspec.yaml
         run: make check-readme
-
-      - name: Commit format fixes
-        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9  # v7.1.0
-        with:
-          commit_message: 'chore: format'
-          commit_user_name: 'github-actions[bot]'
-          commit_user_email: 'github-actions[bot]@users.noreply.github.com'
 
   test:
     name: Test


### PR DESCRIPTION
## Summary
Replace the `dart format .` + `git-auto-commit-action` pattern in `verify.yml` with `dart format --set-exit-if-changed .` so CI fails on unformatted code instead of silently rewriting PRs.

## Why this matters
- **Security**: `git-auto-commit-action` required `contents: write` on the lint job, which is broader than needed. That permission is now removed.
- **Consistency**: `melos format:check` already uses `--set-exit-if-changed`. This makes CI match the local dev script.
- **Clarity**: Auto-commits from CI can confuse contributors and obscure the real state of a PR.

## ⚠️ Behavioural change
Contributors must run `dart run melos format` (or `dart format .`) locally before pushing. CI will now fail the Lint check on unformatted code instead of pushing a fix commit.

## Changes
- `verify.yml` lint job: `dart format .` → `dart format --set-exit-if-changed .`
- Removed `stefanzweifel/git-auto-commit-action` step
- Removed `ref: ${{ github.head_ref || github.ref }}` override on checkout (no longer needed)
- Removed `permissions: contents: write` on lint job (inherits top-level `contents: read`)

## Test plan
- [ ] Lint check passes on this PR (code is already formatted).
- [ ] A follow-up PR with unformatted code should fail the Lint check.

🤖 Generated as part of the CI health audit run.
