### PR TITLE
ci: add workflow_dispatch dry-run trigger to publish workflows

### DIFF
--- a/.github/workflows/publish-permissionless-passkeys.yml
+++ b/.github/workflows/publish-permissionless-passkeys.yml
@@ -7,6 +7,12 @@ on:
     # `-pre.1`, `-rc.2`, or `+hotfix` so those still trigger publishing.
     tags:
       - 'permissionless_passkeys-v[0-9]+.[0-9]+.[0-9]+*'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Run dart pub publish --dry-run without actually publishing'
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -19,9 +25,25 @@ concurrency:
 
 jobs:
   publish:
+    if: github.event_name == 'push'
     permissions:
       id-token: write  # required for OIDC trusted publishing
     uses: dart-lang/setup-dart/.github/workflows/publish.yml@65eb853c7ba17dde3be364c3d2858773e7144260  # v1.7.2
     with:
       environment: release
       working-directory: packages/permissionless_passkeys
+
+  dry-run:
+    if: github.event_name == 'workflow_dispatch' && inputs.dry_run == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Install dependencies
+        uses: ./.github/actions/install-dependencies
+
+      - name: Dry-run publish
+        run: dart pub publish --dry-run
+        working-directory: packages/permissionless_passkeys

--- a/.github/workflows/publish-permissionless.yml
+++ b/.github/workflows/publish-permissionless.yml
@@ -7,6 +7,12 @@ on:
     # `-pre.1`, `-rc.2`, or `+hotfix` so those still trigger publishing.
     tags:
       - 'permissionless-v[0-9]+.[0-9]+.[0-9]+*'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Run dart pub publish --dry-run without actually publishing'
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -19,9 +25,25 @@ concurrency:
 
 jobs:
   publish:
+    if: github.event_name == 'push'
     permissions:
       id-token: write  # required for OIDC trusted publishing
     uses: dart-lang/setup-dart/.github/workflows/publish.yml@65eb853c7ba17dde3be364c3d2858773e7144260  # v1.7.2
     with:
       environment: release
       working-directory: packages/permissionless
+
+  dry-run:
+    if: github.event_name == 'workflow_dispatch' && inputs.dry_run == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Install dependencies
+        uses: ./.github/actions/install-dependencies
+
+      - name: Dry-run publish
+        run: dart pub publish --dry-run
+        working-directory: packages/permissionless


### PR DESCRIPTION
## Summary
Add `workflow_dispatch` with a `dry_run` boolean input to both publish workflows so operators can re-run `dart pub publish --dry-run` without cutting a tag.

## Why
Currently the only way to retry a failed publish or verify that a package is publishable is to push a new tag. A manual dispatch with `dry_run: true` (the default) gives operators a safer, lower-noise option.

## Changes
Both `publish-permissionless.yml` and `publish-permissionless-passkeys.yml`:
- Added `workflow_dispatch.inputs.dry_run` (boolean, default: `true`)
- Added `dry-run` job gated on `github.event_name == 'workflow_dispatch' && inputs.dry_run == true`
- Added `if: github.event_name == 'push'` guard on the existing `publish` job so it never fires on a manual dispatch

The pub.dev reusable workflow (`dart-lang/setup-dart/.github/workflows/publish.yml`) doesn't accept a `dry_run` input, so the dry-run path runs `dart pub publish --dry-run` directly in a standard runner job.

## Test plan
- [ ] PR checks pass (no actual publish triggered).
- [ ] After merge: trigger manually via GitHub Actions UI with `dry_run: true` — should run `dart pub publish --dry-run` and pass.
- [ ] Trigger with `dry_run: false` (or leave unchecked) — should skip `dry-run` job and only run `publish` job if triggered by a tag (i.e., skips on manual dispatch without a tag).

🤖 Generated as part of the CI health audit run.
