### PR TITLE
RALPH #24: Lock down the v0.9 built-in account support matrix

### DIFF
--- a/packages/permissionless/README.md
+++ b/packages/permissionless/README.md
@@ -8,20 +8,26 @@ Build account abstraction applications in Dart with support for multiple smart a
 
 ### Smart Accounts
 
-| Account       | Provider       | EntryPoint | ERC-7579   | Description                      |
-| ------------- | -------------- | ---------- | ---------- | -------------------------------- |
-| **Safe**      | Gnosis         | v0.6, v0.7 | Optional*  | Battle-tested multi-sig account  |
-| **Kernel**    | ZeroDev        | v0.6, v0.7 | v0.3.x     | Modular account with plugins     |
-| **Nexus**     | Biconomy       | v0.7       | Yes        | ERC-7579 modular account         |
-| **Light**     | Alchemy        | v0.6, v0.7 | No         | Gas-efficient single-owner       |
-| **Simple**    | eth-infinitism | v0.6, v0.7 | No         | Minimal reference implementation |
-| **Thirdweb**  | Thirdweb       | v0.6, v0.7 | No         | SDK ecosystem integration        |
-| **Trust**     | Trust Wallet   | v0.6       | No         | Diamond architecture (Barz)      |
-| **Etherspot** | Etherspot      | v0.7       | Internal** | ModularEtherspotWallet           |
-| **Biconomy**  | Biconomy       | v0.6       | No         | *Deprecated - use Nexus*         |
+| Account             | Provider       | EntryPoint       | ERC-7579   | Description                         |
+| ------------------- | -------------- | ---------------- | ---------- | ----------------------------------- |
+| **Safe**            | Gnosis         | v0.6, v0.7       | Optional*  | Battle-tested multi-sig account     |
+| **Kernel**          | ZeroDev        | v0.6, v0.7       | v0.3.x     | Modular account with plugins        |
+| **Nexus**           | Biconomy       | v0.7             | Yes        | ERC-7579 modular account            |
+| **Light**           | Alchemy        | v0.6, v0.7       | No         | Gas-efficient single-owner          |
+| **Simple**          | eth-infinitism | v0.6, v0.7, v0.8 | No         | Minimal reference implementation    |
+| **Simple7702**      | eth-infinitism | v0.8, v0.9       | No         | EIP-7702 Simple account delegation  |
+| **Thirdweb**        | Thirdweb       | v0.6, v0.7       | No         | SDK ecosystem integration           |
+| **Trust**           | Trust Wallet   | v0.6             | No         | Diamond architecture (Barz)         |
+| **Etherspot**       | Etherspot      | v0.7             | Internal** | ModularEtherspotWallet              |
+| **Biconomy**        | Biconomy       | v0.6             | No         | *Deprecated - use Nexus*            |
 
 \* Safe requires `erc7579LaunchpadAddress` configuration to enable ERC-7579 module management.
 \** Etherspot uses ERC-7579 call encoding internally but module management actions are not exposed in permissionless.js.
+
+EntryPoint v0.9 is opt-in. Generic clients can target `EntryPointAddresses.v09`;
+official built-in account support is limited to Simple7702. Other account
+families do not claim v0.9 support unless you provide custom contract addresses,
+which is treated as user-supplied experimentation.
 
 ### Clients
 
@@ -530,6 +536,8 @@ final allowanceOverride = erc20AllowanceOverride(
 | ------- | --------------- | ----------------------------------------------------------------------------------- |
 | v0.6    | `0x5FF1...2789` | Safe v1.4.1, Kernel v0.2.4, Light v1.1.0, Trust                                     |
 | v0.7    | `0x0000...0070` | Safe v1.4.1/v1.5.0, Kernel v0.3.1, Nexus, Light v2.0.0, Simple, Thirdweb, Etherspot |
+| v0.8    | `0x4337...f108` | Simple, Simple7702                                                                  |
+| v0.9    | `0x4337...d009` | Generic clients, Simple7702                                                         |
 
 ## Examples
 

--- a/packages/permissionless/lib/src/accounts/light/constants.dart
+++ b/packages/permissionless/lib/src/accounts/light/constants.dart
@@ -32,6 +32,12 @@ enum LightAccountVersion {
           'Light Account does not support EntryPoint v0.8. '
           'Use Eip7702SimpleSmartAccount for EIP-7702 support.',
         );
+      case EntryPointVersion.v09:
+        throw ArgumentError(
+          'Light Account does not have an official EntryPoint v0.9 '
+          'deployment. Provide a customFactoryAddress and explicit '
+          'LightAccountVersion only for user-supplied experimentation.',
+        );
     }
   }
 }

--- a/packages/permissionless/lib/src/accounts/simple/constants.dart
+++ b/packages/permissionless/lib/src/accounts/simple/constants.dart
@@ -26,6 +26,11 @@ class SimpleAccountFactoryAddresses {
         EntryPointVersion.v06 => v06,
         EntryPointVersion.v07 => v07,
         EntryPointVersion.v08 => v08,
+        EntryPointVersion.v09 => throw UnsupportedError(
+            'SimpleSmartAccount does not have an official EntryPoint v0.9 '
+            'factory deployment. Provide a customFactoryAddress for '
+            'user-supplied v0.9 experimentation.',
+          ),
       };
 }
 
@@ -35,11 +40,32 @@ class SimpleAccountFactoryAddresses {
 class Simple7702AccountAddresses {
   Simple7702AccountAddresses._();
 
-  /// The default Simple7702Account implementation address.
+  /// Simple7702Account implementation for EntryPoint v0.8.
   ///
   /// This contract is part of the eth-infinitism ERC-4337 v0.8 release.
-  static final EthereumAddress defaultLogic =
+  static final EthereumAddress v08 =
       EthereumAddress.fromHex('0xe6Cae83BdE06E4c305530e199D7217f42808555B');
+
+  /// Simple7702Account implementation for EntryPoint v0.9.
+  ///
+  /// This contract is part of the eth-infinitism ERC-4337 v0.9 release.
+  static final EthereumAddress v09 =
+      EthereumAddress.fromHex('0xa46cc63eBF4Bd77888AA327837d20b23A63a56B5');
+
+  /// The default Simple7702Account implementation address.
+  ///
+  /// Defaults remain on EntryPoint v0.8 unless v0.9 is explicitly selected.
+  static final EthereumAddress defaultLogic = v08;
+
+  /// Gets the Simple7702Account implementation for an EntryPoint version.
+  static EthereumAddress fromVersion(EntryPointVersion version) =>
+      switch (version) {
+        EntryPointVersion.v08 => v08,
+        EntryPointVersion.v09 => v09,
+        EntryPointVersion.v06 || EntryPointVersion.v07 => throw ArgumentError(
+            'Simple7702Account supports EntryPoint v0.8 and v0.9 only.',
+          ),
+      };
 }
 
 /// Function selectors for SimpleAccount contracts.

--- a/packages/permissionless/lib/src/accounts/simple/eip7702_simple_account.dart
+++ b/packages/permissionless/lib/src/accounts/simple/eip7702_simple_account.dart
@@ -123,14 +123,18 @@ class Eip7702SimpleSmartAccountConfig {
   ///
   /// Optional parameters:
   /// - [publicClient]: Client for checking deployment status (EIP-1271)
+  /// - [entryPointVersion]: EntryPoint version (v0.8 by default; v0.9 opt-in)
   /// - [accountLogicAddress]: Override the default Simple7702Account logic
   Eip7702SimpleSmartAccountConfig({
     required this.owner,
     required this.chainId,
     this.publicClient,
+    EntryPointVersion entryPointVersion = EntryPointVersion.v08,
     EthereumAddress? accountLogicAddress,
-  }) : accountLogicAddress =
-            accountLogicAddress ?? Simple7702AccountAddresses.defaultLogic;
+  })  : entryPointVersion = _validateEntryPointVersion(entryPointVersion),
+        accountLogicAddress =
+            accountLogicAddress ??
+                Simple7702AccountAddresses.fromVersion(entryPointVersion);
 
   /// The owner of this EIP-7702 account (the EOA).
   final Eip7702SimpleAccountOwner owner;
@@ -144,10 +148,26 @@ class Eip7702SimpleSmartAccountConfig {
   /// has been delegated (deployed) before signing messages/typed data.
   final PublicClient? publicClient;
 
+  /// EntryPoint version to use for this EIP-7702 account.
+  final EntryPointVersion entryPointVersion;
+
   /// The Simple7702Account logic contract address.
   ///
   /// Defaults to the official eth-infinitism Simple7702Account.
   final EthereumAddress accountLogicAddress;
+
+  static EntryPointVersion _validateEntryPointVersion(
+    EntryPointVersion entryPointVersion,
+  ) {
+    if (entryPointVersion == EntryPointVersion.v08 ||
+        entryPointVersion == EntryPointVersion.v09) {
+      return entryPointVersion;
+    }
+
+    throw ArgumentError(
+      'Simple7702Account supports EntryPoint v0.8 and v0.9 only.',
+    );
+  }
 }
 
 /// An EIP-7702 Simple smart account implementation.
@@ -157,8 +177,8 @@ class Eip7702SimpleSmartAccountConfig {
 ///
 /// - **Account address = EOA address**: No separate smart account deployment
 /// - **No factory needed**: The authorization delegates code on-demand
-/// - **EntryPoint v0.8**: Required for native EIP-7702 support
-/// - **Typed data signing**: v0.8 uses EIP-712 typed data for UserOperation signing
+/// - **EntryPoint v0.8/v0.9**: Required for native EIP-7702 support
+/// - **Typed data signing**: Uses EIP-712 typed data for UserOperation signing
 ///
 /// Example:
 /// ```dart
@@ -194,8 +214,8 @@ class Eip7702SimpleSmartAccount implements Eip7702SmartAccount {
   @override
   bool get isEip7702 => true;
 
-  /// The EntryPoint version (always v0.8 for EIP-7702).
-  EntryPointVersion get entryPointVersion => EntryPointVersion.v08;
+  /// The EntryPoint version.
+  EntryPointVersion get entryPointVersion => _config.entryPointVersion;
 
   /// The chain ID.
   @override
@@ -203,7 +223,8 @@ class Eip7702SimpleSmartAccount implements Eip7702SmartAccount {
 
   /// The EntryPoint address for this account.
   @override
-  EthereumAddress get entryPoint => EntryPointAddresses.v08;
+  EthereumAddress get entryPoint =>
+      EntryPointAddresses.fromVersion(entryPointVersion);
 
   /// The nonce key for parallel transaction support.
   @override
@@ -519,7 +540,7 @@ class Eip7702SimpleSmartAccount implements Eip7702SmartAccount {
 /// an EOA to function as a smart account without deploying a separate contract.
 ///
 /// **Requirements:**
-/// - EntryPoint v0.8 (automatically used)
+/// - EntryPoint v0.8 by default, or v0.9 when explicitly selected
 /// - Bundler with EIP-7702 support
 /// - Chain with EIP-7702 enabled
 ///
@@ -540,6 +561,7 @@ Eip7702SimpleSmartAccount createEip7702SimpleSmartAccount({
   required Eip7702SimpleAccountOwner owner,
   required BigInt chainId,
   PublicClient? publicClient,
+  EntryPointVersion entryPointVersion = EntryPointVersion.v08,
   EthereumAddress? accountLogicAddress,
 }) =>
     Eip7702SimpleSmartAccount(
@@ -547,6 +569,7 @@ Eip7702SimpleSmartAccount createEip7702SimpleSmartAccount({
         owner: owner,
         chainId: chainId,
         publicClient: publicClient,
+        entryPointVersion: entryPointVersion,
         accountLogicAddress: accountLogicAddress,
       ),
     );

--- a/packages/permissionless/lib/src/accounts/simple/eip7702_simple_account.dart
+++ b/packages/permissionless/lib/src/accounts/simple/eip7702_simple_account.dart
@@ -132,9 +132,8 @@ class Eip7702SimpleSmartAccountConfig {
     EntryPointVersion entryPointVersion = EntryPointVersion.v08,
     EthereumAddress? accountLogicAddress,
   })  : entryPointVersion = _validateEntryPointVersion(entryPointVersion),
-        accountLogicAddress =
-            accountLogicAddress ??
-                Simple7702AccountAddresses.fromVersion(entryPointVersion);
+        accountLogicAddress = accountLogicAddress ??
+            Simple7702AccountAddresses.fromVersion(entryPointVersion);
 
   /// The owner of this EIP-7702 account (the EOA).
   final Eip7702SimpleAccountOwner owner;

--- a/packages/permissionless/lib/src/accounts/thirdweb/thirdweb_account.dart
+++ b/packages/permissionless/lib/src/accounts/thirdweb/thirdweb_account.dart
@@ -83,14 +83,34 @@ class ThirdwebSmartAccount implements SmartAccount {
   /// Prefer using [createThirdwebSmartAccount] factory function instead
   /// of calling this constructor directly.
   ThirdwebSmartAccount(this._config)
-      : _factoryAddress = _config.customFactoryAddress ??
-            (_config.entryPointVersion == EntryPointVersion.v07
-                ? ThirdwebAddresses.factoryV07
-                : ThirdwebAddresses.factoryV06);
+      : _factoryAddress = _resolveFactoryAddress(_config);
 
   final ThirdwebSmartAccountConfig _config;
   final EthereumAddress _factoryAddress;
   EthereumAddress? _cachedAddress;
+
+  static EthereumAddress _resolveFactoryAddress(
+    ThirdwebSmartAccountConfig config,
+  ) {
+    if (config.customFactoryAddress != null) {
+      return config.customFactoryAddress!;
+    }
+
+    return switch (config.entryPointVersion) {
+      EntryPointVersion.v06 => ThirdwebAddresses.factoryV06,
+      EntryPointVersion.v07 => ThirdwebAddresses.factoryV07,
+      EntryPointVersion.v08 => throw UnsupportedError(
+          'ThirdwebSmartAccount does not have an official EntryPoint v0.8 '
+          'factory deployment. Provide a customFactoryAddress for '
+          'user-supplied experimentation.',
+        ),
+      EntryPointVersion.v09 => throw UnsupportedError(
+          'ThirdwebSmartAccount does not have an official EntryPoint v0.9 '
+          'factory deployment. Provide a customFactoryAddress for '
+          'user-supplied experimentation.',
+        ),
+    };
+  }
 
   /// The owner of this account.
   AccountOwner get owner => _config.owner;
@@ -105,9 +125,7 @@ class ThirdwebSmartAccount implements SmartAccount {
   /// The EntryPoint address.
   @override
   EthereumAddress get entryPoint =>
-      _config.entryPointVersion == EntryPointVersion.v07
-          ? EntryPointAddresses.v07
-          : EntryPointAddresses.v06;
+      EntryPointAddresses.fromVersion(_config.entryPointVersion);
 
   /// The nonce key for parallel transaction support.
   @override

--- a/packages/permissionless/lib/src/clients/bundler/bundler_client.dart
+++ b/packages/permissionless/lib/src/clients/bundler/bundler_client.dart
@@ -70,7 +70,8 @@ class BundlerClient {
   ///
   /// Returns the UserOperation hash.
   ///
-  /// **Note**: Requires a bundler that supports EntryPoint v0.8 and EIP-7702.
+  /// **Note**: Requires a bundler that supports the selected EntryPoint version
+  /// and EIP-7702.
   Future<String> sendUserOperationWithAuthorization(
     UserOperation userOp,
     List<Eip7702Authorization> authorizationList,
@@ -118,7 +119,8 @@ class BundlerClient {
   /// Similar to [estimateUserOperationGas] but includes the authorization
   /// inside the UserOperation for accurate gas estimation of EIP-7702 accounts.
   ///
-  /// **Note**: Requires a bundler that supports EntryPoint v0.8 and EIP-7702.
+  /// **Note**: Requires a bundler that supports the selected EntryPoint version
+  /// and EIP-7702.
   Future<UserOperationGasEstimate> estimateUserOperationGasWithAuthorization(
     UserOperation userOp,
     List<Eip7702Authorization> authorizationList, {

--- a/packages/permissionless/lib/src/clients/smart_account/smart_account_interface.dart
+++ b/packages/permissionless/lib/src/clients/smart_account/smart_account_interface.dart
@@ -139,7 +139,7 @@ abstract class SmartAccountV06 implements SmartAccount {
 /// - Account address equals the owner's EOA address
 /// - No factory deployment needed (`getFactoryData()` returns null)
 /// - Requires EIP-7702 authorization to be included in transactions
-/// - Uses EntryPoint v0.8
+/// - Uses EntryPoint v0.8 or v0.9
 ///
 /// Example:
 /// ```dart

--- a/packages/permissionless/lib/src/constants/entry_point.dart
+++ b/packages/permissionless/lib/src/constants/entry_point.dart
@@ -27,11 +27,18 @@ class EntryPointAddresses {
   static final EthereumAddress v08 =
       EthereumAddress.fromHex('0x4337084d9e255ff0702461cf8895ce9e3b5ff108');
 
+  /// EntryPoint v0.9 address.
+  ///
+  /// Deployed at the same address on all chains.
+  static final EthereumAddress v09 =
+      EthereumAddress.fromHex('0x433709009B8330FDa32311DF1C2AFA402eD8D009');
+
   /// Gets the EntryPoint address for a given version.
   static EthereumAddress fromVersion(EntryPointVersion version) =>
       switch (version) {
         EntryPointVersion.v06 => v06,
         EntryPointVersion.v07 => v07,
         EntryPointVersion.v08 => v08,
+        EntryPointVersion.v09 => v09,
       };
 }

--- a/packages/permissionless/lib/src/types/user_operation.dart
+++ b/packages/permissionless/lib/src/types/user_operation.dart
@@ -11,6 +11,9 @@ import 'hex.dart';
 /// - **v0.6**: Original specification, widely deployed
 /// - **v0.7**: Updated spec with separate factory/paymaster fields,
 ///   better gas handling, and uint128 gas limits
+/// - **v0.8**: Adds native EIP-7702 support
+/// - **v0.9**: Latest EntryPoint deployment; opt-in and supported only by
+///   account families with verified v0.9 deployments
 enum EntryPointVersion {
   /// EntryPoint v0.6 - Original ERC-4337 specification.
   ///
@@ -22,18 +25,24 @@ enum EntryPointVersion {
   /// Address: `0x0000000071727De22E5E9d8BAf0edAc6f37da032`
   v07('0.7'),
 
-  /// EntryPoint v0.8 - Latest specification with EIP-7702 support.
+  /// EntryPoint v0.8 - Specification with EIP-7702 support.
   ///
   /// Address: `0x4337084d9e255ff0702461cf8895ce9e3b5ff108`
   /// This version adds native EIP-7702 support including:
   /// - UserOperation hash includes EIP-7702 delegation address
   /// - EntryPoint checks delegation address is set correctly
   /// - Support for `eip7702Auth` parameter in eth_sendUserOperation
-  v08('0.8');
+  v08('0.8'),
+
+  /// EntryPoint v0.9 - Latest EntryPoint deployment.
+  ///
+  /// Address: `0x433709009B8330FDa32311DF1C2AFA402eD8D009`
+  /// This version keeps the v0.7-style unpacked UserOperation RPC shape.
+  v09('0.9');
 
   const EntryPointVersion(this.value);
 
-  /// The version string (e.g., "0.6", "0.7", or "0.8").
+  /// The version string (e.g., "0.6", "0.7", "0.8", or "0.9").
   final String value;
 }
 
@@ -51,9 +60,10 @@ enum EntryPointVersion {
 /// - **signature**: Proof that the account owner(s) authorized this operation
 ///
 /// ## Usage
-/// This sealed class allows type-safe handling of both v0.6 and v0.7
-/// UserOperations. Use [UserOperationV06] for EntryPoint v0.6 or
-/// [UserOperationV07] for EntryPoint v0.7.
+/// This sealed class allows type-safe handling of v0.6 and the unpacked
+/// v0.7-style UserOperation shape used by EntryPoint v0.7, v0.8, and v0.9.
+/// Use [UserOperationV06] for EntryPoint v0.6 or [UserOperationV07] for the
+/// unpacked shape.
 sealed class UserOperation {
   /// The smart account address that will execute this operation.
   ///

--- a/packages/permissionless/test/accounts/light/light_account_test.dart
+++ b/packages/permissionless/test/accounts/light/light_account_test.dart
@@ -22,6 +22,13 @@ void main() {
         );
       });
 
+      test('v0.9 does not auto-select an official Light version', () {
+        expect(
+          () => LightAccountVersion.forEntryPoint(EntryPointVersion.v09),
+          throwsArgumentError,
+        );
+      });
+
       test('v110 has version string "1.1.0"', () {
         expect(LightAccountVersion.v110.version, equals('1.1.0'));
       });
@@ -161,6 +168,36 @@ void main() {
         );
 
         expect(account.entryPointVersion, equals(EntryPointVersion.v06));
+      });
+
+      test('rejects EntryPoint v0.9 without explicit custom configuration', () {
+        expect(
+          () => createLightSmartAccount(
+            owner: owner,
+            chainId: BigInt.from(1),
+            entryPointVersion: EntryPointVersion.v09,
+            address: mockAddress,
+          ),
+          throwsArgumentError,
+        );
+      });
+
+      test('allows custom EntryPoint v0.9 factory experimentation', () {
+        final customFactory = EthereumAddress.fromHex(
+          '0x1234567890123456789012345678901234567890',
+        );
+
+        final account = createLightSmartAccount(
+          owner: owner,
+          chainId: BigInt.from(1),
+          entryPointVersion: EntryPointVersion.v09,
+          version: LightAccountVersion.v200,
+          customFactoryAddress: customFactory,
+          address: mockAddress,
+        );
+
+        expect(account.entryPointVersion, equals(EntryPointVersion.v09));
+        expect(account.entryPoint, equals(EntryPointAddresses.v09));
       });
 
       test('address is deterministic', () async {

--- a/packages/permissionless/test/accounts/safe/safe_account_test.dart
+++ b/packages/permissionless/test/accounts/safe/safe_account_test.dart
@@ -133,6 +133,19 @@ void main() {
           throwsArgumentError,
         );
       });
+
+      test('throws for unsupported EntryPoint v0.9 combination', () {
+        final owner = PrivateKeyOwner(testPrivateKey);
+
+        expect(
+          () => createSafeSmartAccount(
+            owners: [owner],
+            entryPointVersion: EntryPointVersion.v09,
+            chainId: BigInt.from(1),
+          ),
+          throwsArgumentError,
+        );
+      });
     });
 
     group('getAddress', () {

--- a/packages/permissionless/test/accounts/simple/simple_account_test.dart
+++ b/packages/permissionless/test/accounts/simple/simple_account_test.dart
@@ -621,7 +621,8 @@ void main() {
 
       expect(account.entryPointVersion, equals(EntryPointVersion.v08));
       expect(account.entryPoint, equals(EntryPointAddresses.v08));
-      expect(account.accountLogicAddress, equals(Simple7702AccountAddresses.v08));
+      expect(
+          account.accountLogicAddress, equals(Simple7702AccountAddresses.v08));
     });
 
     test('supports explicit EntryPoint v0.9 logic', () {
@@ -633,7 +634,8 @@ void main() {
 
       expect(account.entryPointVersion, equals(EntryPointVersion.v09));
       expect(account.entryPoint, equals(EntryPointAddresses.v09));
-      expect(account.accountLogicAddress, equals(Simple7702AccountAddresses.v09));
+      expect(
+          account.accountLogicAddress, equals(Simple7702AccountAddresses.v09));
     });
 
     test('rejects older EntryPoint versions', () {

--- a/packages/permissionless/test/accounts/simple/simple_account_test.dart
+++ b/packages/permissionless/test/accounts/simple/simple_account_test.dart
@@ -69,6 +69,35 @@ void main() {
         // We can verify this through getFactoryData
         expect(account, isNotNull);
       });
+
+      test('rejects built-in EntryPoint v0.9 factory selection', () {
+        expect(
+          () => createSimpleSmartAccount(
+            owner: owner,
+            chainId: BigInt.from(1),
+            entryPointVersion: EntryPointVersion.v09,
+            address: mockAddress,
+          ),
+          throwsA(isA<UnsupportedError>()),
+        );
+      });
+
+      test('allows custom EntryPoint v0.9 factory experimentation', () {
+        final customFactory = EthereumAddress.fromHex(
+          '0x1234567890123456789012345678901234567890',
+        );
+
+        account = createSimpleSmartAccount(
+          owner: owner,
+          chainId: BigInt.from(1),
+          entryPointVersion: EntryPointVersion.v09,
+          customFactoryAddress: customFactory,
+          address: mockAddress,
+        );
+
+        expect(account.entryPointVersion, equals(EntryPointVersion.v09));
+        expect(account.entryPoint, equals(EntryPointAddresses.v09));
+      });
     });
 
     group('getAddress', () {
@@ -540,6 +569,81 @@ void main() {
       expect(
         SimpleAccountFactoryAddresses.fromVersion(EntryPointVersion.v07),
         equals(SimpleAccountFactoryAddresses.v07),
+      );
+    });
+
+    test('fromVersion rejects v0.9 without a verified factory', () {
+      expect(
+        () => SimpleAccountFactoryAddresses.fromVersion(EntryPointVersion.v09),
+        throwsA(isA<UnsupportedError>()),
+      );
+    });
+  });
+
+  group('Simple7702AccountAddresses', () {
+    test('selects v0.8 and v0.9 logic addresses', () {
+      expect(
+        Simple7702AccountAddresses.fromVersion(EntryPointVersion.v08),
+        equals(Simple7702AccountAddresses.v08),
+      );
+      expect(
+        Simple7702AccountAddresses.fromVersion(EntryPointVersion.v09),
+        equals(Simple7702AccountAddresses.v09),
+      );
+      expect(
+        Simple7702AccountAddresses.v09.hex.toLowerCase(),
+        equals('0xa46cc63ebf4bd77888aa327837d20b23a63a56b5'),
+      );
+    });
+
+    test('rejects non-EIP-7702 EntryPoint versions', () {
+      expect(
+        () => Simple7702AccountAddresses.fromVersion(EntryPointVersion.v07),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('Eip7702SimpleSmartAccount', () {
+    late PrivateKeyEip7702Owner owner;
+
+    setUp(() {
+      owner = PrivateKeyEip7702Owner(
+        '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80',
+      );
+    });
+
+    test('defaults to EntryPoint v0.8 logic', () {
+      final account = createEip7702SimpleSmartAccount(
+        owner: owner,
+        chainId: BigInt.from(1),
+      );
+
+      expect(account.entryPointVersion, equals(EntryPointVersion.v08));
+      expect(account.entryPoint, equals(EntryPointAddresses.v08));
+      expect(account.accountLogicAddress, equals(Simple7702AccountAddresses.v08));
+    });
+
+    test('supports explicit EntryPoint v0.9 logic', () {
+      final account = createEip7702SimpleSmartAccount(
+        owner: owner,
+        chainId: BigInt.from(1),
+        entryPointVersion: EntryPointVersion.v09,
+      );
+
+      expect(account.entryPointVersion, equals(EntryPointVersion.v09));
+      expect(account.entryPoint, equals(EntryPointAddresses.v09));
+      expect(account.accountLogicAddress, equals(Simple7702AccountAddresses.v09));
+    });
+
+    test('rejects older EntryPoint versions', () {
+      expect(
+        () => createEip7702SimpleSmartAccount(
+          owner: owner,
+          chainId: BigInt.from(1),
+          entryPointVersion: EntryPointVersion.v07,
+        ),
+        throwsArgumentError,
       );
     });
   });

--- a/packages/permissionless/test/accounts/thirdweb/thirdweb_account_test.dart
+++ b/packages/permissionless/test/accounts/thirdweb/thirdweb_account_test.dart
@@ -1,0 +1,46 @@
+import 'package:permissionless/permissionless.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ThirdwebSmartAccount', () {
+    late PrivateKeyOwner owner;
+
+    final mockAddress =
+        EthereumAddress.fromHex('0x1234567890123456789012345678901234567890');
+
+    setUp(() {
+      owner = PrivateKeyOwner(
+        '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80',
+      );
+    });
+
+    test('rejects built-in EntryPoint v0.9 factory selection', () {
+      expect(
+        () => createThirdwebSmartAccount(
+          owner: owner,
+          chainId: BigInt.from(1),
+          entryPointVersion: EntryPointVersion.v09,
+          address: mockAddress,
+        ),
+        throwsA(isA<UnsupportedError>()),
+      );
+    });
+
+    test('allows custom EntryPoint v0.9 factory experimentation', () {
+      final customFactory = EthereumAddress.fromHex(
+        '0x1234567890123456789012345678901234567890',
+      );
+
+      final account = createThirdwebSmartAccount(
+        owner: owner,
+        chainId: BigInt.from(1),
+        entryPointVersion: EntryPointVersion.v09,
+        customFactoryAddress: customFactory,
+        address: mockAddress,
+      );
+
+      expect(account.entryPointVersion, equals(EntryPointVersion.v09));
+      expect(account.entryPoint, equals(EntryPointAddresses.v09));
+    });
+  });
+}

--- a/packages/permissionless/test/constants/entry_point_test.dart
+++ b/packages/permissionless/test/constants/entry_point_test.dart
@@ -1,0 +1,32 @@
+import 'package:permissionless/permissionless.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('EntryPointAddresses', () {
+    test('maps all supported EntryPoint versions', () {
+      expect(
+        EntryPointAddresses.fromVersion(EntryPointVersion.v06),
+        equals(EntryPointAddresses.v06),
+      );
+      expect(
+        EntryPointAddresses.fromVersion(EntryPointVersion.v07),
+        equals(EntryPointAddresses.v07),
+      );
+      expect(
+        EntryPointAddresses.fromVersion(EntryPointVersion.v08),
+        equals(EntryPointAddresses.v08),
+      );
+      expect(
+        EntryPointAddresses.fromVersion(EntryPointVersion.v09),
+        equals(EntryPointAddresses.v09),
+      );
+    });
+
+    test('has official v0.9 EntryPoint address', () {
+      expect(
+        EntryPointAddresses.v09.hex.toLowerCase(),
+        equals('0x433709009b8330fda32311df1c2afa402ed8d009'),
+      );
+    });
+  });
+}


### PR DESCRIPTION
Refs #24

Automated Ralph backlog draft from branch `ralph/issue-24-v09-support-matrix`.