### PR TITLE
RALPH: live Pimlico Sepolia v0.9 verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ permissionless-dart/
 
 ### Core Package (`permissionless`)
 - **SimpleSmartAccount** - Minimal ERC-4337 account
+- **Eip7702SimpleSmartAccount** - EIP-7702 Simple account with v0.9 opt-in support
 - **SafeSmartAccount** - Safe (Gnosis Safe) smart account
 - **KernelSmartAccount** - ZeroDev Kernel smart account
 

--- a/packages/permissionless/README.md
+++ b/packages/permissionless/README.md
@@ -8,20 +8,30 @@ Build account abstraction applications in Dart with support for multiple smart a
 
 ### Smart Accounts
 
-| Account       | Provider       | EntryPoint | ERC-7579   | Description                      |
-| ------------- | -------------- | ---------- | ---------- | -------------------------------- |
-| **Safe**      | Gnosis         | v0.6, v0.7 | Optional*  | Battle-tested multi-sig account  |
-| **Kernel**    | ZeroDev        | v0.6, v0.7 | v0.3.x     | Modular account with plugins     |
-| **Nexus**     | Biconomy       | v0.7       | Yes        | ERC-7579 modular account         |
-| **Light**     | Alchemy        | v0.6, v0.7 | No         | Gas-efficient single-owner       |
-| **Simple**    | eth-infinitism | v0.6, v0.7 | No         | Minimal reference implementation |
-| **Thirdweb**  | Thirdweb       | v0.6, v0.7 | No         | SDK ecosystem integration        |
-| **Trust**     | Trust Wallet   | v0.6       | No         | Diamond architecture (Barz)      |
-| **Etherspot** | Etherspot      | v0.7       | Internal** | ModularEtherspotWallet           |
-| **Biconomy**  | Biconomy       | v0.6       | No         | *Deprecated - use Nexus*         |
+| Account       | Provider       | EntryPoint             | ERC-7579   | Description                      |
+| ------------- | -------------- | ---------------------- | ---------- | -------------------------------- |
+| **Safe**      | Gnosis         | v0.6, v0.7             | Optional*  | Battle-tested multi-sig account  |
+| **Kernel**    | ZeroDev        | v0.6, v0.7             | v0.3.x     | Modular account with plugins     |
+| **Nexus**     | Biconomy       | v0.7                   | Yes        | ERC-7579 modular account         |
+| **Light**     | Alchemy        | v0.6, v0.7             | No         | Gas-efficient single-owner       |
+| **Simple**    | eth-infinitism | v0.6, v0.7             | No         | Minimal reference implementation |
+| **Simple7702** | eth-infinitism | v0.8, v0.9 opt-in      | No         | EIP-7702 delegated Simple account |
+| **Thirdweb**  | Thirdweb       | v0.6, v0.7             | No         | SDK ecosystem integration        |
+| **Trust**     | Trust Wallet   | v0.6                   | No         | Diamond architecture (Barz)      |
+| **Etherspot** | Etherspot      | v0.7                   | Internal** | ModularEtherspotWallet           |
+| **Biconomy**  | Biconomy       | v0.6                   | No         | *Deprecated - use Nexus*         |
 
 \* Safe requires `erc7579LaunchpadAddress` configuration to enable ERC-7579 module management.
 \** Etherspot uses ERC-7579 call encoding internally but module management actions are not exposed in permissionless.js.
+
+EntryPoint v0.9 is opt-in. Existing account defaults stay on their current
+EntryPoint versions. The first officially supported v0.9 built-in account
+target is Simple7702Account with EntryPoint
+`0x433709009B8330FDa32311DF1C2AFA402eD8D009` and Simple7702Account
+implementation `0xa46cc63eBF4Bd77888AA327837d20b23A63a56B5`.
+Custom account addresses can still be supplied where an account API supports
+them, but custom v0.9 deployments are user-provided and not part of the package
+support matrix.
 
 ### Clients
 
@@ -216,6 +226,30 @@ final account = createSimpleSmartAccount(
 - Minimal, gas-efficient design
 - Direct signature validation
 - Ideal for learning ERC-4337
+
+### EIP-7702 Simple Account
+
+Simple7702Account delegates code from the owner's EOA, so the account address
+is the owner's address. v0.8 remains the default; select v0.9 explicitly when
+your bundler and paymaster support it:
+
+```dart
+final owner = PrivateKeyEip7702Owner('0x...');
+final account = createEip7702SimpleSmartAccount(
+  owner: owner,
+  chainId: BigInt.from(11155111), // Sepolia
+  entryPointVersion: EntryPointVersion.v09,
+);
+
+final bundler = createBundlerClient(
+  url: 'https://api.pimlico.io/v2/sepolia/rpc?apikey=YOUR_KEY',
+  entryPoint: EntryPointAddresses.v09,
+);
+```
+
+The official v0.9 addresses are:
+- EntryPoint v0.9: `0x433709009B8330FDa32311DF1C2AFA402eD8D009`
+- Simple7702Account v0.9: `0xa46cc63eBF4Bd77888AA327837d20b23A63a56B5`
 
 ### Thirdweb Account
 
@@ -530,6 +564,8 @@ final allowanceOverride = erc20AllowanceOverride(
 | ------- | --------------- | ----------------------------------------------------------------------------------- |
 | v0.6    | `0x5FF1...2789` | Safe v1.4.1, Kernel v0.2.4, Light v1.1.0, Trust                                     |
 | v0.7    | `0x0000...0070` | Safe v1.4.1/v1.5.0, Kernel v0.3.1, Nexus, Light v2.0.0, Simple, Thirdweb, Etherspot |
+| v0.8    | `0x4337...f108` | Simple7702Account by default                                                        |
+| v0.9    | `0x4337...D009` | Simple7702Account when explicitly configured                                        |
 
 ## Examples
 
@@ -542,6 +578,7 @@ See the [example/](example/) directory for complete working examples:
 | `nexus_example.dart`           | Biconomy Nexus (ERC-7579)  |
 | `light_example.dart`           | Alchemy Light Account      |
 | `simple_example.dart`          | Minimal reference account  |
+| `eip7702_simple_example.dart`  | EIP-7702 Simple v0.9 setup |
 | `thirdweb_example.dart`        | Thirdweb SDK account       |
 | `trust_example.dart`           | Trust Wallet Barz          |
 | `etherspot_example.dart`       | Etherspot modular account  |

--- a/packages/permissionless/README.md
+++ b/packages/permissionless/README.md
@@ -8,20 +8,26 @@ Build account abstraction applications in Dart with support for multiple smart a
 
 ### Smart Accounts
 
-| Account       | Provider       | EntryPoint | ERC-7579   | Description                      |
-| ------------- | -------------- | ---------- | ---------- | -------------------------------- |
-| **Safe**      | Gnosis         | v0.6, v0.7 | Optional*  | Battle-tested multi-sig account  |
-| **Kernel**    | ZeroDev        | v0.6, v0.7 | v0.3.x     | Modular account with plugins     |
-| **Nexus**     | Biconomy       | v0.7       | Yes        | ERC-7579 modular account         |
-| **Light**     | Alchemy        | v0.6, v0.7 | No         | Gas-efficient single-owner       |
-| **Simple**    | eth-infinitism | v0.6, v0.7 | No         | Minimal reference implementation |
-| **Thirdweb**  | Thirdweb       | v0.6, v0.7 | No         | SDK ecosystem integration        |
-| **Trust**     | Trust Wallet   | v0.6       | No         | Diamond architecture (Barz)      |
-| **Etherspot** | Etherspot      | v0.7       | Internal** | ModularEtherspotWallet           |
-| **Biconomy**  | Biconomy       | v0.6       | No         | *Deprecated - use Nexus*         |
+| Account             | Provider       | EntryPoint       | ERC-7579   | Description                         |
+| ------------------- | -------------- | ---------------- | ---------- | ----------------------------------- |
+| **Safe**            | Gnosis         | v0.6, v0.7       | Optional*  | Battle-tested multi-sig account     |
+| **Kernel**          | ZeroDev        | v0.6, v0.7       | v0.3.x     | Modular account with plugins        |
+| **Nexus**           | Biconomy       | v0.7             | Yes        | ERC-7579 modular account            |
+| **Light**           | Alchemy        | v0.6, v0.7       | No         | Gas-efficient single-owner          |
+| **Simple**          | eth-infinitism | v0.6, v0.7, v0.8 | No         | Minimal reference implementation    |
+| **Simple7702**      | eth-infinitism | v0.8, v0.9       | No         | EIP-7702 Simple account delegation  |
+| **Thirdweb**        | Thirdweb       | v0.6, v0.7       | No         | SDK ecosystem integration           |
+| **Trust**           | Trust Wallet   | v0.6             | No         | Diamond architecture (Barz)         |
+| **Etherspot**       | Etherspot      | v0.7             | Internal** | ModularEtherspotWallet              |
+| **Biconomy**        | Biconomy       | v0.6             | No         | *Deprecated - use Nexus*            |
 
 \* Safe requires `erc7579LaunchpadAddress` configuration to enable ERC-7579 module management.
 \** Etherspot uses ERC-7579 call encoding internally but module management actions are not exposed in permissionless.js.
+
+EntryPoint v0.9 is opt-in. Generic clients can target `EntryPointAddresses.v09`;
+official built-in account support is limited to Simple7702. Other account
+families do not claim v0.9 support unless you provide custom contract addresses,
+which is treated as user-supplied experimentation.
 
 ### Clients
 
@@ -530,6 +536,8 @@ final allowanceOverride = erc20AllowanceOverride(
 | ------- | --------------- | ----------------------------------------------------------------------------------- |
 | v0.6    | `0x5FF1...2789` | Safe v1.4.1, Kernel v0.2.4, Light v1.1.0, Trust                                     |
 | v0.7    | `0x0000...0070` | Safe v1.4.1/v1.5.0, Kernel v0.3.1, Nexus, Light v2.0.0, Simple, Thirdweb, Etherspot |
+| v0.8    | `0x4337...f108` | Simple, Simple7702                                                                  |
+| v0.9    | `0x4337...d009` | Generic clients, Simple7702                                                         |
 
 ## Examples
 

--- a/packages/permissionless/example/biconomy_example.dart
+++ b/packages/permissionless/example/biconomy_example.dart
@@ -141,11 +141,7 @@ void main(List<String> args) async {
   print('\n--- Building Transaction ---');
 
   // Send a "ping" transaction to self
-  final call = Call(
-    to: accountAddress,
-    value: BigInt.zero,
-    data: '0x',
-  );
+  final call = Call(to: accountAddress, value: BigInt.zero, data: '0x');
 
   print('Transaction: Self-ping (0 ETH to self)');
 
@@ -206,8 +202,9 @@ void main(List<String> args) async {
   final signedUserOp = await smartAccountClient.signUserOperationV06(userOp);
   print('Signature length: ${signedUserOp.signature.length} chars');
 
-  final hash =
-      await smartAccountClient.sendPreparedUserOperationV06(signedUserOp);
+  final hash = await smartAccountClient.sendPreparedUserOperationV06(
+    signedUserOp,
+  );
   print('UserOperation hash: $hash');
 
   // ================================================================

--- a/packages/permissionless/example/eip7702_simple_example.dart
+++ b/packages/permissionless/example/eip7702_simple_example.dart
@@ -11,7 +11,7 @@
 //   dart run example/eip7702_simple_example.dart --self-fund  # Self-funded
 //
 // REQUIREMENTS:
-// - A bundler that supports EIP-7702 (EntryPoint v0.8)
+// - A bundler that supports EIP-7702 (EntryPoint v0.9 in this example)
 // - A chain with EIP-7702 enabled (Sepolia after Prague upgrade)
 //
 // KEY FEATURES:
@@ -37,12 +37,12 @@ void main(List<String> args) async {
   //
   // EIP-7702 requires:
   // - A chain that supports EIP-7702 (Prague upgrade)
-  // - A bundler that supports EntryPoint v0.8
+  // - A bundler that supports EntryPoint v0.9
 
   const chainId = 11155111; // Sepolia
   const rpcUrl = 'https://eth-sepolia.g.alchemy.com/v2/YOUR_KEY';
 
-  // NOTE: Replace with a bundler URL that supports EntryPoint v0.8
+  // NOTE: Replace with a bundler URL that supports EntryPoint v0.9
   const pimlicoUrl = 'https://api.pimlico.io/v2/sepolia/rpc?apikey=YOUR_KEY';
 
   // ================================================================
@@ -75,7 +75,7 @@ void main(List<String> args) async {
   // - The account address IS the owner's EOA address
   // - No factory deployment needed
   // - Code is delegated via signed authorization
-  // - Uses EntryPoint v0.8
+  // - Explicitly opts into EntryPoint v0.9
 
   // Create public client first - needed for EIP-7702 delegation checks
   final publicClient = createPublicClient(url: rpcUrl);
@@ -84,6 +84,7 @@ void main(List<String> args) async {
     owner: owner,
     chainId: BigInt.from(chainId),
     publicClient: publicClient,
+    entryPointVersion: EntryPointVersion.v09,
   );
 
   // ================================================================
@@ -98,12 +99,12 @@ void main(List<String> args) async {
 
   final bundler = createBundlerClient(
     url: pimlicoUrl,
-    entryPoint: EntryPointAddresses.v08,
+    entryPoint: EntryPointAddresses.v09,
   );
 
   final pimlico = createPimlicoClient(
     url: pimlicoUrl,
-    entryPoint: EntryPointAddresses.v08,
+    entryPoint: EntryPointAddresses.v09,
   );
 
   // Paymaster for sponsored transactions (optional)
@@ -151,7 +152,7 @@ void main(List<String> args) async {
   // Get the EntryPoint nonce for the smart account
   final nonce = await publicClient.getAccountNonce(
     accountAddress,
-    EntryPointAddresses.v08,
+    EntryPointAddresses.v09,
   );
   print('EntryPoint nonce: $nonce');
 
@@ -201,10 +202,10 @@ void main(List<String> args) async {
   } on BundlerRpcError catch (e) {
     print('\nUserOperation preparation failed: ${e.message}');
     print('\nThis likely means:');
-    print('  - The bundler does not support EntryPoint v0.8');
+    print('  - The bundler does not support EntryPoint v0.9');
     print('  - The bundler does not support EIP-7702 authorization');
     print('\nFor EIP-7702 to work, you may need:');
-    print('  - A bundler with explicit EIP-7702/v0.8 support');
+    print('  - A bundler with explicit EIP-7702/v0.9 support');
     print('  - A chain with EIP-7702 enabled');
 
     smartAccountClient.close();
@@ -301,7 +302,7 @@ void main(List<String> args) async {
   print('Key takeaways:');
   print('  - Account address = Owner\'s EOA address');
   print('  - SmartAccountClient handles authorization automatically');
-  print('  - Uses EntryPoint v0.8');
+  print('  - Uses EntryPoint v0.9');
   print('  - Uses EIP-712 typed data signing');
   print('='.padRight(60, '='));
 

--- a/packages/permissionless/example/etherspot_example.dart
+++ b/packages/permissionless/example/etherspot_example.dart
@@ -115,11 +115,7 @@ void main(List<String> args) async {
   print('\n--- Building Transaction ---');
 
   // Send a "ping" transaction to self
-  final call = Call(
-    to: accountAddress,
-    value: BigInt.zero,
-    data: '0x',
-  );
+  final call = Call(to: accountAddress, value: BigInt.zero, data: '0x');
 
   print('Transaction: Self-ping (0 ETH to self)');
 

--- a/packages/permissionless/example/example.dart
+++ b/packages/permissionless/example/example.dart
@@ -56,13 +56,7 @@ void main() async {
 
   // 6. Send a sponsored transaction
   final hash = await client.sendUserOperation(
-    calls: [
-      Call(
-        to: accountAddress,
-        value: BigInt.zero,
-        data: '0x',
-      ),
-    ],
+    calls: [Call(to: accountAddress, value: BigInt.zero, data: '0x')],
     maxFeePerGas: BigInt.from(20000000000),
     maxPriorityFeePerGas: BigInt.from(1000000000),
   );

--- a/packages/permissionless/example/kernel_example.dart
+++ b/packages/permissionless/example/kernel_example.dart
@@ -116,11 +116,7 @@ void main(List<String> args) async {
   print('\n--- Building Transaction ---');
 
   // Send a "ping" transaction to self
-  final call = Call(
-    to: accountAddress,
-    value: BigInt.zero,
-    data: '0x',
-  );
+  final call = Call(to: accountAddress, value: BigInt.zero, data: '0x');
 
   print('Transaction: Self-ping (0 ETH to self)');
 

--- a/packages/permissionless/example/kernel_v024_example.dart
+++ b/packages/permissionless/example/kernel_v024_example.dart
@@ -134,11 +134,7 @@ void main(List<String> args) async {
   print('\n--- Building Transaction ---');
 
   // Send a "ping" transaction to self
-  final call = Call(
-    to: accountAddress,
-    value: BigInt.zero,
-    data: '0x',
-  );
+  final call = Call(to: accountAddress, value: BigInt.zero, data: '0x');
 
   print('Transaction: Self-ping (0 ETH to self)');
 
@@ -202,8 +198,9 @@ void main(List<String> args) async {
   final signedUserOp = userOp.copyWith(signature: signature);
   print('Signature length: ${signedUserOp.signature.length} chars');
 
-  final hash =
-      await smartAccountClient.sendPreparedUserOperationV06(signedUserOp);
+  final hash = await smartAccountClient.sendPreparedUserOperationV06(
+    signedUserOp,
+  );
   print('UserOperation hash: $hash');
 
   // ================================================================

--- a/packages/permissionless/example/light_example.dart
+++ b/packages/permissionless/example/light_example.dart
@@ -116,11 +116,7 @@ void main(List<String> args) async {
   print('\n--- Building Transaction ---');
 
   // Send a "ping" transaction to self
-  final call = Call(
-    to: accountAddress,
-    value: BigInt.zero,
-    data: '0x',
-  );
+  final call = Call(to: accountAddress, value: BigInt.zero, data: '0x');
 
   print('Transaction: Self-ping (0 ETH to self)');
 

--- a/packages/permissionless/example/nexus_example.dart
+++ b/packages/permissionless/example/nexus_example.dart
@@ -116,11 +116,7 @@ void main(List<String> args) async {
   print('\n--- Building Transaction ---');
 
   // Send a "ping" transaction to self
-  final call = Call(
-    to: accountAddress,
-    value: BigInt.zero,
-    data: '0x',
-  );
+  final call = Call(to: accountAddress, value: BigInt.zero, data: '0x');
 
   print('Transaction: Self-ping (0 ETH to self)');
 

--- a/packages/permissionless/example/safe_7579_example.dart
+++ b/packages/permissionless/example/safe_7579_example.dart
@@ -128,11 +128,7 @@ void main(List<String> args) async {
 
   print('\n--- Building Transaction ---');
 
-  final call = Call(
-    to: accountAddress,
-    value: BigInt.zero,
-    data: '0x',
-  );
+  final call = Call(to: accountAddress, value: BigInt.zero, data: '0x');
 
   print('Transaction: Self-ping using ERC-7579 execute encoding');
 

--- a/packages/permissionless/example/safe_example.dart
+++ b/packages/permissionless/example/safe_example.dart
@@ -114,11 +114,7 @@ void main(List<String> args) async {
   print('\n--- Building Transaction ---');
 
   // Send a "ping" transaction to self (proves account works)
-  final call = Call(
-    to: accountAddress,
-    value: BigInt.zero,
-    data: '0x',
-  );
+  final call = Call(to: accountAddress, value: BigInt.zero, data: '0x');
 
   print('Transaction: Self-ping (0 ETH to self)');
 

--- a/packages/permissionless/example/thirdweb_example.dart
+++ b/packages/permissionless/example/thirdweb_example.dart
@@ -115,11 +115,7 @@ void main(List<String> args) async {
   print('\n--- Building Transaction ---');
 
   // Send a "ping" transaction to self
-  final call = Call(
-    to: accountAddress,
-    value: BigInt.zero,
-    data: '0x',
-  );
+  final call = Call(to: accountAddress, value: BigInt.zero, data: '0x');
 
   print('Transaction: Self-ping (0 ETH to self)');
 

--- a/packages/permissionless/example/trust_example.dart
+++ b/packages/permissionless/example/trust_example.dart
@@ -136,11 +136,7 @@ void main(List<String> args) async {
   print('\n--- Building Transaction ---');
 
   // Send a "ping" transaction to self (proves account works)
-  final call = Call(
-    to: accountAddress,
-    value: BigInt.zero,
-    data: '0x',
-  );
+  final call = Call(to: accountAddress, value: BigInt.zero, data: '0x');
 
   print('Transaction: Self-ping (0 ETH to self)');
 
@@ -194,8 +190,9 @@ void main(List<String> args) async {
   final signedUserOp = await smartAccountClient.signUserOperationV06(userOp);
   print('Signature length: ${(signedUserOp.signature.length - 2) ~/ 2} bytes');
 
-  final hash =
-      await smartAccountClient.sendPreparedUserOperationV06(signedUserOp);
+  final hash = await smartAccountClient.sendPreparedUserOperationV06(
+    signedUserOp,
+  );
   print('UserOperation hash: $hash');
 
   // ================================================================

--- a/packages/permissionless/lib/permissionless.dart
+++ b/packages/permissionless/lib/permissionless.dart
@@ -63,6 +63,7 @@ export 'src/utils/gas.dart';
 export 'src/utils/message_hash.dart';
 export 'src/utils/multisend.dart';
 export 'src/utils/packed_user_operation.dart';
+export 'src/utils/paymaster_signature.dart';
 export 'src/utils/rip7212.dart';
 export 'src/utils/units.dart';
 export 'src/utils/webauthn_encoding.dart';

--- a/packages/permissionless/lib/src/accounts/biconomy/biconomy_account.dart
+++ b/packages/permissionless/lib/src/accounts/biconomy/biconomy_account.dart
@@ -204,10 +204,7 @@ class BiconomySmartAccount implements SmartAccountV06 {
   @override
   Future<String> getInitCode() async {
     final factoryData = _encodeDeployCounterFactualAccount();
-    return Hex.concat([
-      _factoryAddress.hex,
-      Hex.strip0x(factoryData),
-    ]);
+    return Hex.concat([_factoryAddress.hex, Hex.strip0x(factoryData)]);
   }
 
   /// Gets the factory address and data for UserOperation.

--- a/packages/permissionless/lib/src/accounts/biconomy/constants.dart
+++ b/packages/permissionless/lib/src/accounts/biconomy/constants.dart
@@ -8,20 +8,24 @@ class BiconomyAddresses {
   BiconomyAddresses._();
 
   /// ECDSA Ownership Registry Module address.
-  static final EthereumAddress ecdsaOwnershipModule =
-      EthereumAddress.fromHex('0x0000001c5b32F37F5beA87BDD5374eB2aC54eA8e');
+  static final EthereumAddress ecdsaOwnershipModule = EthereumAddress.fromHex(
+    '0x0000001c5b32F37F5beA87BDD5374eB2aC54eA8e',
+  );
 
   /// Factory address for account deployment.
-  static final EthereumAddress factory =
-      EthereumAddress.fromHex('0x000000a56Aaca3e9a4C479ea6b6CD0DbcB6634F5');
+  static final EthereumAddress factory = EthereumAddress.fromHex(
+    '0x000000a56Aaca3e9a4C479ea6b6CD0DbcB6634F5',
+  );
 
   /// Account v2.0 logic/implementation address.
-  static final EthereumAddress accountV2Logic =
-      EthereumAddress.fromHex('0x0000002512019Dafb59528B82CB92D3c5D2423aC');
+  static final EthereumAddress accountV2Logic = EthereumAddress.fromHex(
+    '0x0000002512019Dafb59528B82CB92D3c5D2423aC',
+  );
 
   /// Default fallback handler address.
-  static final EthereumAddress defaultFallbackHandler =
-      EthereumAddress.fromHex('0x0bBa6d96BD616BedC6BFaa341742FD43c60b83C1');
+  static final EthereumAddress defaultFallbackHandler = EthereumAddress.fromHex(
+    '0x0bBa6d96BD616BedC6BFaa341742FD43c60b83C1',
+  );
 }
 
 /// Biconomy function selectors.

--- a/packages/permissionless/lib/src/accounts/etherspot/etherspot_account.dart
+++ b/packages/permissionless/lib/src/accounts/etherspot/etherspot_account.dart
@@ -218,16 +218,20 @@ class EtherspotSmartAccount implements SmartAccount {
   String _encodeInitMSA() {
     // Build validators array with ECDSA validator
     final validatorOnInstall = _encodeOnInstall('0x');
-    final validatorConfig =
-        _encodeBootstrapConfig(ecdsaValidator, validatorOnInstall);
+    final validatorConfig = _encodeBootstrapConfig(
+      ecdsaValidator,
+      validatorOnInstall,
+    );
 
     // Build executors array with zero address (matching TS implementation)
     final zeroOnInstall = _encodeOnInstall('0x');
     final executorConfig = _encodeBootstrapConfig(zeroAddress, zeroOnInstall);
 
     // Hook - single BootstrapConfig (not array)
-    final hookConfig =
-        _encodeBootstrapConfigTuple(zeroAddress, _encodeOnInstall('0x'));
+    final hookConfig = _encodeBootstrapConfigTuple(
+      zeroAddress,
+      _encodeOnInstall('0x'),
+    );
 
     // Fallbacks array with zero address (matching TS implementation)
     final fallbackConfig = _encodeBootstrapConfig(zeroAddress, zeroOnInstall);

--- a/packages/permissionless/lib/src/accounts/kernel/eip7702_kernel_account.dart
+++ b/packages/permissionless/lib/src/accounts/kernel/eip7702_kernel_account.dart
@@ -89,8 +89,10 @@ class PrivateKeyEip7702KernelOwner implements Eip7702KernelOwner {
     final hashBytes = Hex.decode(hash);
 
     // Sign the typed data hash directly using raw sign function
-    final sig =
-        crypto.sign(Uint8List.fromList(hashBytes), _privateKey.privateKey);
+    final sig = crypto.sign(
+      Uint8List.fromList(hashBytes),
+      _privateKey.privateKey,
+    );
 
     // Pack r, s, v into 65 bytes
     final rBytes = Hex.decode(Hex.fromBigInt(sig.r, byteLength: 32));
@@ -387,15 +389,21 @@ class Eip7702KernelSmartAccount implements Eip7702SmartAccount {
     final callDataHash = crypto.keccak256(Hex.decode(userOp.callData));
 
     // Pack accountGasLimits (v0.7 packing)
-    final verificationGasLimitHex =
-        Hex.fromBigInt(userOp.verificationGasLimit, byteLength: 16);
+    final verificationGasLimitHex = Hex.fromBigInt(
+      userOp.verificationGasLimit,
+      byteLength: 16,
+    );
     final callGasLimitHex = Hex.fromBigInt(userOp.callGasLimit, byteLength: 16);
-    final accountGasLimits =
-        Hex.concat([verificationGasLimitHex, callGasLimitHex]);
+    final accountGasLimits = Hex.concat([
+      verificationGasLimitHex,
+      callGasLimitHex,
+    ]);
 
     // Pack gasFees
-    final maxPriorityFeeHex =
-        Hex.fromBigInt(userOp.maxPriorityFeePerGas, byteLength: 16);
+    final maxPriorityFeeHex = Hex.fromBigInt(
+      userOp.maxPriorityFeePerGas,
+      byteLength: 16,
+    );
     final maxFeeHex = Hex.fromBigInt(userOp.maxFeePerGas, byteLength: 16);
     final gasFees = Hex.concat([maxPriorityFeeHex, maxFeeHex]);
 
@@ -492,14 +500,10 @@ class Eip7702KernelSmartAccount implements Eip7702SmartAccount {
           const TypedDataField(name: 'chainId', type: 'uint256'),
           const TypedDataField(name: 'verifyingContract', type: 'address'),
         ],
-        'Kernel': [
-          const TypedDataField(name: 'hash', type: 'bytes32'),
-        ],
+        'Kernel': [const TypedDataField(name: 'hash', type: 'bytes32')],
       },
       primaryType: 'Kernel',
-      message: {
-        'hash': messageHash,
-      },
+      message: {'hash': messageHash},
     );
 
     final signature = await _config.owner.signTypedData(kernelTypedData);

--- a/packages/permissionless/lib/src/accounts/kernel/kernel_account.dart
+++ b/packages/permissionless/lib/src/accounts/kernel/kernel_account.dart
@@ -587,10 +587,7 @@ class KernelSmartAccount implements SmartAccount {
 
     if (_config.version == KernelVersion.v0_2_4) {
       // v0.2.x: ROOT_MODE (4 bytes) + signature
-      return Hex.concat([
-        '0x00000000',
-        Hex.strip0x(signature),
-      ]);
+      return Hex.concat(['0x00000000', Hex.strip0x(signature)]);
     } else {
       // v0.3.x: just the signature (no prefix)
       return signature;
@@ -606,10 +603,7 @@ class KernelSmartAccount implements SmartAccount {
     final signature = await _config.owner.signRawHash(userOpHash);
 
     // v0.2.x: ROOT_MODE (4 bytes) + signature
-    return Hex.concat([
-      '0x00000000',
-      Hex.strip0x(signature),
-    ]);
+    return Hex.concat(['0x00000000', Hex.strip0x(signature)]);
   }
 
   /// Computes the userOpHash for v0.6 UserOperation.

--- a/packages/permissionless/lib/src/accounts/light/constants.dart
+++ b/packages/permissionless/lib/src/accounts/light/constants.dart
@@ -32,6 +32,11 @@ enum LightAccountVersion {
           'Light Account does not support EntryPoint v0.8. '
           'Use Eip7702SimpleSmartAccount for EIP-7702 support.',
         );
+      case EntryPointVersion.v09:
+        throw ArgumentError(
+          'Light Account does not support EntryPoint v0.9. '
+          'Use Eip7702SimpleSmartAccount for Simple7702 v0.9 support.',
+        );
     }
   }
 }

--- a/packages/permissionless/lib/src/accounts/light/constants.dart
+++ b/packages/permissionless/lib/src/accounts/light/constants.dart
@@ -32,6 +32,12 @@ enum LightAccountVersion {
           'Light Account does not support EntryPoint v0.8. '
           'Use Eip7702SimpleSmartAccount for EIP-7702 support.',
         );
+      case EntryPointVersion.v09:
+        throw ArgumentError(
+          'Light Account does not have an official EntryPoint v0.9 '
+          'deployment. Provide a customFactoryAddress and explicit '
+          'LightAccountVersion only for user-supplied experimentation.',
+        );
     }
   }
 }

--- a/packages/permissionless/lib/src/accounts/light/constants.dart
+++ b/packages/permissionless/lib/src/accounts/light/constants.dart
@@ -28,8 +28,9 @@ enum LightAccountVersion {
       case EntryPointVersion.v07:
         return LightAccountVersion.v200;
       case EntryPointVersion.v08:
+      case EntryPointVersion.v09:
         throw ArgumentError(
-          'Light Account does not support EntryPoint v0.8. '
+          'Light Account does not support EntryPoint v${entryPoint.value}. '
           'Use Eip7702SimpleSmartAccount for EIP-7702 support.',
         );
     }

--- a/packages/permissionless/lib/src/accounts/light/constants.dart
+++ b/packages/permissionless/lib/src/accounts/light/constants.dart
@@ -46,12 +46,14 @@ class LightAccountFactoryAddresses {
   LightAccountFactoryAddresses._();
 
   /// Factory for Light Account v1.1.0 (EntryPoint v0.6).
-  static final v110 =
-      EthereumAddress.fromHex('0x00004EC70002a32400f8ae005A26081065620D20');
+  static final v110 = EthereumAddress.fromHex(
+    '0x00004EC70002a32400f8ae005A26081065620D20',
+  );
 
   /// Factory for Light Account v2.0.0 (EntryPoint v0.7).
-  static final v200 =
-      EthereumAddress.fromHex('0x0000000000400CdFef5E2714E63d8040b700BC24');
+  static final v200 = EthereumAddress.fromHex(
+    '0x0000000000400CdFef5E2714E63d8040b700BC24',
+  );
 
   /// Gets the factory address for a Light Account version.
   static EthereumAddress fromVersion(LightAccountVersion version) {

--- a/packages/permissionless/lib/src/accounts/light/constants.dart
+++ b/packages/permissionless/lib/src/accounts/light/constants.dart
@@ -32,6 +32,10 @@ enum LightAccountVersion {
           'Light Account does not support EntryPoint v0.8. '
           'Use Eip7702SimpleSmartAccount for EIP-7702 support.',
         );
+      case EntryPointVersion.v09:
+        throw ArgumentError(
+          'Light Account does not support EntryPoint v0.9.',
+        );
     }
   }
 }

--- a/packages/permissionless/lib/src/accounts/light/light_account.dart
+++ b/packages/permissionless/lib/src/accounts/light/light_account.dart
@@ -178,10 +178,7 @@ class LightSmartAccount implements SmartAccount {
   @override
   Future<String> getInitCode() async {
     final factoryData = _encodeCreateAccount();
-    return Hex.concat([
-      _factoryAddress.hex,
-      Hex.strip0x(factoryData),
-    ]);
+    return Hex.concat([_factoryAddress.hex, Hex.strip0x(factoryData)]);
   }
 
   @override
@@ -349,10 +346,7 @@ class LightSmartAccount implements SmartAccount {
     final accountAddress = await getAddress();
 
     // Sign using EIP-1271 wrapper with LightAccountMessage typed data
-    final signature = await _signLightAccountMessage(
-      accountAddress,
-      hash,
-    );
+    final signature = await _signLightAccountMessage(accountAddress, hash);
 
     // v2.0.0 prepends signature type
     if (_config.version == LightAccountVersion.v200) {

--- a/packages/permissionless/lib/src/accounts/nexus/constants.dart
+++ b/packages/permissionless/lib/src/accounts/nexus/constants.dart
@@ -8,12 +8,14 @@ class NexusAddresses {
   NexusAddresses._();
 
   /// K1 Validator Factory address for account deployment.
-  static final EthereumAddress k1ValidatorFactory =
-      EthereumAddress.fromHex('0x00000bb19a3579F4D779215dEf97AFbd0e30DB55');
+  static final EthereumAddress k1ValidatorFactory = EthereumAddress.fromHex(
+    '0x00000bb19a3579F4D779215dEf97AFbd0e30DB55',
+  );
 
   /// K1 Validator address for ECDSA signature validation.
-  static final EthereumAddress k1Validator =
-      EthereumAddress.fromHex('0x00000004171351c442B202678c48D8AB5B321E8f');
+  static final EthereumAddress k1Validator = EthereumAddress.fromHex(
+    '0x00000004171351c442B202678c48D8AB5B321E8f',
+  );
 }
 
 /// Nexus function selectors.

--- a/packages/permissionless/lib/src/accounts/nexus/nexus_account.dart
+++ b/packages/permissionless/lib/src/accounts/nexus/nexus_account.dart
@@ -179,10 +179,7 @@ class NexusSmartAccount implements SmartAccount {
   @override
   Future<String> getInitCode() async {
     final factoryData = _encodeCreateAccount();
-    return Hex.concat([
-      _factoryAddress.hex,
-      Hex.strip0x(factoryData),
-    ]);
+    return Hex.concat([_factoryAddress.hex, Hex.strip0x(factoryData)]);
   }
 
   /// Gets the factory address and data for UserOperation v0.7.
@@ -268,10 +265,7 @@ class NexusSmartAccount implements SmartAccount {
     final signature = await _config.owner.signPersonalMessage(userOpHash);
 
     // Pack: validator address + signature (85 bytes total)
-    return Hex.concat([
-      _validatorAddress.hex,
-      Hex.strip0x(signature),
-    ]);
+    return Hex.concat([_validatorAddress.hex, Hex.strip0x(signature)]);
   }
 
   /// Signs a personal message (EIP-191) with Nexus wrapper.
@@ -282,10 +276,7 @@ class NexusSmartAccount implements SmartAccount {
     final signature = await _config.owner.signPersonalMessage(wrappedHash);
 
     // Return packed: validator address + signature
-    return Hex.concat([
-      _validatorAddress.hex,
-      Hex.strip0x(signature),
-    ]);
+    return Hex.concat([_validatorAddress.hex, Hex.strip0x(signature)]);
   }
 
   /// Signs EIP-712 typed data with Nexus wrapper.
@@ -296,10 +287,7 @@ class NexusSmartAccount implements SmartAccount {
     final signature = await _config.owner.signPersonalMessage(wrappedHash);
 
     // Return packed: validator address + signature
-    return Hex.concat([
-      _validatorAddress.hex,
-      Hex.strip0x(signature),
-    ]);
+    return Hex.concat([_validatorAddress.hex, Hex.strip0x(signature)]);
   }
 
   /// Wraps a message hash with Nexus-specific EIP-712 domain.
@@ -323,27 +311,18 @@ class NexusSmartAccount implements SmartAccount {
     );
 
     final structHash = keccak256(
-      Hex.decode(
-        Hex.concat(
-          [
-            Hex.fromBytes(typeHash),
-            messageHash,
-          ],
-        ),
-      ),
+      Hex.decode(Hex.concat([Hex.fromBytes(typeHash), messageHash])),
     );
 
     // Final hash: keccak256(0x1901 + domainSeparator + structHash)
     return Hex.fromBytes(
       keccak256(
         Hex.decode(
-          Hex.concat(
-            [
-              '0x1901',
-              Hex.strip0x(domainSep),
-              Hex.fromBytes(structHash),
-            ],
-          ),
+          Hex.concat([
+            '0x1901',
+            Hex.strip0x(domainSep),
+            Hex.fromBytes(structHash),
+          ]),
         ),
       ),
     );

--- a/packages/permissionless/lib/src/accounts/safe/constants.dart
+++ b/packages/permissionless/lib/src/accounts/safe/constants.dart
@@ -71,8 +71,9 @@ class Safe7579Addresses {
   ///
   /// This module implements the ERC-7579 interface for Safe accounts,
   /// enabling module installation, uninstallation, and execution.
-  static final EthereumAddress safe7579ModuleAddress =
-      EthereumAddress.fromHex('0x7579EE8307284F293B1927136486880611F20002');
+  static final EthereumAddress safe7579ModuleAddress = EthereumAddress.fromHex(
+    '0x7579EE8307284F293B1927136486880611F20002',
+  );
 
   /// The Safe7579 launchpad address for deploying ERC-7579 Safe accounts.
   ///
@@ -86,8 +87,9 @@ class Safe7579Addresses {
   ///
   /// By designating Rhinestone as an attester, only modules explicitly
   /// approved by Rhinestone can be installed on your Safe.
-  static final EthereumAddress rhinestoneAttester =
-      EthereumAddress.fromHex('0x000000333034E9f539ce08819E12c1b8Cb29084d');
+  static final EthereumAddress rhinestoneAttester = EthereumAddress.fromHex(
+    '0x000000333034E9f539ce08819E12c1b8Cb29084d',
+  );
 }
 
 /// Module initialization configuration for ERC-7579 Safe accounts.
@@ -99,10 +101,7 @@ class Safe7579ModuleInit {
   ///
   /// - [module]: The address of the ERC-7579 module to install
   /// - [initData]: Optional initialization data for the module's `onInstall`
-  const Safe7579ModuleInit({
-    required this.module,
-    this.initData = '0x',
-  });
+  const Safe7579ModuleInit({required this.module, this.initData = '0x'});
 
   /// The address of the module to install.
   final EthereumAddress module;

--- a/packages/permissionless/lib/src/accounts/safe/safe_account.dart
+++ b/packages/permissionless/lib/src/accounts/safe/safe_account.dart
@@ -370,9 +370,7 @@ class SafeSmartAccount implements SmartAccount {
       final sharedSignerAddress = _addresses.webAuthnSharedSignerAddress!;
       final p256Verifier = _addresses.safeP256VerifierAddress;
       if (p256Verifier == null) {
-        throw StateError(
-          'WebAuthn owners require safeP256VerifierAddress.',
-        );
+        throw StateError('WebAuthn owners require safeP256VerifierAddress.');
       }
 
       for (final webAuthnOwner in _webAuthnOwners) {
@@ -770,8 +768,10 @@ class SafeSmartAccount implements SmartAccount {
         );
       } else {
         // ECDSA stub: r (32) + s (32) + v (1) = 65 bytes
-        final r =
-            Hex.fromBigInt(Hex.toBigInt(owner.address.hex), byteLength: 32);
+        final r = Hex.fromBigInt(
+          Hex.toBigInt(owner.address.hex),
+          byteLength: 32,
+        );
         const s = Hex.zero32;
         final v = Hex.fromBigInt(BigInt.from(1), byteLength: 1);
         signatureEntries.add(
@@ -838,11 +838,7 @@ class SafeSmartAccount implements SmartAccount {
         // ECDSA signing - Safe signs the raw EIP-712 hash directly
         final sig = await owner.signRawHash(safeOpHash);
         signatureEntries.add(
-          _SignatureEntry(
-            signer: owner.address,
-            data: sig,
-            isDynamic: false,
-          ),
+          _SignatureEntry(signer: owner.address, data: sig, isDynamic: false),
         );
       }
     }
@@ -944,8 +940,9 @@ class SafeSmartAccount implements SmartAccount {
     // Domain type hash: keccak256("EIP712Domain(uint256 chainId,address verifyingContract)")
     const domainTypeString =
         'EIP712Domain(uint256 chainId,address verifyingContract)';
-    final domainTypeHash =
-        keccak256(Uint8List.fromList(domainTypeString.codeUnits));
+    final domainTypeHash = keccak256(
+      Uint8List.fromList(domainTypeString.codeUnits),
+    );
 
     final encoded = Hex.concat([
       Hex.fromBytes(domainTypeHash),
@@ -967,14 +964,17 @@ class SafeSmartAccount implements SmartAccount {
     const safeOpTypeString =
         'SafeOp(address safe,uint256 nonce,bytes initCode,bytes callData,uint128 verificationGasLimit,uint128 callGasLimit,uint256 preVerificationGas,uint128 maxPriorityFeePerGas,uint128 maxFeePerGas,bytes paymasterAndData,uint48 validAfter,uint48 validUntil,address entryPoint)';
 
-    final safeOpTypeHash =
-        keccak256(Uint8List.fromList(safeOpTypeString.codeUnits));
+    final safeOpTypeHash = keccak256(
+      Uint8List.fromList(safeOpTypeString.codeUnits),
+    );
 
     // Compute initCode hash
     var initCode = '0x';
     if (userOp.factory != null && userOp.factoryData != null) {
-      initCode =
-          Hex.concat([userOp.factory!.hex, Hex.strip0x(userOp.factoryData!)]);
+      initCode = Hex.concat([
+        userOp.factory!.hex,
+        Hex.strip0x(userOp.factoryData!),
+      ]);
     }
     final initCodeHash = keccak256(Hex.decode(initCode));
 

--- a/packages/permissionless/lib/src/accounts/simple/constants.dart
+++ b/packages/permissionless/lib/src/accounts/simple/constants.dart
@@ -26,6 +26,10 @@ class SimpleAccountFactoryAddresses {
         EntryPointVersion.v06 => v06,
         EntryPointVersion.v07 => v07,
         EntryPointVersion.v08 => v08,
+        EntryPointVersion.v09 => throw ArgumentError(
+            'SimpleAccountFactory does not have an official EntryPoint v0.9 '
+            'deployment. Use Eip7702SimpleSmartAccount for Simple7702 v0.9.',
+          ),
       };
 }
 
@@ -35,11 +39,31 @@ class SimpleAccountFactoryAddresses {
 class Simple7702AccountAddresses {
   Simple7702AccountAddresses._();
 
-  /// The default Simple7702Account implementation address.
+  /// Simple7702Account implementation for EntryPoint v0.8.
   ///
   /// This contract is part of the eth-infinitism ERC-4337 v0.8 release.
-  static final EthereumAddress defaultLogic =
+  static final EthereumAddress v08 =
       EthereumAddress.fromHex('0xe6Cae83BdE06E4c305530e199D7217f42808555B');
+
+  /// Simple7702Account implementation for EntryPoint v0.9.
+  static final EthereumAddress v09 =
+      EthereumAddress.fromHex('0xa46cc63eBF4Bd77888AA327837d20b23A63a56B5');
+
+  /// The default Simple7702Account implementation address.
+  ///
+  /// Defaults remain on EntryPoint v0.8 for backward compatibility.
+  static EthereumAddress get defaultLogic => v08;
+
+  /// Gets the Simple7702Account implementation for an EntryPoint version.
+  static EthereumAddress fromEntryPointVersion(EntryPointVersion version) =>
+      switch (version) {
+        EntryPointVersion.v08 => v08,
+        EntryPointVersion.v09 => v09,
+        EntryPointVersion.v06 || EntryPointVersion.v07 => throw ArgumentError(
+            'Simple7702Account supports EntryPoint v0.8 and v0.9 only. '
+            'Received EntryPoint v${version.value}.',
+          ),
+      };
 }
 
 /// Function selectors for SimpleAccount contracts.

--- a/packages/permissionless/lib/src/accounts/simple/constants.dart
+++ b/packages/permissionless/lib/src/accounts/simple/constants.dart
@@ -26,6 +26,11 @@ class SimpleAccountFactoryAddresses {
         EntryPointVersion.v06 => v06,
         EntryPointVersion.v07 => v07,
         EntryPointVersion.v08 => v08,
+        EntryPointVersion.v09 => throw UnsupportedError(
+            'SimpleSmartAccount does not have an official EntryPoint v0.9 '
+            'factory deployment. Provide a customFactoryAddress for '
+            'user-supplied v0.9 experimentation.',
+          ),
       };
 }
 
@@ -35,11 +40,32 @@ class SimpleAccountFactoryAddresses {
 class Simple7702AccountAddresses {
   Simple7702AccountAddresses._();
 
-  /// The default Simple7702Account implementation address.
+  /// Simple7702Account implementation for EntryPoint v0.8.
   ///
   /// This contract is part of the eth-infinitism ERC-4337 v0.8 release.
-  static final EthereumAddress defaultLogic =
+  static final EthereumAddress v08 =
       EthereumAddress.fromHex('0xe6Cae83BdE06E4c305530e199D7217f42808555B');
+
+  /// Simple7702Account implementation for EntryPoint v0.9.
+  ///
+  /// This contract is part of the eth-infinitism ERC-4337 v0.9 release.
+  static final EthereumAddress v09 =
+      EthereumAddress.fromHex('0xa46cc63eBF4Bd77888AA327837d20b23A63a56B5');
+
+  /// The default Simple7702Account implementation address.
+  ///
+  /// Defaults remain on EntryPoint v0.8 unless v0.9 is explicitly selected.
+  static final EthereumAddress defaultLogic = v08;
+
+  /// Gets the Simple7702Account implementation for an EntryPoint version.
+  static EthereumAddress fromVersion(EntryPointVersion version) =>
+      switch (version) {
+        EntryPointVersion.v08 => v08,
+        EntryPointVersion.v09 => v09,
+        EntryPointVersion.v06 || EntryPointVersion.v07 => throw ArgumentError(
+            'Simple7702Account supports EntryPoint v0.8 and v0.9 only.',
+          ),
+      };
 }
 
 /// Function selectors for SimpleAccount contracts.

--- a/packages/permissionless/lib/src/accounts/simple/constants.dart
+++ b/packages/permissionless/lib/src/accounts/simple/constants.dart
@@ -26,6 +26,10 @@ class SimpleAccountFactoryAddresses {
         EntryPointVersion.v06 => v06,
         EntryPointVersion.v07 => v07,
         EntryPointVersion.v08 => v08,
+        EntryPointVersion.v09 => throw UnsupportedError(
+            'SimpleAccountFactory does not support EntryPoint v0.9. '
+            'Use Eip7702SimpleSmartAccount for Simple7702 v0.9.',
+          ),
       };
 }
 
@@ -35,11 +39,33 @@ class SimpleAccountFactoryAddresses {
 class Simple7702AccountAddresses {
   Simple7702AccountAddresses._();
 
-  /// The default Simple7702Account implementation address.
+  /// The Simple7702Account implementation address for EntryPoint v0.8.
   ///
   /// This contract is part of the eth-infinitism ERC-4337 v0.8 release.
-  static final EthereumAddress defaultLogic =
+  static final EthereumAddress v08 =
       EthereumAddress.fromHex('0xe6Cae83BdE06E4c305530e199D7217f42808555B');
+
+  /// The Simple7702Account implementation address for EntryPoint v0.9.
+  ///
+  /// This contract is part of the eth-infinitism ERC-4337 v0.9 release.
+  static final EthereumAddress v09 =
+      EthereumAddress.fromHex('0xa46cc63eBF4Bd77888AA327837d20b23A63a56B5');
+
+  /// The default Simple7702Account implementation address.
+  ///
+  /// Defaults remain on EntryPoint v0.8 for backward compatibility.
+  static final EthereumAddress defaultLogic = v08;
+
+  /// Gets the Simple7702Account implementation for an EntryPoint version.
+  static EthereumAddress fromVersion(EntryPointVersion version) =>
+      switch (version) {
+        EntryPointVersion.v08 => v08,
+        EntryPointVersion.v09 => v09,
+        EntryPointVersion.v06 || EntryPointVersion.v07 => throw ArgumentError(
+            'Simple7702Account supports EntryPoint v0.8 and v0.9 only. '
+            'Received EntryPoint v${version.value}.',
+          ),
+      };
 }
 
 /// Function selectors for SimpleAccount contracts.

--- a/packages/permissionless/lib/src/accounts/simple/constants.dart
+++ b/packages/permissionless/lib/src/accounts/simple/constants.dart
@@ -26,6 +26,11 @@ class SimpleAccountFactoryAddresses {
         EntryPointVersion.v06 => v06,
         EntryPointVersion.v07 => v07,
         EntryPointVersion.v08 => v08,
+        EntryPointVersion.v09 => throw ArgumentError(
+            'SimpleAccountFactory does not have an official EntryPoint v0.9 '
+            'deployment. Use a custom factory address for user-supplied '
+            'deployments.',
+          ),
       };
 }
 

--- a/packages/permissionless/lib/src/accounts/simple/constants.dart
+++ b/packages/permissionless/lib/src/accounts/simple/constants.dart
@@ -9,16 +9,19 @@ class SimpleAccountFactoryAddresses {
   SimpleAccountFactoryAddresses._();
 
   /// SimpleAccountFactory for EntryPoint v0.6.
-  static final EthereumAddress v06 =
-      EthereumAddress.fromHex('0x9406Cc6185a346906296840746125a0E44976454');
+  static final EthereumAddress v06 = EthereumAddress.fromHex(
+    '0x9406Cc6185a346906296840746125a0E44976454',
+  );
 
   /// SimpleAccountFactory for EntryPoint v0.7.
-  static final EthereumAddress v07 =
-      EthereumAddress.fromHex('0x91E60e0613810449d098b0b5Ec8b51A0FE8c8985');
+  static final EthereumAddress v07 = EthereumAddress.fromHex(
+    '0x91E60e0613810449d098b0b5Ec8b51A0FE8c8985',
+  );
 
   /// SimpleAccountFactory for EntryPoint v0.8.
-  static final EthereumAddress v08 =
-      EthereumAddress.fromHex('0x13E9ed32155810FDbd067D4522C492D6f68E5944');
+  static final EthereumAddress v08 = EthereumAddress.fromHex(
+    '0x13E9ed32155810FDbd067D4522C492D6f68E5944',
+  );
 
   /// Gets the factory address for the given EntryPoint version.
   static EthereumAddress fromVersion(EntryPointVersion version) =>
@@ -42,14 +45,16 @@ class Simple7702AccountAddresses {
   /// The Simple7702Account implementation address for EntryPoint v0.8.
   ///
   /// This contract is part of the eth-infinitism ERC-4337 v0.8 release.
-  static final EthereumAddress v08 =
-      EthereumAddress.fromHex('0xe6Cae83BdE06E4c305530e199D7217f42808555B');
+  static final EthereumAddress v08 = EthereumAddress.fromHex(
+    '0xe6Cae83BdE06E4c305530e199D7217f42808555B',
+  );
 
   /// The Simple7702Account implementation address for EntryPoint v0.9.
   ///
   /// This contract is part of the eth-infinitism ERC-4337 v0.9 release.
-  static final EthereumAddress v09 =
-      EthereumAddress.fromHex('0xa46cc63eBF4Bd77888AA327837d20b23A63a56B5');
+  static final EthereumAddress v09 = EthereumAddress.fromHex(
+    '0xa46cc63eBF4Bd77888AA327837d20b23A63a56B5',
+  );
 
   /// The default Simple7702Account implementation address.
   ///

--- a/packages/permissionless/lib/src/accounts/simple/eip7702_simple_account.dart
+++ b/packages/permissionless/lib/src/accounts/simple/eip7702_simple_account.dart
@@ -123,14 +123,18 @@ class Eip7702SimpleSmartAccountConfig {
   ///
   /// Optional parameters:
   /// - [publicClient]: Client for checking deployment status (EIP-1271)
+  /// - [entryPointVersion]: EntryPoint version (v0.8 by default; v0.9 opt-in)
   /// - [accountLogicAddress]: Override the default Simple7702Account logic
   Eip7702SimpleSmartAccountConfig({
     required this.owner,
     required this.chainId,
     this.publicClient,
+    EntryPointVersion entryPointVersion = EntryPointVersion.v08,
     EthereumAddress? accountLogicAddress,
-  }) : accountLogicAddress =
-            accountLogicAddress ?? Simple7702AccountAddresses.defaultLogic;
+  })  : entryPointVersion = _validateEntryPointVersion(entryPointVersion),
+        accountLogicAddress =
+            accountLogicAddress ??
+                Simple7702AccountAddresses.fromVersion(entryPointVersion);
 
   /// The owner of this EIP-7702 account (the EOA).
   final Eip7702SimpleAccountOwner owner;
@@ -144,10 +148,26 @@ class Eip7702SimpleSmartAccountConfig {
   /// has been delegated (deployed) before signing messages/typed data.
   final PublicClient? publicClient;
 
+  /// EntryPoint version to use for this EIP-7702 account.
+  final EntryPointVersion entryPointVersion;
+
   /// The Simple7702Account logic contract address.
   ///
   /// Defaults to the official eth-infinitism Simple7702Account.
   final EthereumAddress accountLogicAddress;
+
+  static EntryPointVersion _validateEntryPointVersion(
+    EntryPointVersion entryPointVersion,
+  ) {
+    if (entryPointVersion == EntryPointVersion.v08 ||
+        entryPointVersion == EntryPointVersion.v09) {
+      return entryPointVersion;
+    }
+
+    throw ArgumentError(
+      'Simple7702Account supports EntryPoint v0.8 and v0.9 only.',
+    );
+  }
 }
 
 /// An EIP-7702 Simple smart account implementation.
@@ -157,8 +177,8 @@ class Eip7702SimpleSmartAccountConfig {
 ///
 /// - **Account address = EOA address**: No separate smart account deployment
 /// - **No factory needed**: The authorization delegates code on-demand
-/// - **EntryPoint v0.8**: Required for native EIP-7702 support
-/// - **Typed data signing**: v0.8 uses EIP-712 typed data for UserOperation signing
+/// - **EntryPoint v0.8/v0.9**: Required for native EIP-7702 support
+/// - **Typed data signing**: Uses EIP-712 typed data for UserOperation signing
 ///
 /// Example:
 /// ```dart
@@ -194,8 +214,8 @@ class Eip7702SimpleSmartAccount implements Eip7702SmartAccount {
   @override
   bool get isEip7702 => true;
 
-  /// The EntryPoint version (always v0.8 for EIP-7702).
-  EntryPointVersion get entryPointVersion => EntryPointVersion.v08;
+  /// The EntryPoint version.
+  EntryPointVersion get entryPointVersion => _config.entryPointVersion;
 
   /// The chain ID.
   @override
@@ -203,7 +223,8 @@ class Eip7702SimpleSmartAccount implements Eip7702SmartAccount {
 
   /// The EntryPoint address for this account.
   @override
-  EthereumAddress get entryPoint => EntryPointAddresses.v08;
+  EthereumAddress get entryPoint =>
+      EntryPointAddresses.fromVersion(entryPointVersion);
 
   /// The nonce key for parallel transaction support.
   @override
@@ -519,7 +540,7 @@ class Eip7702SimpleSmartAccount implements Eip7702SmartAccount {
 /// an EOA to function as a smart account without deploying a separate contract.
 ///
 /// **Requirements:**
-/// - EntryPoint v0.8 (automatically used)
+/// - EntryPoint v0.8 by default, or v0.9 when explicitly selected
 /// - Bundler with EIP-7702 support
 /// - Chain with EIP-7702 enabled
 ///
@@ -540,6 +561,7 @@ Eip7702SimpleSmartAccount createEip7702SimpleSmartAccount({
   required Eip7702SimpleAccountOwner owner,
   required BigInt chainId,
   PublicClient? publicClient,
+  EntryPointVersion entryPointVersion = EntryPointVersion.v08,
   EthereumAddress? accountLogicAddress,
 }) =>
     Eip7702SimpleSmartAccount(
@@ -547,6 +569,7 @@ Eip7702SimpleSmartAccount createEip7702SimpleSmartAccount({
         owner: owner,
         chainId: chainId,
         publicClient: publicClient,
+        entryPointVersion: entryPointVersion,
         accountLogicAddress: accountLogicAddress,
       ),
     );

--- a/packages/permissionless/lib/src/accounts/simple/eip7702_simple_account.dart
+++ b/packages/permissionless/lib/src/accounts/simple/eip7702_simple_account.dart
@@ -335,7 +335,6 @@ class Eip7702SimpleSmartAccount implements Eip7702SmartAccount {
       Hex.strip0x(AbiEncoder.encodeUint256(BigInt.from(calls.length))),
     ]
         // Array offset
-
         // Array length
         ;
 

--- a/packages/permissionless/lib/src/accounts/simple/eip7702_simple_account.dart
+++ b/packages/permissionless/lib/src/accounts/simple/eip7702_simple_account.dart
@@ -123,14 +123,16 @@ class Eip7702SimpleSmartAccountConfig {
   ///
   /// Optional parameters:
   /// - [publicClient]: Client for checking deployment status (EIP-1271)
+  /// - [entryPointVersion]: EntryPoint version, v0.8 by default; v0.9 opt-in
   /// - [accountLogicAddress]: Override the default Simple7702Account logic
   Eip7702SimpleSmartAccountConfig({
     required this.owner,
     required this.chainId,
     this.publicClient,
+    this.entryPointVersion = EntryPointVersion.v08,
     EthereumAddress? accountLogicAddress,
-  }) : accountLogicAddress =
-            accountLogicAddress ?? Simple7702AccountAddresses.defaultLogic;
+  }) : accountLogicAddress = accountLogicAddress ??
+            Simple7702AccountAddresses.fromVersion(entryPointVersion);
 
   /// The owner of this EIP-7702 account (the EOA).
   final Eip7702SimpleAccountOwner owner;
@@ -143,6 +145,11 @@ class Eip7702SimpleSmartAccountConfig {
   /// Required for EIP-1271 signature validation to check if the account
   /// has been delegated (deployed) before signing messages/typed data.
   final PublicClient? publicClient;
+
+  /// EntryPoint version used by this account.
+  ///
+  /// Defaults to v0.8. v0.9 must be selected explicitly.
+  final EntryPointVersion entryPointVersion;
 
   /// The Simple7702Account logic contract address.
   ///
@@ -157,8 +164,8 @@ class Eip7702SimpleSmartAccountConfig {
 ///
 /// - **Account address = EOA address**: No separate smart account deployment
 /// - **No factory needed**: The authorization delegates code on-demand
-/// - **EntryPoint v0.8**: Required for native EIP-7702 support
-/// - **Typed data signing**: v0.8 uses EIP-712 typed data for UserOperation signing
+/// - **EntryPoint v0.8 by default**: v0.9 is available as explicit opt-in
+/// - **Typed data signing**: Uses EIP-712 typed data for UserOperation signing
 ///
 /// Example:
 /// ```dart
@@ -194,8 +201,10 @@ class Eip7702SimpleSmartAccount implements Eip7702SmartAccount {
   @override
   bool get isEip7702 => true;
 
-  /// The EntryPoint version (always v0.8 for EIP-7702).
-  EntryPointVersion get entryPointVersion => EntryPointVersion.v08;
+  /// The EntryPoint version.
+  ///
+  /// Defaults to v0.8 unless v0.9 was explicitly configured.
+  EntryPointVersion get entryPointVersion => _config.entryPointVersion;
 
   /// The chain ID.
   @override
@@ -203,7 +212,8 @@ class Eip7702SimpleSmartAccount implements Eip7702SmartAccount {
 
   /// The EntryPoint address for this account.
   @override
-  EthereumAddress get entryPoint => EntryPointAddresses.v08;
+  EthereumAddress get entryPoint =>
+      EntryPointAddresses.fromVersion(_config.entryPointVersion);
 
   /// The nonce key for parallel transaction support.
   @override
@@ -519,7 +529,7 @@ class Eip7702SimpleSmartAccount implements Eip7702SmartAccount {
 /// an EOA to function as a smart account without deploying a separate contract.
 ///
 /// **Requirements:**
-/// - EntryPoint v0.8 (automatically used)
+/// - EntryPoint v0.8 by default, or v0.9 when explicitly configured
 /// - Bundler with EIP-7702 support
 /// - Chain with EIP-7702 enabled
 ///
@@ -540,6 +550,7 @@ Eip7702SimpleSmartAccount createEip7702SimpleSmartAccount({
   required Eip7702SimpleAccountOwner owner,
   required BigInt chainId,
   PublicClient? publicClient,
+  EntryPointVersion entryPointVersion = EntryPointVersion.v08,
   EthereumAddress? accountLogicAddress,
 }) =>
     Eip7702SimpleSmartAccount(
@@ -547,6 +558,7 @@ Eip7702SimpleSmartAccount createEip7702SimpleSmartAccount({
         owner: owner,
         chainId: chainId,
         publicClient: publicClient,
+        entryPointVersion: entryPointVersion,
         accountLogicAddress: accountLogicAddress,
       ),
     );

--- a/packages/permissionless/lib/src/accounts/simple/eip7702_simple_account.dart
+++ b/packages/permissionless/lib/src/accounts/simple/eip7702_simple_account.dart
@@ -132,9 +132,8 @@ class Eip7702SimpleSmartAccountConfig {
     EntryPointVersion entryPointVersion = EntryPointVersion.v08,
     EthereumAddress? accountLogicAddress,
   })  : entryPointVersion = _validateEntryPointVersion(entryPointVersion),
-        accountLogicAddress =
-            accountLogicAddress ??
-                Simple7702AccountAddresses.fromVersion(entryPointVersion);
+        accountLogicAddress = accountLogicAddress ??
+            Simple7702AccountAddresses.fromVersion(entryPointVersion);
 
   /// The owner of this EIP-7702 account (the EOA).
   final Eip7702SimpleAccountOwner owner;

--- a/packages/permissionless/lib/src/accounts/simple/eip7702_simple_account.dart
+++ b/packages/permissionless/lib/src/accounts/simple/eip7702_simple_account.dart
@@ -123,14 +123,32 @@ class Eip7702SimpleSmartAccountConfig {
   ///
   /// Optional parameters:
   /// - [publicClient]: Client for checking deployment status (EIP-1271)
+  /// - [entryPointVersion]: EntryPoint version, defaults to v0.8
   /// - [accountLogicAddress]: Override the default Simple7702Account logic
   Eip7702SimpleSmartAccountConfig({
     required this.owner,
     required this.chainId,
     this.publicClient,
+    this.entryPointVersion = EntryPointVersion.v08,
     EthereumAddress? accountLogicAddress,
-  }) : accountLogicAddress =
-            accountLogicAddress ?? Simple7702AccountAddresses.defaultLogic;
+  }) : accountLogicAddress = accountLogicAddress ??
+            Simple7702AccountAddresses.fromEntryPointVersion(
+              entryPointVersion,
+            ) {
+    _validateEntryPointVersion(entryPointVersion);
+  }
+
+  static void _validateEntryPointVersion(EntryPointVersion version) {
+    if (version == EntryPointVersion.v08 || version == EntryPointVersion.v09) {
+      return;
+    }
+
+    throw ArgumentError.value(
+      version,
+      'entryPointVersion',
+      'Simple7702Account supports EntryPoint v0.8 and v0.9 only',
+    );
+  }
 
   /// The owner of this EIP-7702 account (the EOA).
   final Eip7702SimpleAccountOwner owner;
@@ -144,9 +162,16 @@ class Eip7702SimpleSmartAccountConfig {
   /// has been delegated (deployed) before signing messages/typed data.
   final PublicClient? publicClient;
 
+  /// EntryPoint version used by this EIP-7702 Simple account.
+  ///
+  /// Only v0.8 and v0.9 are supported by official Simple7702Account
+  /// deployments.
+  final EntryPointVersion entryPointVersion;
+
   /// The Simple7702Account logic contract address.
   ///
-  /// Defaults to the official eth-infinitism Simple7702Account.
+  /// Defaults to the official eth-infinitism Simple7702Account for
+  /// [entryPointVersion].
   final EthereumAddress accountLogicAddress;
 }
 
@@ -157,8 +182,8 @@ class Eip7702SimpleSmartAccountConfig {
 ///
 /// - **Account address = EOA address**: No separate smart account deployment
 /// - **No factory needed**: The authorization delegates code on-demand
-/// - **EntryPoint v0.8**: Required for native EIP-7702 support
-/// - **Typed data signing**: v0.8 uses EIP-712 typed data for UserOperation signing
+/// - **EntryPoint v0.8 or v0.9**: Required for native EIP-7702 support
+/// - **Typed data signing**: Uses EIP-712 typed data for UserOperation signing
 ///
 /// Example:
 /// ```dart
@@ -194,8 +219,8 @@ class Eip7702SimpleSmartAccount implements Eip7702SmartAccount {
   @override
   bool get isEip7702 => true;
 
-  /// The EntryPoint version (always v0.8 for EIP-7702).
-  EntryPointVersion get entryPointVersion => EntryPointVersion.v08;
+  /// The EntryPoint version for this EIP-7702 account.
+  EntryPointVersion get entryPointVersion => _config.entryPointVersion;
 
   /// The chain ID.
   @override
@@ -203,7 +228,8 @@ class Eip7702SimpleSmartAccount implements Eip7702SmartAccount {
 
   /// The EntryPoint address for this account.
   @override
-  EthereumAddress get entryPoint => EntryPointAddresses.v08;
+  EthereumAddress get entryPoint =>
+      EntryPointAddresses.fromVersion(_config.entryPointVersion);
 
   /// The nonce key for parallel transaction support.
   @override
@@ -225,7 +251,7 @@ class Eip7702SimpleSmartAccount implements Eip7702SmartAccount {
   @override
   Future<String> getInitCode() async => '0x';
 
-  /// Gets the factory address and data for UserOperation v0.7/v0.8.
+  /// Gets the factory address and data for unpacked UserOperations.
   ///
   /// For EIP-7702 accounts, this returns null as no factory is used.
   @override
@@ -366,12 +392,13 @@ class Eip7702SimpleSmartAccount implements Eip7702SmartAccount {
   String getStubSignature() =>
       '0xfffffffffffffffffffffffffffffff0000000000000000000000000000000007aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1c';
 
-  /// Signs a UserOperation using EIP-712 typed data (v0.8 format).
+  /// Signs a UserOperation using EIP-712 typed data.
   ///
-  /// EntryPoint v0.8 uses typed data signing instead of raw hash signing.
+  /// EIP-7702 Simple accounts use typed data signing instead of raw hash
+  /// signing.
   @override
   Future<String> signUserOperation(UserOperationV07 userOp) async {
-    // v0.8 uses EIP-712 typed data for signing
+    // Simple7702 uses EIP-712 typed data for signing.
     final typedData = _getUserOperationTypedData(userOp);
     return _config.owner.signTypedData(typedData);
   }
@@ -426,7 +453,7 @@ class Eip7702SimpleSmartAccount implements Eip7702SmartAccount {
 
   /// Creates the EIP-712 typed data for a UserOperation.
   ///
-  /// This is the v0.8 format for UserOperation signing.
+  /// This is the Simple7702 typed data format for UserOperation signing.
   /// Matches viem's getUserOperationTypedData implementation.
   TypedData _getUserOperationTypedData(UserOperationV07 userOp) {
     // Pack gas limits: verificationGasLimit (16 bytes) + callGasLimit (16 bytes)
@@ -519,7 +546,7 @@ class Eip7702SimpleSmartAccount implements Eip7702SmartAccount {
 /// an EOA to function as a smart account without deploying a separate contract.
 ///
 /// **Requirements:**
-/// - EntryPoint v0.8 (automatically used)
+/// - EntryPoint v0.8 by default, or explicit EntryPoint v0.9 opt-in
 /// - Bundler with EIP-7702 support
 /// - Chain with EIP-7702 enabled
 ///
@@ -540,6 +567,7 @@ Eip7702SimpleSmartAccount createEip7702SimpleSmartAccount({
   required Eip7702SimpleAccountOwner owner,
   required BigInt chainId,
   PublicClient? publicClient,
+  EntryPointVersion entryPointVersion = EntryPointVersion.v08,
   EthereumAddress? accountLogicAddress,
 }) =>
     Eip7702SimpleSmartAccount(
@@ -547,6 +575,7 @@ Eip7702SimpleSmartAccount createEip7702SimpleSmartAccount({
         owner: owner,
         chainId: chainId,
         publicClient: publicClient,
+        entryPointVersion: entryPointVersion,
         accountLogicAddress: accountLogicAddress,
       ),
     );

--- a/packages/permissionless/lib/src/accounts/simple/simple_account.dart
+++ b/packages/permissionless/lib/src/accounts/simple/simple_account.dart
@@ -191,10 +191,7 @@ class SimpleSmartAccount implements SmartAccount {
     final factoryData = _encodeCreateAccount();
 
     // InitCode = factory address (20 bytes) + factory calldata
-    return Hex.concat([
-      _factoryAddress.hex,
-      Hex.strip0x(factoryData),
-    ]);
+    return Hex.concat([_factoryAddress.hex, Hex.strip0x(factoryData)]);
   }
 
   /// Gets the factory address and data for UserOperation v0.7.

--- a/packages/permissionless/lib/src/accounts/thirdweb/constants.dart
+++ b/packages/permissionless/lib/src/accounts/thirdweb/constants.dart
@@ -7,12 +7,14 @@ class ThirdwebAddresses {
   ThirdwebAddresses._();
 
   /// Factory address for EntryPoint v0.6.
-  static final EthereumAddress factoryV06 =
-      EthereumAddress.fromHex('0x85e23b94e7F5E9cC1fF78BCe78cfb15B81f0DF00');
+  static final EthereumAddress factoryV06 = EthereumAddress.fromHex(
+    '0x85e23b94e7F5E9cC1fF78BCe78cfb15B81f0DF00',
+  );
 
   /// Factory address for EntryPoint v0.7.
-  static final EthereumAddress factoryV07 =
-      EthereumAddress.fromHex('0x4be0ddfebca9a5a4a617dee4dece99e7c862dceb');
+  static final EthereumAddress factoryV07 = EthereumAddress.fromHex(
+    '0x4be0ddfebca9a5a4a617dee4dece99e7c862dceb',
+  );
 }
 
 /// Thirdweb function selectors.

--- a/packages/permissionless/lib/src/accounts/thirdweb/thirdweb_account.dart
+++ b/packages/permissionless/lib/src/accounts/thirdweb/thirdweb_account.dart
@@ -84,9 +84,7 @@ class ThirdwebSmartAccount implements SmartAccount {
   /// of calling this constructor directly.
   ThirdwebSmartAccount(this._config)
       : _factoryAddress = _config.customFactoryAddress ??
-            (_config.entryPointVersion == EntryPointVersion.v07
-                ? ThirdwebAddresses.factoryV07
-                : ThirdwebAddresses.factoryV06);
+            _factoryAddressFor(_config.entryPointVersion);
 
   final ThirdwebSmartAccountConfig _config;
   final EthereumAddress _factoryAddress;
@@ -104,10 +102,28 @@ class ThirdwebSmartAccount implements SmartAccount {
 
   /// The EntryPoint address.
   @override
-  EthereumAddress get entryPoint =>
-      _config.entryPointVersion == EntryPointVersion.v07
-          ? EntryPointAddresses.v07
-          : EntryPointAddresses.v06;
+  EthereumAddress get entryPoint => switch (_config.entryPointVersion) {
+        EntryPointVersion.v06 => EntryPointAddresses.v06,
+        EntryPointVersion.v07 => EntryPointAddresses.v07,
+        EntryPointVersion.v08 => throw ArgumentError(
+            'Thirdweb account does not support EntryPoint v0.8.',
+          ),
+        EntryPointVersion.v09 => throw ArgumentError(
+            'Thirdweb account does not support EntryPoint v0.9.',
+          ),
+      };
+
+  static EthereumAddress _factoryAddressFor(EntryPointVersion version) =>
+      switch (version) {
+        EntryPointVersion.v06 => ThirdwebAddresses.factoryV06,
+        EntryPointVersion.v07 => ThirdwebAddresses.factoryV07,
+        EntryPointVersion.v08 => throw ArgumentError(
+            'Thirdweb account does not support EntryPoint v0.8.',
+          ),
+        EntryPointVersion.v09 => throw ArgumentError(
+            'Thirdweb account does not support EntryPoint v0.9.',
+          ),
+      };
 
   /// The nonce key for parallel transaction support.
   @override

--- a/packages/permissionless/lib/src/accounts/thirdweb/thirdweb_account.dart
+++ b/packages/permissionless/lib/src/accounts/thirdweb/thirdweb_account.dart
@@ -84,9 +84,7 @@ class ThirdwebSmartAccount implements SmartAccount {
   /// of calling this constructor directly.
   ThirdwebSmartAccount(this._config)
       : _factoryAddress = _config.customFactoryAddress ??
-            (_config.entryPointVersion == EntryPointVersion.v07
-                ? ThirdwebAddresses.factoryV07
-                : ThirdwebAddresses.factoryV06);
+            _factoryAddressForVersion(_config.entryPointVersion);
 
   final ThirdwebSmartAccountConfig _config;
   final EthereumAddress _factoryAddress;
@@ -105,9 +103,31 @@ class ThirdwebSmartAccount implements SmartAccount {
   /// The EntryPoint address.
   @override
   EthereumAddress get entryPoint =>
-      _config.entryPointVersion == EntryPointVersion.v07
-          ? EntryPointAddresses.v07
-          : EntryPointAddresses.v06;
+      _entryPointAddressForVersion(_config.entryPointVersion);
+
+  static EthereumAddress _factoryAddressForVersion(
+    EntryPointVersion entryPointVersion,
+  ) =>
+      switch (entryPointVersion) {
+        EntryPointVersion.v06 => ThirdwebAddresses.factoryV06,
+        EntryPointVersion.v07 => ThirdwebAddresses.factoryV07,
+        EntryPointVersion.v08 || EntryPointVersion.v09 => throw ArgumentError(
+            'Thirdweb accounts support EntryPoint v0.6 and v0.7 only. '
+            'Received EntryPoint v${entryPointVersion.value}.',
+          ),
+      };
+
+  static EthereumAddress _entryPointAddressForVersion(
+    EntryPointVersion entryPointVersion,
+  ) =>
+      switch (entryPointVersion) {
+        EntryPointVersion.v06 || EntryPointVersion.v07 =>
+          EntryPointAddresses.fromVersion(entryPointVersion),
+        EntryPointVersion.v08 || EntryPointVersion.v09 => throw ArgumentError(
+            'Thirdweb accounts support EntryPoint v0.6 and v0.7 only. '
+            'Received EntryPoint v${entryPointVersion.value}.',
+          ),
+      };
 
   /// The nonce key for parallel transaction support.
   @override

--- a/packages/permissionless/lib/src/accounts/thirdweb/thirdweb_account.dart
+++ b/packages/permissionless/lib/src/accounts/thirdweb/thirdweb_account.dart
@@ -83,14 +83,34 @@ class ThirdwebSmartAccount implements SmartAccount {
   /// Prefer using [createThirdwebSmartAccount] factory function instead
   /// of calling this constructor directly.
   ThirdwebSmartAccount(this._config)
-      : _factoryAddress = _config.customFactoryAddress ??
-            (_config.entryPointVersion == EntryPointVersion.v07
-                ? ThirdwebAddresses.factoryV07
-                : ThirdwebAddresses.factoryV06);
+      : _factoryAddress = _resolveFactoryAddress(_config);
 
   final ThirdwebSmartAccountConfig _config;
   final EthereumAddress _factoryAddress;
   EthereumAddress? _cachedAddress;
+
+  static EthereumAddress _resolveFactoryAddress(
+    ThirdwebSmartAccountConfig config,
+  ) {
+    if (config.customFactoryAddress != null) {
+      return config.customFactoryAddress!;
+    }
+
+    return switch (config.entryPointVersion) {
+      EntryPointVersion.v06 => ThirdwebAddresses.factoryV06,
+      EntryPointVersion.v07 => ThirdwebAddresses.factoryV07,
+      EntryPointVersion.v08 => throw UnsupportedError(
+          'ThirdwebSmartAccount does not have an official EntryPoint v0.8 '
+          'factory deployment. Provide a customFactoryAddress for '
+          'user-supplied experimentation.',
+        ),
+      EntryPointVersion.v09 => throw UnsupportedError(
+          'ThirdwebSmartAccount does not have an official EntryPoint v0.9 '
+          'factory deployment. Provide a customFactoryAddress for '
+          'user-supplied experimentation.',
+        ),
+    };
+  }
 
   /// The owner of this account.
   AccountOwner get owner => _config.owner;
@@ -105,9 +125,7 @@ class ThirdwebSmartAccount implements SmartAccount {
   /// The EntryPoint address.
   @override
   EthereumAddress get entryPoint =>
-      _config.entryPointVersion == EntryPointVersion.v07
-          ? EntryPointAddresses.v07
-          : EntryPointAddresses.v06;
+      EntryPointAddresses.fromVersion(_config.entryPointVersion);
 
   /// The nonce key for parallel transaction support.
   @override

--- a/packages/permissionless/lib/src/accounts/thirdweb/thirdweb_account.dart
+++ b/packages/permissionless/lib/src/accounts/thirdweb/thirdweb_account.dart
@@ -121,7 +121,8 @@ class ThirdwebSmartAccount implements SmartAccount {
     EntryPointVersion entryPointVersion,
   ) =>
       switch (entryPointVersion) {
-        EntryPointVersion.v06 || EntryPointVersion.v07 =>
+        EntryPointVersion.v06 ||
+        EntryPointVersion.v07 =>
           EntryPointAddresses.fromVersion(entryPointVersion),
         EntryPointVersion.v08 || EntryPointVersion.v09 => throw ArgumentError(
             'Thirdweb accounts support EntryPoint v0.6 and v0.7 only. '

--- a/packages/permissionless/lib/src/accounts/thirdweb/thirdweb_account.dart
+++ b/packages/permissionless/lib/src/accounts/thirdweb/thirdweb_account.dart
@@ -83,8 +83,7 @@ class ThirdwebSmartAccount implements SmartAccount {
   /// Prefer using [createThirdwebSmartAccount] factory function instead
   /// of calling this constructor directly.
   ThirdwebSmartAccount(this._config)
-      : _factoryAddress = _config.customFactoryAddress ??
-            _factoryAddressForVersion(_config.entryPointVersion);
+      : _factoryAddress = _resolveFactoryAddress(_config);
 
   final ThirdwebSmartAccountConfig _config;
   final EthereumAddress _factoryAddress;
@@ -103,32 +102,30 @@ class ThirdwebSmartAccount implements SmartAccount {
   /// The EntryPoint address.
   @override
   EthereumAddress get entryPoint =>
-      _entryPointAddressForVersion(_config.entryPointVersion);
+      EntryPointAddresses.fromVersion(_config.entryPointVersion);
 
-  static EthereumAddress _factoryAddressForVersion(
-    EntryPointVersion entryPointVersion,
-  ) =>
-      switch (entryPointVersion) {
-        EntryPointVersion.v06 => ThirdwebAddresses.factoryV06,
-        EntryPointVersion.v07 => ThirdwebAddresses.factoryV07,
-        EntryPointVersion.v08 || EntryPointVersion.v09 => throw ArgumentError(
-            'Thirdweb accounts support EntryPoint v0.6 and v0.7 only. '
-            'Received EntryPoint v${entryPointVersion.value}.',
-          ),
-      };
+  static EthereumAddress _resolveFactoryAddress(
+    ThirdwebSmartAccountConfig config,
+  ) {
+    if (config.customFactoryAddress != null) {
+      return config.customFactoryAddress!;
+    }
 
-  static EthereumAddress _entryPointAddressForVersion(
-    EntryPointVersion entryPointVersion,
-  ) =>
-      switch (entryPointVersion) {
-        EntryPointVersion.v06 ||
-        EntryPointVersion.v07 =>
-          EntryPointAddresses.fromVersion(entryPointVersion),
-        EntryPointVersion.v08 || EntryPointVersion.v09 => throw ArgumentError(
-            'Thirdweb accounts support EntryPoint v0.6 and v0.7 only. '
-            'Received EntryPoint v${entryPointVersion.value}.',
-          ),
-      };
+    return switch (config.entryPointVersion) {
+      EntryPointVersion.v06 => ThirdwebAddresses.factoryV06,
+      EntryPointVersion.v07 => ThirdwebAddresses.factoryV07,
+      EntryPointVersion.v08 => throw UnsupportedError(
+          'ThirdwebSmartAccount does not have an official EntryPoint v0.8 '
+          'factory deployment. Provide a customFactoryAddress for '
+          'user-supplied experimentation.',
+        ),
+      EntryPointVersion.v09 => throw UnsupportedError(
+          'ThirdwebSmartAccount does not have an official EntryPoint v0.9 '
+          'factory deployment. Provide a customFactoryAddress for '
+          'user-supplied experimentation.',
+        ),
+    };
+  }
 
   /// The nonce key for parallel transaction support.
   @override
@@ -174,10 +171,7 @@ class ThirdwebSmartAccount implements SmartAccount {
   @override
   Future<String> getInitCode() async {
     final factoryData = _encodeCreateAccount();
-    return Hex.concat([
-      _factoryAddress.hex,
-      Hex.strip0x(factoryData),
-    ]);
+    return Hex.concat([_factoryAddress.hex, Hex.strip0x(factoryData)]);
   }
 
   /// Gets the factory address and data for UserOperation v0.7.

--- a/packages/permissionless/lib/src/accounts/trust/constants.dart
+++ b/packages/permissionless/lib/src/accounts/trust/constants.dart
@@ -7,8 +7,9 @@ class TrustAddresses {
   TrustAddresses._();
 
   /// Factory address for account deployment.
-  static final EthereumAddress factory =
-      EthereumAddress.fromHex('0x729c310186a57833f622630a16d13f710b83272a');
+  static final EthereumAddress factory = EthereumAddress.fromHex(
+    '0x729c310186a57833f622630a16d13f710b83272a',
+  );
 
   /// Secp256k1 verification facet address.
   static final EthereumAddress secp256k1VerificationFacet =

--- a/packages/permissionless/lib/src/accounts/trust/trust_account.dart
+++ b/packages/permissionless/lib/src/accounts/trust/trust_account.dart
@@ -152,10 +152,7 @@ class TrustSmartAccount implements SmartAccountV06 {
   @override
   Future<String> getInitCode() async {
     final factoryData = _encodeCreateAccount();
-    return Hex.concat([
-      _factoryAddress.hex,
-      Hex.strip0x(factoryData),
-    ]);
+    return Hex.concat([_factoryAddress.hex, Hex.strip0x(factoryData)]);
   }
 
   /// Gets the factory address and data for UserOperation v0.7.
@@ -342,9 +339,7 @@ class TrustSmartAccount implements SmartAccountV06 {
         verifyingContract: accountAddress,
       ),
       types: {
-        'BarzMessage': [
-          const TypedDataField(name: 'message', type: 'bytes'),
-        ],
+        'BarzMessage': [const TypedDataField(name: 'message', type: 'bytes')],
       },
       primaryType: 'BarzMessage',
       message: {'message': hashedMessage},

--- a/packages/permissionless/lib/src/actions/erc7579/erc7579_actions.dart
+++ b/packages/permissionless/lib/src/actions/erc7579/erc7579_actions.dart
@@ -314,8 +314,9 @@ extension Erc7579Actions on SmartAccountClient {
     final callData = encode7579SupportsExecutionMode(mode);
 
     try {
-      final result =
-          await publicClient.call(Call(to: accountAddress, data: callData));
+      final result = await publicClient.call(
+        Call(to: accountAddress, data: callData),
+      );
       return decode7579BoolResult(result);
     } catch (_) {
       // If the call fails, the mode is not supported
@@ -346,8 +347,9 @@ extension Erc7579Actions on SmartAccountClient {
     final callData = encode7579SupportsModule(moduleType);
 
     try {
-      final result =
-          await publicClient.call(Call(to: accountAddress, data: callData));
+      final result = await publicClient.call(
+        Call(to: accountAddress, data: callData),
+      );
       return decode7579BoolResult(result);
     } catch (_) {
       return false;
@@ -381,8 +383,9 @@ extension Erc7579Actions on SmartAccountClient {
     );
 
     try {
-      final result =
-          await publicClient.call(Call(to: accountAddress, data: callData));
+      final result = await publicClient.call(
+        Call(to: accountAddress, data: callData),
+      );
       return decode7579BoolResult(result);
     } catch (_) {
       return false;
@@ -399,15 +402,14 @@ extension Erc7579Actions on SmartAccountClient {
   /// final accountId = await client.getAccountId(publicClient: publicClient);
   /// print('Account type: $accountId');
   /// ```
-  Future<String> getAccountId({
-    required PublicClient publicClient,
-  }) async {
+  Future<String> getAccountId({required PublicClient publicClient}) async {
     final accountAddress = await getAddress();
     final callData = encode7579AccountId();
 
     try {
-      final result =
-          await publicClient.call(Call(to: accountAddress, data: callData));
+      final result = await publicClient.call(
+        Call(to: accountAddress, data: callData),
+      );
       return decode7579StringResult(result);
     } catch (_) {
       return '';

--- a/packages/permissionless/lib/src/clients/bundler/bundler_client.dart
+++ b/packages/permissionless/lib/src/clients/bundler/bundler_client.dart
@@ -70,7 +70,8 @@ class BundlerClient {
   ///
   /// Returns the UserOperation hash.
   ///
-  /// **Note**: Requires a bundler that supports EntryPoint v0.8 and EIP-7702.
+  /// **Note**: Requires a bundler that supports the selected EntryPoint version
+  /// and EIP-7702.
   Future<String> sendUserOperationWithAuthorization(
     UserOperation userOp,
     List<Eip7702Authorization> authorizationList,
@@ -118,7 +119,8 @@ class BundlerClient {
   /// Similar to [estimateUserOperationGas] but includes the authorization
   /// inside the UserOperation for accurate gas estimation of EIP-7702 accounts.
   ///
-  /// **Note**: Requires a bundler that supports EntryPoint v0.8 and EIP-7702.
+  /// **Note**: Requires a bundler that supports the selected EntryPoint version
+  /// and EIP-7702.
   Future<UserOperationGasEstimate> estimateUserOperationGasWithAuthorization(
     UserOperation userOp,
     List<Eip7702Authorization> authorizationList, {

--- a/packages/permissionless/lib/src/clients/bundler/bundler_client.dart
+++ b/packages/permissionless/lib/src/clients/bundler/bundler_client.dart
@@ -34,7 +34,7 @@ class BundlerClient {
   /// calling this constructor directly, as it handles RPC client setup.
   ///
   /// - [rpcClient]: The JSON-RPC client for bundler communication
-  /// - [entryPoint]: The EntryPoint contract address (v0.6 or v0.7)
+  /// - [entryPoint]: The EntryPoint contract address.
   BundlerClient({
     required this.rpcClient,
     required this.entryPoint,
@@ -70,7 +70,7 @@ class BundlerClient {
   ///
   /// Returns the UserOperation hash.
   ///
-  /// **Note**: Requires a bundler that supports EntryPoint v0.8 and EIP-7702.
+  /// **Note**: Requires a bundler that supports EIP-7702.
   Future<String> sendUserOperationWithAuthorization(
     UserOperation userOp,
     List<Eip7702Authorization> authorizationList,
@@ -118,7 +118,7 @@ class BundlerClient {
   /// Similar to [estimateUserOperationGas] but includes the authorization
   /// inside the UserOperation for accurate gas estimation of EIP-7702 accounts.
   ///
-  /// **Note**: Requires a bundler that supports EntryPoint v0.8 and EIP-7702.
+  /// **Note**: Requires a bundler that supports EIP-7702.
   Future<UserOperationGasEstimate> estimateUserOperationGasWithAuthorization(
     UserOperation userOp,
     List<Eip7702Authorization> authorizationList, {

--- a/packages/permissionless/lib/src/clients/bundler/bundler_client.dart
+++ b/packages/permissionless/lib/src/clients/bundler/bundler_client.dart
@@ -70,7 +70,8 @@ class BundlerClient {
   ///
   /// Returns the UserOperation hash.
   ///
-  /// **Note**: Requires a bundler that supports EntryPoint v0.8 and EIP-7702.
+  /// **Note**: Requires a bundler that supports the configured EntryPoint
+  /// version and EIP-7702.
   Future<String> sendUserOperationWithAuthorization(
     UserOperation userOp,
     List<Eip7702Authorization> authorizationList,
@@ -118,7 +119,8 @@ class BundlerClient {
   /// Similar to [estimateUserOperationGas] but includes the authorization
   /// inside the UserOperation for accurate gas estimation of EIP-7702 accounts.
   ///
-  /// **Note**: Requires a bundler that supports EntryPoint v0.8 and EIP-7702.
+  /// **Note**: Requires a bundler that supports the configured EntryPoint
+  /// version and EIP-7702.
   Future<UserOperationGasEstimate> estimateUserOperationGasWithAuthorization(
     UserOperation userOp,
     List<Eip7702Authorization> authorizationList, {

--- a/packages/permissionless/lib/src/clients/bundler/bundler_client.dart
+++ b/packages/permissionless/lib/src/clients/bundler/bundler_client.dart
@@ -35,10 +35,7 @@ class BundlerClient {
   ///
   /// - [rpcClient]: The JSON-RPC client for bundler communication
   /// - [entryPoint]: The EntryPoint contract address.
-  BundlerClient({
-    required this.rpcClient,
-    required this.entryPoint,
-  });
+  BundlerClient({required this.rpcClient, required this.entryPoint});
 
   /// The underlying JSON-RPC client.
   final JsonRpcClient rpcClient;
@@ -53,10 +50,10 @@ class BundlerClient {
   ///
   /// Throws [BundlerRpcError] if validation fails.
   Future<String> sendUserOperation(UserOperation userOp) async {
-    final result = await rpcClient.call(
-      'eth_sendUserOperation',
-      [userOp.toJson(), entryPoint.hex],
-    );
+    final result = await rpcClient.call('eth_sendUserOperation', [
+      userOp.toJson(),
+      entryPoint.hex,
+    ]);
     return result as String;
   }
 
@@ -84,10 +81,10 @@ class BundlerClient {
     // Handle EIP-7702 factory marker - bundler expects '0x7702' not the padded form
     _normalizeEip7702Factory(userOpJson);
 
-    final result = await rpcClient.call(
-      'eth_sendUserOperation',
-      [userOpJson, entryPoint.hex],
-    );
+    final result = await rpcClient.call('eth_sendUserOperation', [
+      userOpJson,
+      entryPoint.hex,
+    ]);
     return result as String;
   }
 
@@ -107,10 +104,7 @@ class BundlerClient {
       params.add(stateOverride);
     }
 
-    final result = await rpcClient.call(
-      'eth_estimateUserOperationGas',
-      params,
-    );
+    final result = await rpcClient.call('eth_estimateUserOperationGas', params);
     return UserOperationGasEstimate.fromJson(result as Map<String, dynamic>);
   }
 
@@ -139,10 +133,7 @@ class BundlerClient {
       params.add(stateOverride);
     }
 
-    final result = await rpcClient.call(
-      'eth_estimateUserOperationGas',
-      params,
-    );
+    final result = await rpcClient.call('eth_estimateUserOperationGas', params);
     return UserOperationGasEstimate.fromJson(result as Map<String, dynamic>);
   }
 
@@ -163,10 +154,9 @@ class BundlerClient {
   Future<UserOperationByHashResponse?> getUserOperationByHash(
     String userOpHash,
   ) async {
-    final result = await rpcClient.call(
-      'eth_getUserOperationByHash',
-      [userOpHash],
-    );
+    final result = await rpcClient.call('eth_getUserOperationByHash', [
+      userOpHash,
+    ]);
     if (result == null) return null;
     return UserOperationByHashResponse.fromJson(result as Map<String, dynamic>);
   }
@@ -178,10 +168,9 @@ class BundlerClient {
   Future<UserOperationReceipt?> getUserOperationReceipt(
     String userOpHash,
   ) async {
-    final result = await rpcClient.call(
-      'eth_getUserOperationReceipt',
-      [userOpHash],
-    );
+    final result = await rpcClient.call('eth_getUserOperationReceipt', [
+      userOpHash,
+    ]);
     if (result == null) return null;
     return UserOperationReceipt.fromJson(result as Map<String, dynamic>);
   }

--- a/packages/permissionless/lib/src/clients/bundler/rpc_client.dart
+++ b/packages/permissionless/lib/src/clients/bundler/rpc_client.dart
@@ -53,10 +53,7 @@ class JsonRpcClient {
     final response = await _httpClient
         .post(
           url,
-          headers: {
-            'Content-Type': 'application/json',
-            ...headers,
-          },
+          headers: {'Content-Type': 'application/json', ...headers},
           body: body,
         )
         .timeout(timeout);
@@ -106,10 +103,7 @@ class JsonRpcClient {
     final response = await _httpClient
         .post(
           url,
-          headers: {
-            'Content-Type': 'application/json',
-            ...headers,
-          },
+          headers: {'Content-Type': 'application/json', ...headers},
           body: jsonEncode(batchBody),
         )
         .timeout(timeout);
@@ -142,9 +136,7 @@ class JsonRpcClient {
     }
 
     // Return results in request order
-    return [
-      for (var i = startId; i <= _requestId; i++) results[i],
-    ];
+    return [for (var i = startId; i <= _requestId; i++) results[i]];
   }
 
   /// Closes the underlying HTTP client.

--- a/packages/permissionless/lib/src/clients/bundler/types.dart
+++ b/packages/permissionless/lib/src/clients/bundler/types.dart
@@ -188,7 +188,9 @@ class UserOperationLog {
   /// Creates a [UserOperationLog] from a JSON response.
   ///
   /// Parses log entries from UserOperation receipts.
-  factory UserOperationLog.fromJson(Map<String, dynamic> json) =>
+  factory UserOperationLog.fromJson(
+    Map<String, dynamic> json,
+  ) =>
       UserOperationLog(
         address: EthereumAddress.fromHex(json['address'] as String),
         topics:
@@ -299,11 +301,7 @@ class BundlerRpcError implements Exception {
   ///
   /// Use [aaErrorCode] to extract ERC-4337 specific error codes like
   /// "AA21" (insufficient funds) or "AA25" (invalid nonce).
-  const BundlerRpcError({
-    required this.code,
-    required this.message,
-    this.data,
-  });
+  const BundlerRpcError({required this.code, required this.message, this.data});
 
   /// JSON-RPC error code.
   final int code;

--- a/packages/permissionless/lib/src/clients/etherspot/etherspot_client.dart
+++ b/packages/permissionless/lib/src/clients/etherspot/etherspot_client.dart
@@ -31,10 +31,7 @@ class EtherspotClient extends BundlerClient {
   ///
   /// Prefer using [createEtherspotClient] factory function instead
   /// of calling this constructor directly.
-  EtherspotClient({
-    required super.rpcClient,
-    required super.entryPoint,
-  });
+  EtherspotClient({required super.rpcClient, required super.entryPoint});
 
   /// Gets recommended gas prices from Skandha's gas oracle.
   ///

--- a/packages/permissionless/lib/src/clients/paymaster/paymaster.dart
+++ b/packages/permissionless/lib/src/clients/paymaster/paymaster.dart
@@ -4,5 +4,6 @@
 /// to enable gasless transactions for users.
 library;
 
+export '../../utils/paymaster_signature.dart';
 export 'paymaster_client.dart';
 export 'types.dart';

--- a/packages/permissionless/lib/src/clients/paymaster/paymaster_client.dart
+++ b/packages/permissionless/lib/src/clients/paymaster/paymaster_client.dart
@@ -37,9 +37,7 @@ class PaymasterClient {
   ///
   /// Prefer using [createPaymasterClient] factory function instead
   /// of calling this constructor directly.
-  PaymasterClient({
-    required this.rpcClient,
-  });
+  PaymasterClient({required this.rpcClient});
 
   /// The underlying JSON-RPC client.
   final JsonRpcClient rpcClient;
@@ -178,8 +176,10 @@ extension PaymasterUserOperationV06Extension on UserOperationV06 {
   /// that concatenates the paymaster address (20 bytes) with the paymaster data.
   UserOperationV06 withPaymasterStubV06(PaymasterStubData stub) {
     // v0.6 format: paymasterAndData = paymaster (20 bytes) + paymasterData
-    final paymasterAndData =
-        Hex.concat([stub.paymaster.hex, stub.paymasterData]);
+    final paymasterAndData = Hex.concat([
+      stub.paymaster.hex,
+      stub.paymasterData,
+    ]);
     return copyWith(paymasterAndData: paymasterAndData);
   }
 
@@ -189,8 +189,10 @@ extension PaymasterUserOperationV06Extension on UserOperationV06 {
   /// that concatenates the paymaster address (20 bytes) with the paymaster data.
   UserOperationV06 withPaymasterDataV06(PaymasterData data) {
     // v0.6 format: paymasterAndData = paymaster (20 bytes) + paymasterData
-    final paymasterAndData =
-        Hex.concat([data.paymaster.hex, data.paymasterData]);
+    final paymasterAndData = Hex.concat([
+      data.paymaster.hex,
+      data.paymasterData,
+    ]);
     return copyWith(paymasterAndData: paymasterAndData);
   }
 
@@ -200,8 +202,10 @@ extension PaymasterUserOperationV06Extension on UserOperationV06 {
   /// a sponsorUserOperation call.
   UserOperationV06 withSponsorshipV06(SponsorUserOperationResult result) {
     // v0.6 format: paymasterAndData = paymaster (20 bytes) + paymasterData
-    final paymasterAndData =
-        Hex.concat([result.paymaster.hex, result.paymasterData]);
+    final paymasterAndData = Hex.concat([
+      result.paymaster.hex,
+      result.paymasterData,
+    ]);
     return copyWith(
       paymasterAndData: paymasterAndData,
       preVerificationGas: result.preVerificationGas ?? preVerificationGas,

--- a/packages/permissionless/lib/src/clients/paymaster/types.dart
+++ b/packages/permissionless/lib/src/clients/paymaster/types.dart
@@ -211,11 +211,7 @@ class PaymasterContext {
   /// - [sponsorshipPolicyId]: Optional policy ID for policy-based paymasters
   /// - [token]: Optional ERC-20 token address for paying gas with tokens
   /// - [extra]: Additional context data specific to the paymaster
-  const PaymasterContext({
-    this.sponsorshipPolicyId,
-    this.token,
-    this.extra,
-  });
+  const PaymasterContext({this.sponsorshipPolicyId, this.token, this.extra});
 
   /// Sponsorship policy identifier (for policy-based paymasters).
   final String? sponsorshipPolicyId;

--- a/packages/permissionless/lib/src/clients/pimlico/pimlico_client.dart
+++ b/packages/permissionless/lib/src/clients/pimlico/pimlico_client.dart
@@ -36,10 +36,7 @@ class PimlicoClient extends BundlerClient {
   ///
   /// Prefer using [createPimlicoClient] factory function instead of
   /// calling this constructor directly, as it handles RPC client setup.
-  PimlicoClient({
-    required super.rpcClient,
-    required super.entryPoint,
-  });
+  PimlicoClient({required super.rpcClient, required super.entryPoint});
 
   /// Gets detailed status of a UserOperation.
   ///
@@ -57,10 +54,9 @@ class PimlicoClient extends BundlerClient {
   Future<PimlicoUserOperationStatus> getUserOperationStatus(
     String userOpHash,
   ) async {
-    final result = await rpcClient.call(
-      'pimlico_getUserOperationStatus',
-      [userOpHash],
-    );
+    final result = await rpcClient.call('pimlico_getUserOperationStatus', [
+      userOpHash,
+    ]);
     return PimlicoUserOperationStatus.fromJson(result as Map<String, dynamic>);
   }
 
@@ -94,15 +90,12 @@ class PimlicoClient extends BundlerClient {
   ) async {
     final packedUserOp = _packUserOperationV07(userOp);
 
-    final result = await rpcClient.call(
-      'pimlico_sendCompressedUserOperation',
-      [
-        packedUserOp,
-        entryPoint.hex,
-        compressedCalldata,
-        inflator.hex,
-      ],
-    );
+    final result = await rpcClient.call('pimlico_sendCompressedUserOperation', [
+      packedUserOp,
+      entryPoint.hex,
+      compressedCalldata,
+      inflator.hex,
+    ]);
     return result as String;
   }
 
@@ -161,17 +154,14 @@ class PimlicoClient extends BundlerClient {
     List<EthereumAddress> tokens,
   ) async {
     final chain = await chainId();
-    final result = await rpcClient.call(
-      'pimlico_getTokenQuotes',
-      [
-        // First param: object with tokens array
-        {'tokens': tokens.map((t) => t.hex).toList()},
-        // Second param: entryPoint address
-        entryPoint.hex,
-        // Third param: chainId in hex
-        Hex.fromBigInt(chain),
-      ],
-    );
+    final result = await rpcClient.call('pimlico_getTokenQuotes', [
+      // First param: object with tokens array
+      {'tokens': tokens.map((t) => t.hex).toList()},
+      // Second param: entryPoint address
+      entryPoint.hex,
+      // Third param: chainId in hex
+      Hex.fromBigInt(chain),
+    ]);
 
     // API returns { quotes: [...] }
     final quotes = (result as Map<String, dynamic>)['quotes'] as List<dynamic>;
@@ -194,10 +184,7 @@ class PimlicoClient extends BundlerClient {
   /// }
   /// ```
   Future<List<PimlicoSupportedToken>> getSupportedTokens() async {
-    final result = await rpcClient.call(
-      'pimlico_getSupportedTokens',
-      [],
-    );
+    final result = await rpcClient.call('pimlico_getSupportedTokens', []);
 
     // API returns a list directly
     if (result is List) {
@@ -242,14 +229,11 @@ class PimlicoClient extends BundlerClient {
   }) async {
     final packedUserOp = _packUserOperationV07(userOperation);
 
-    final result = await rpcClient.call(
-      'pimlico_estimateErc20PaymasterCost',
-      [
-        packedUserOp,
-        entryPoint.hex,
-        token.hex,
-      ],
-    );
+    final result = await rpcClient.call('pimlico_estimateErc20PaymasterCost', [
+      packedUserOp,
+      entryPoint.hex,
+      token.hex,
+    ]);
 
     return PimlicoErc20PaymasterCost.fromJson(result as Map<String, dynamic>);
   }
@@ -293,14 +277,11 @@ class PimlicoClient extends BundlerClient {
 
     final packedUserOp = _packUserOperationV07(userOperation);
 
-    final result = await rpcClient.call(
-      'pimlico_validateSponsorshipPolicies',
-      [
-        packedUserOp,
-        entryPoint.hex,
-        sponsorshipPolicyIds,
-      ],
-    );
+    final result = await rpcClient.call('pimlico_validateSponsorshipPolicies', [
+      packedUserOp,
+      entryPoint.hex,
+      sponsorshipPolicyIds,
+    ]);
 
     return (result as List<dynamic>)
         .cast<Map<String, dynamic>>()
@@ -358,10 +339,12 @@ Map<String, dynamic> _packUserOperationV07(UserOperationV07 userOp) {
   // Paymaster data (v0.7 style)
   if (userOp.paymaster != null) {
     packed['paymaster'] = userOp.paymaster!.hex;
-    packed['paymasterVerificationGasLimit'] =
-        Hex.fromBigInt(userOp.paymasterVerificationGasLimit ?? BigInt.zero);
-    packed['paymasterPostOpGasLimit'] =
-        Hex.fromBigInt(userOp.paymasterPostOpGasLimit ?? BigInt.zero);
+    packed['paymasterVerificationGasLimit'] = Hex.fromBigInt(
+      userOp.paymasterVerificationGasLimit ?? BigInt.zero,
+    );
+    packed['paymasterPostOpGasLimit'] = Hex.fromBigInt(
+      userOp.paymasterPostOpGasLimit ?? BigInt.zero,
+    );
     packed['paymasterData'] = userOp.paymasterData ?? '0x';
   }
 

--- a/packages/permissionless/lib/src/clients/pimlico/types.dart
+++ b/packages/permissionless/lib/src/clients/pimlico/types.dart
@@ -116,8 +116,9 @@ class PimlicoGasPrices {
   factory PimlicoGasPrices.fromJson(Map<String, dynamic> json) =>
       PimlicoGasPrices(
         slow: PimlicoGasPrice.fromJson(json['slow'] as Map<String, dynamic>),
-        standard:
-            PimlicoGasPrice.fromJson(json['standard'] as Map<String, dynamic>),
+        standard: PimlicoGasPrice.fromJson(
+          json['standard'] as Map<String, dynamic>,
+        ),
         fast: PimlicoGasPrice.fromJson(json['fast'] as Map<String, dynamic>),
       );
 

--- a/packages/permissionless/lib/src/clients/public/public_client.dart
+++ b/packages/permissionless/lib/src/clients/public/public_client.dart
@@ -33,9 +33,7 @@ class PublicClient {
   ///
   /// Prefer using [createPublicClient] factory function instead of
   /// calling this constructor directly, as it handles RPC client setup.
-  PublicClient({
-    required this.rpcClient,
-  });
+  PublicClient({required this.rpcClient});
 
   /// The underlying JSON-RPC client.
   final JsonRpcClient rpcClient;
@@ -47,10 +45,7 @@ class PublicClient {
     EthereumAddress address, {
     String blockTag = 'latest',
   }) async {
-    final result = await rpcClient.call(
-      'eth_getCode',
-      [address.hex, blockTag],
-    );
+    final result = await rpcClient.call('eth_getCode', [address.hex, blockTag]);
     return result as String;
   }
 
@@ -67,31 +62,25 @@ class PublicClient {
     EthereumAddress address, {
     String blockTag = 'latest',
   }) async {
-    final result = await rpcClient.call(
-      'eth_getBalance',
-      [address.hex, blockTag],
-    );
+    final result = await rpcClient.call('eth_getBalance', [
+      address.hex,
+      blockTag,
+    ]);
     return parseBigInt(result);
   }
 
   /// Executes a read-only call to a contract.
   ///
   /// Returns the encoded result data.
-  Future<String> call(
-    Call call, {
-    String blockTag = 'latest',
-  }) async {
-    final result = await rpcClient.call(
-      'eth_call',
-      [
-        {
-          'to': call.to.hex,
-          'data': call.data,
-          if (call.value != BigInt.zero) 'value': Hex.fromBigInt(call.value),
-        },
-        blockTag,
-      ],
-    );
+  Future<String> call(Call call, {String blockTag = 'latest'}) async {
+    final result = await rpcClient.call('eth_call', [
+      {
+        'to': call.to.hex,
+        'data': call.data,
+        if (call.value != BigInt.zero) 'value': Hex.fromBigInt(call.value),
+      },
+      blockTag,
+    ]);
     return result as String;
   }
 
@@ -102,10 +91,10 @@ class PublicClient {
     EthereumAddress address, {
     String blockTag = 'latest',
   }) async {
-    final result = await rpcClient.call(
-      'eth_getTransactionCount',
-      [address.hex, blockTag],
-    );
+    final result = await rpcClient.call('eth_getTransactionCount', [
+      address.hex,
+      blockTag,
+    ]);
     return parseBigInt(result);
   }
 
@@ -143,10 +132,7 @@ class PublicClient {
       // Network might not support EIP-1559
     }
 
-    return FeeData(
-      gasPrice: gasPrice,
-      maxPriorityFeePerGas: maxPriorityFee,
-    );
+    return FeeData(gasPrice: gasPrice, maxPriorityFeePerGas: maxPriorityFee);
   }
 
   /// Gets the ERC-4337 nonce for a smart account from the EntryPoint.

--- a/packages/permissionless/lib/src/clients/public/types.dart
+++ b/packages/permissionless/lib/src/clients/public/types.dart
@@ -6,10 +6,7 @@ class FeeData {
   ///
   /// - [gasPrice]: Legacy gas price in wei
   /// - [maxPriorityFeePerGas]: EIP-1559 priority fee (null if not supported)
-  const FeeData({
-    required this.gasPrice,
-    this.maxPriorityFeePerGas,
-  });
+  const FeeData({required this.gasPrice, this.maxPriorityFeePerGas});
 
   /// Legacy gas price (wei per gas unit).
   final BigInt gasPrice;
@@ -25,11 +22,7 @@ class PublicRpcError implements Exception {
   /// - [code]: The JSON-RPC error code
   /// - [message]: Human-readable error description
   /// - [data]: Optional additional error data
-  const PublicRpcError({
-    required this.code,
-    required this.message,
-    this.data,
-  });
+  const PublicRpcError({required this.code, required this.message, this.data});
 
   /// JSON-RPC error code.
   final int code;

--- a/packages/permissionless/lib/src/clients/smart_account/smart_account_client.dart
+++ b/packages/permissionless/lib/src/clients/smart_account/smart_account_client.dart
@@ -20,10 +20,7 @@ class PreparedUserOperation {
   ///
   /// - [userOp]: The prepared but unsigned UserOperation
   /// - [authorization]: Optional EIP-7702 authorization for first-time delegation
-  const PreparedUserOperation({
-    required this.userOp,
-    this.authorization,
-  });
+  const PreparedUserOperation({required this.userOp, this.authorization});
 
   /// The prepared UserOperation (unsigned).
   final UserOperationV07 userOp;
@@ -127,8 +124,9 @@ class SmartAccountClient {
   ///
   /// Used to signal to the bundler that this UserOperation requires
   /// EIP-7702 authorization handling.
-  static final _eip7702FactoryMarker =
-      EthereumAddress.fromHex('0x7702000000000000000000000000000000000000');
+  static final _eip7702FactoryMarker = EthereumAddress.fromHex(
+    '0x7702000000000000000000000000000000000000',
+  );
 
   /// Prepares a UserOperation without signing.
   ///
@@ -316,10 +314,7 @@ class SmartAccountClient {
       userOp = userOp.withPaymasterData(finalData);
     }
 
-    return PreparedUserOperation(
-      userOp: userOp,
-      authorization: authorization,
-    );
+    return PreparedUserOperation(userOp: userOp, authorization: authorization);
   }
 
   /// Signs a prepared UserOperation.
@@ -360,8 +355,9 @@ class SmartAccountClient {
     Eip7702Authorization? authorization,
   ) {
     if (authorization != null) {
-      return bundler
-          .sendUserOperationWithAuthorization(userOp, [authorization]);
+      return bundler.sendUserOperationWithAuthorization(userOp, [
+        authorization,
+      ]);
     }
     return bundler.sendUserOperation(userOp);
   }
@@ -545,8 +541,9 @@ class SmartAccountClient {
         'Account must implement SmartAccountV06.',
       );
     }
-    final signature =
-        await (account as SmartAccountV06).signUserOperationV06(userOp);
+    final signature = await (account as SmartAccountV06).signUserOperationV06(
+      userOp,
+    );
     return userOp.copyWith(signature: signature);
   }
 

--- a/packages/permissionless/lib/src/clients/smart_account/smart_account_interface.dart
+++ b/packages/permissionless/lib/src/clients/smart_account/smart_account_interface.dart
@@ -139,7 +139,7 @@ abstract class SmartAccountV06 implements SmartAccount {
 /// - Account address equals the owner's EOA address
 /// - No factory deployment needed (`getFactoryData()` returns null)
 /// - Requires EIP-7702 authorization to be included in transactions
-/// - Uses EntryPoint v0.8
+/// - Uses EntryPoint v0.8 or newer EIP-7702-capable EntryPoints
 ///
 /// Example:
 /// ```dart

--- a/packages/permissionless/lib/src/clients/smart_account/smart_account_interface.dart
+++ b/packages/permissionless/lib/src/clients/smart_account/smart_account_interface.dart
@@ -139,7 +139,7 @@ abstract class SmartAccountV06 implements SmartAccount {
 /// - Account address equals the owner's EOA address
 /// - No factory deployment needed (`getFactoryData()` returns null)
 /// - Requires EIP-7702 authorization to be included in transactions
-/// - Uses EntryPoint v0.8
+/// - Uses an EIP-7702-capable EntryPoint version
 ///
 /// Example:
 /// ```dart

--- a/packages/permissionless/lib/src/clients/smart_account/smart_account_interface.dart
+++ b/packages/permissionless/lib/src/clients/smart_account/smart_account_interface.dart
@@ -139,7 +139,7 @@ abstract class SmartAccountV06 implements SmartAccount {
 /// - Account address equals the owner's EOA address
 /// - No factory deployment needed (`getFactoryData()` returns null)
 /// - Requires EIP-7702 authorization to be included in transactions
-/// - Uses EntryPoint v0.8
+/// - Uses EntryPoint v0.8 or v0.9
 ///
 /// Example:
 /// ```dart

--- a/packages/permissionless/lib/src/constants/entry_point.dart
+++ b/packages/permissionless/lib/src/constants/entry_point.dart
@@ -11,26 +11,30 @@ class EntryPointAddresses {
   /// EntryPoint v0.6 address.
   ///
   /// Deployed at the same address on all chains.
-  static final EthereumAddress v06 =
-      EthereumAddress.fromHex('0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789');
+  static final EthereumAddress v06 = EthereumAddress.fromHex(
+    '0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789',
+  );
 
   /// EntryPoint v0.7 address.
   ///
   /// Deployed at the same address on all chains.
-  static final EthereumAddress v07 =
-      EthereumAddress.fromHex('0x0000000071727De22E5E9d8BAf0edAc6f37da032');
+  static final EthereumAddress v07 = EthereumAddress.fromHex(
+    '0x0000000071727De22E5E9d8BAf0edAc6f37da032',
+  );
 
   /// EntryPoint v0.8 address.
   ///
   /// Deployed at the same address on all chains.
-  static final EthereumAddress v08 =
-      EthereumAddress.fromHex('0x4337084d9e255ff0702461cf8895ce9e3b5ff108');
+  static final EthereumAddress v08 = EthereumAddress.fromHex(
+    '0x4337084d9e255ff0702461cf8895ce9e3b5ff108',
+  );
 
   /// EntryPoint v0.9 address.
   ///
   /// Deployed at the same address on all chains.
-  static final EthereumAddress v09 =
-      EthereumAddress.fromHex('0x433709009B8330FDa32311DF1C2AFA402eD8D009');
+  static final EthereumAddress v09 = EthereumAddress.fromHex(
+    '0x433709009B8330FDa32311DF1C2AFA402eD8D009',
+  );
 
   /// Gets the EntryPoint address for a given version.
   static EthereumAddress fromVersion(EntryPointVersion version) =>

--- a/packages/permissionless/lib/src/constants/entry_point.dart
+++ b/packages/permissionless/lib/src/constants/entry_point.dart
@@ -17,7 +17,6 @@ class EntryPointAddresses {
   /// EntryPoint v0.7 address.
   ///
   /// Deployed at the same address on all chains.
-  /// This is the recommended version for new deployments.
   static final EthereumAddress v07 =
       EthereumAddress.fromHex('0x0000000071727De22E5E9d8BAf0edAc6f37da032');
 
@@ -27,11 +26,18 @@ class EntryPointAddresses {
   static final EthereumAddress v08 =
       EthereumAddress.fromHex('0x4337084d9e255ff0702461cf8895ce9e3b5ff108');
 
+  /// EntryPoint v0.9 address.
+  ///
+  /// Deployed at the same address on all chains.
+  static final EthereumAddress v09 =
+      EthereumAddress.fromHex('0x433709009B8330FDa32311DF1C2AFA402eD8D009');
+
   /// Gets the EntryPoint address for a given version.
   static EthereumAddress fromVersion(EntryPointVersion version) =>
       switch (version) {
         EntryPointVersion.v06 => v06,
         EntryPointVersion.v07 => v07,
         EntryPointVersion.v08 => v08,
+        EntryPointVersion.v09 => v09,
       };
 }

--- a/packages/permissionless/lib/src/constants/entry_point.dart
+++ b/packages/permissionless/lib/src/constants/entry_point.dart
@@ -27,11 +27,18 @@ class EntryPointAddresses {
   static final EthereumAddress v08 =
       EthereumAddress.fromHex('0x4337084d9e255ff0702461cf8895ce9e3b5ff108');
 
+  /// EntryPoint v0.9 address.
+  ///
+  /// Deployed at the same address on all chains.
+  static final EthereumAddress v09 =
+      EthereumAddress.fromHex('0x433709009B8330FDa32311DF1C2AFA402eD8D009');
+
   /// Gets the EntryPoint address for a given version.
   static EthereumAddress fromVersion(EntryPointVersion version) =>
       switch (version) {
         EntryPointVersion.v06 => v06,
         EntryPointVersion.v07 => v07,
         EntryPointVersion.v08 => v08,
+        EntryPointVersion.v09 => v09,
       };
 }

--- a/packages/permissionless/lib/src/experimental/pimlico/erc20_paymaster.dart
+++ b/packages/permissionless/lib/src/experimental/pimlico/erc20_paymaster.dart
@@ -16,8 +16,9 @@ import '../../types/user_operation.dart';
 import '../../utils/erc20.dart';
 
 /// Mainnet USDT address - requires special handling (reset to 0 before approve).
-final EthereumAddress _mainnetUsdtAddress =
-    EthereumAddress.fromHex('0xdAC17F958D2ee523a2206206994597C13D831ec7');
+final EthereumAddress _mainnetUsdtAddress = EthereumAddress.fromHex(
+  '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+);
 
 /// Configuration for ERC-20 paymaster preparation.
 class Erc20PaymasterConfig {
@@ -25,10 +26,7 @@ class Erc20PaymasterConfig {
   ///
   /// - [balanceOverride]: Whether to simulate a large token balance
   /// - [balanceSlot]: Custom storage slot for the balance mapping
-  const Erc20PaymasterConfig({
-    this.balanceOverride = false,
-    this.balanceSlot,
-  });
+  const Erc20PaymasterConfig({this.balanceOverride = false, this.balanceSlot});
 
   /// Whether to use balance state override for gas estimation.
   ///

--- a/packages/permissionless/lib/src/types/address.dart
+++ b/packages/permissionless/lib/src/types/address.dart
@@ -6,8 +6,9 @@ import 'hex.dart';
 export 'package:wallet/wallet.dart' show EthereumAddress;
 
 /// Zero address constant.
-final EthereumAddress zeroAddress =
-    EthereumAddress.fromHex('0x0000000000000000000000000000000000000000');
+final EthereumAddress zeroAddress = EthereumAddress.fromHex(
+  '0x0000000000000000000000000000000000000000',
+);
 
 /// Extension to add utility methods to EthereumAddress.
 extension EthereumAddressExtension on EthereumAddress {

--- a/packages/permissionless/lib/src/types/eip7702.dart
+++ b/packages/permissionless/lib/src/types/eip7702.dart
@@ -105,10 +105,7 @@ class Eip7702Authorization {
     // Sign the authorization hash directly using the raw sign function.
     // Note: signToEcSignature adds an extra keccak256 hash, which we don't want
     // since authHash is already a keccak256 hash.
-    final signature = crypto.sign(
-      Uint8List.fromList(authHash),
-      key.privateKey,
-    );
+    final signature = crypto.sign(Uint8List.fromList(authHash), key.privateKey);
 
     return Eip7702Authorization(
       chainId: chainId,

--- a/packages/permissionless/lib/src/types/typed_data.dart
+++ b/packages/permissionless/lib/src/types/typed_data.dart
@@ -63,10 +63,7 @@ class TypedDataField {
   /// - [name]: The field name as it appears in the struct
   /// - [type]: The Solidity type (e.g., 'address', 'uint256', 'bytes32',
   ///   or a custom type name defined in the types map)
-  const TypedDataField({
-    required this.name,
-    required this.type,
-  });
+  const TypedDataField({required this.name, required this.type});
 
   /// The name of the field.
   final String name;

--- a/packages/permissionless/lib/src/types/user_operation.dart
+++ b/packages/permissionless/lib/src/types/user_operation.dart
@@ -11,6 +11,9 @@ import 'hex.dart';
 /// - **v0.6**: Original specification, widely deployed
 /// - **v0.7**: Updated spec with separate factory/paymaster fields,
 ///   better gas handling, and uint128 gas limits
+/// - **v0.8**: Adds native EIP-7702 support
+/// - **v0.9**: Latest EntryPoint deployment; opt-in and supported only by
+///   account families with verified v0.9 deployments
 enum EntryPointVersion {
   /// EntryPoint v0.6 - Original ERC-4337 specification.
   ///
@@ -22,18 +25,24 @@ enum EntryPointVersion {
   /// Address: `0x0000000071727De22E5E9d8BAf0edAc6f37da032`
   v07('0.7'),
 
-  /// EntryPoint v0.8 - Latest specification with EIP-7702 support.
+  /// EntryPoint v0.8 - Specification with EIP-7702 support.
   ///
   /// Address: `0x4337084d9e255ff0702461cf8895ce9e3b5ff108`
   /// This version adds native EIP-7702 support including:
   /// - UserOperation hash includes EIP-7702 delegation address
   /// - EntryPoint checks delegation address is set correctly
   /// - Support for `eip7702Auth` parameter in eth_sendUserOperation
-  v08('0.8');
+  v08('0.8'),
+
+  /// EntryPoint v0.9 - Latest EntryPoint deployment.
+  ///
+  /// Address: `0x433709009B8330FDa32311DF1C2AFA402eD8D009`
+  /// This version keeps the v0.7-style unpacked UserOperation RPC shape.
+  v09('0.9');
 
   const EntryPointVersion(this.value);
 
-  /// The version string (e.g., "0.6", "0.7", or "0.8").
+  /// The version string (e.g., "0.6", "0.7", "0.8", or "0.9").
   final String value;
 }
 
@@ -51,9 +60,10 @@ enum EntryPointVersion {
 /// - **signature**: Proof that the account owner(s) authorized this operation
 ///
 /// ## Usage
-/// This sealed class allows type-safe handling of both v0.6 and v0.7
-/// UserOperations. Use [UserOperationV06] for EntryPoint v0.6 or
-/// [UserOperationV07] for EntryPoint v0.7.
+/// This sealed class allows type-safe handling of v0.6 and the unpacked
+/// v0.7-style UserOperation shape used by EntryPoint v0.7, v0.8, and v0.9.
+/// Use [UserOperationV06] for EntryPoint v0.6 or [UserOperationV07] for the
+/// unpacked shape.
 sealed class UserOperation {
   /// The smart account address that will execute this operation.
   ///

--- a/packages/permissionless/lib/src/types/user_operation.dart
+++ b/packages/permissionless/lib/src/types/user_operation.dart
@@ -11,6 +11,9 @@ import 'hex.dart';
 /// - **v0.6**: Original specification, widely deployed
 /// - **v0.7**: Updated spec with separate factory/paymaster fields,
 ///   better gas handling, and uint128 gas limits
+/// - **v0.8**: Adds native EIP-7702 support
+/// - **v0.9**: Current EntryPoint release, reusing the v0.7-style
+///   unpacked UserOperation RPC model
 enum EntryPointVersion {
   /// EntryPoint v0.6 - Original ERC-4337 specification.
   ///
@@ -22,18 +25,25 @@ enum EntryPointVersion {
   /// Address: `0x0000000071727De22E5E9d8BAf0edAc6f37da032`
   v07('0.7'),
 
-  /// EntryPoint v0.8 - Latest specification with EIP-7702 support.
+  /// EntryPoint v0.8 - Specification with EIP-7702 support.
   ///
   /// Address: `0x4337084d9e255ff0702461cf8895ce9e3b5ff108`
   /// This version adds native EIP-7702 support including:
   /// - UserOperation hash includes EIP-7702 delegation address
   /// - EntryPoint checks delegation address is set correctly
   /// - Support for `eip7702Auth` parameter in eth_sendUserOperation
-  v08('0.8');
+  v08('0.8'),
+
+  /// EntryPoint v0.9 - Current specification release.
+  ///
+  /// Address: `0x433709009B8330FDa32311DF1C2AFA402eD8D009`
+  /// This version keeps the v0.7-style unpacked UserOperation RPC shape
+  /// while adding v0.9-specific EntryPoint and account deployments.
+  v09('0.9');
 
   const EntryPointVersion(this.value);
 
-  /// The version string (e.g., "0.6", "0.7", or "0.8").
+  /// The version string (e.g., "0.6", "0.7", "0.8", or "0.9").
   final String value;
 }
 

--- a/packages/permissionless/lib/src/types/user_operation.dart
+++ b/packages/permissionless/lib/src/types/user_operation.dart
@@ -11,6 +11,8 @@ import 'hex.dart';
 /// - **v0.6**: Original specification, widely deployed
 /// - **v0.7**: Updated spec with separate factory/paymaster fields,
 ///   better gas handling, and uint128 gas limits
+/// - **v0.8**: Adds native EIP-7702 support
+/// - **v0.9**: Latest EntryPoint release, opt-in in this package
 enum EntryPointVersion {
   /// EntryPoint v0.6 - Original ERC-4337 specification.
   ///
@@ -22,18 +24,25 @@ enum EntryPointVersion {
   /// Address: `0x0000000071727De22E5E9d8BAf0edAc6f37da032`
   v07('0.7'),
 
-  /// EntryPoint v0.8 - Latest specification with EIP-7702 support.
+  /// EntryPoint v0.8 - Specification with EIP-7702 support.
   ///
   /// Address: `0x4337084d9e255ff0702461cf8895ce9e3b5ff108`
   /// This version adds native EIP-7702 support including:
   /// - UserOperation hash includes EIP-7702 delegation address
   /// - EntryPoint checks delegation address is set correctly
   /// - Support for `eip7702Auth` parameter in eth_sendUserOperation
-  v08('0.8');
+  v08('0.8'),
+
+  /// EntryPoint v0.9 - Latest EntryPoint release.
+  ///
+  /// Address: `0x433709009B8330FDa32311DF1C2AFA402eD8D009`
+  /// This package supports v0.9 as an explicit opt-in. The first built-in
+  /// account target with official v0.9 support is Simple7702Account.
+  v09('0.9');
 
   const EntryPointVersion(this.value);
 
-  /// The version string (e.g., "0.6", "0.7", or "0.8").
+  /// The version string (e.g., "0.6", "0.7", "0.8", or "0.9").
   final String value;
 }
 

--- a/packages/permissionless/lib/src/types/user_operation.dart
+++ b/packages/permissionless/lib/src/types/user_operation.dart
@@ -11,6 +11,9 @@ import 'hex.dart';
 /// - **v0.6**: Original specification, widely deployed
 /// - **v0.7**: Updated spec with separate factory/paymaster fields,
 ///   better gas handling, and uint128 gas limits
+/// - **v0.8**: Adds native EIP-7702 support
+/// - **v0.9**: Uses the v0.7-style UserOperation RPC shape with updated
+///   EntryPoint deployment and paymaster signature support
 enum EntryPointVersion {
   /// EntryPoint v0.6 - Original ERC-4337 specification.
   ///
@@ -22,18 +25,24 @@ enum EntryPointVersion {
   /// Address: `0x0000000071727De22E5E9d8BAf0edAc6f37da032`
   v07('0.7'),
 
-  /// EntryPoint v0.8 - Latest specification with EIP-7702 support.
+  /// EntryPoint v0.8 - Specification with EIP-7702 support.
   ///
   /// Address: `0x4337084d9e255ff0702461cf8895ce9e3b5ff108`
   /// This version adds native EIP-7702 support including:
   /// - UserOperation hash includes EIP-7702 delegation address
   /// - EntryPoint checks delegation address is set correctly
   /// - Support for `eip7702Auth` parameter in eth_sendUserOperation
-  v08('0.8');
+  v08('0.8'),
+
+  /// EntryPoint v0.9 - ERC-4337 v0.9 singleton deployment.
+  ///
+  /// Address: `0x433709009B8330FDa32311DF1C2AFA402eD8D009`
+  /// This version keeps the v0.7-style unpacked UserOperation RPC shape.
+  v09('0.9');
 
   const EntryPointVersion(this.value);
 
-  /// The version string (e.g., "0.6", "0.7", or "0.8").
+  /// The version string (e.g., "0.6", "0.7", "0.8", or "0.9").
   final String value;
 }
 
@@ -51,9 +60,9 @@ enum EntryPointVersion {
 /// - **signature**: Proof that the account owner(s) authorized this operation
 ///
 /// ## Usage
-/// This sealed class allows type-safe handling of both v0.6 and v0.7
+/// This sealed class allows type-safe handling of both v0.6 and v0.7+
 /// UserOperations. Use [UserOperationV06] for EntryPoint v0.6 or
-/// [UserOperationV07] for EntryPoint v0.7.
+/// [UserOperationV07] for EntryPoint v0.7, v0.8, and v0.9.
 sealed class UserOperation {
   /// The smart account address that will execute this operation.
   ///
@@ -217,11 +226,11 @@ class UserOperationV06 implements UserOperation {
       };
 }
 
-/// ERC-4337 User Operation for EntryPoint v0.7.
+/// ERC-4337 User Operation for EntryPoint v0.7+.
 ///
 /// This is the updated UserOperation format with improved gas handling
 /// and cleaner field separation. Use this when interacting with
-/// EntryPoint v0.7.
+/// EntryPoint v0.7, v0.8, or v0.9.
 ///
 /// ## Key Differences from v0.6
 /// - [factory] and [factoryData] replace `initCode` (cleaner separation)

--- a/packages/permissionless/lib/src/types/user_operation.dart
+++ b/packages/permissionless/lib/src/types/user_operation.dart
@@ -135,7 +135,9 @@ class UserOperationV06 implements UserOperation {
   });
 
   /// Creates from JSON-RPC response.
-  factory UserOperationV06.fromJson(Map<String, dynamic> json) =>
+  factory UserOperationV06.fromJson(
+    Map<String, dynamic> json,
+  ) =>
       UserOperationV06(
         sender: EthereumAddress.fromHex(json['sender'] as String),
         nonce: Hex.toBigInt(json['nonce'] as String),
@@ -275,7 +277,9 @@ class UserOperationV07 implements UserOperation {
   });
 
   /// Creates from JSON-RPC response.
-  factory UserOperationV07.fromJson(Map<String, dynamic> json) =>
+  factory UserOperationV07.fromJson(
+    Map<String, dynamic> json,
+  ) =>
       UserOperationV07(
         sender: EthereumAddress.fromHex(json['sender'] as String),
         nonce: Hex.toBigInt(json['nonce'] as String),
@@ -410,12 +414,14 @@ class UserOperationV07 implements UserOperation {
       result['paymaster'] = paymaster!.hex;
     }
     if (paymasterVerificationGasLimit != null) {
-      result['paymasterVerificationGasLimit'] =
-          Hex.fromBigInt(paymasterVerificationGasLimit!);
+      result['paymasterVerificationGasLimit'] = Hex.fromBigInt(
+        paymasterVerificationGasLimit!,
+      );
     }
     if (paymasterPostOpGasLimit != null) {
-      result['paymasterPostOpGasLimit'] =
-          Hex.fromBigInt(paymasterPostOpGasLimit!);
+      result['paymasterPostOpGasLimit'] = Hex.fromBigInt(
+        paymasterPostOpGasLimit!,
+      );
     }
     if (paymasterData != null) {
       result['paymasterData'] = paymasterData;
@@ -457,11 +463,8 @@ class Call {
   /// - [to]: The target address to call
   /// - [value]: Amount of ETH to send in wei (defaults to 0)
   /// - [data]: Encoded calldata (defaults to '0x' for simple transfers)
-  Call({
-    required this.to,
-    BigInt? value,
-    this.data = '0x',
-  }) : value = value ?? BigInt.zero;
+  Call({required this.to, BigInt? value, this.data = '0x'})
+      : value = value ?? BigInt.zero;
 
   /// Creates a call from a JSON map.
   factory Call.fromJson(Map<String, dynamic> json) => Call(

--- a/packages/permissionless/lib/src/utils/encoding.dart
+++ b/packages/permissionless/lib/src/utils/encoding.dart
@@ -111,12 +111,14 @@ class SafeSelectors {
   );
 
   /// Selector for Safe module setup `enableModules` function.
-  static final String enableModules =
-      AbiEncoder.functionSelector('enableModules(address[])');
+  static final String enableModules = AbiEncoder.functionSelector(
+    'enableModules(address[])',
+  );
 
   /// Selector for MultiSend `multiSend` function.
-  static final String multiSend =
-      AbiEncoder.functionSelector('multiSend(bytes)');
+  static final String multiSend = AbiEncoder.functionSelector(
+    'multiSend(bytes)',
+  );
 }
 
 /// Encodes a Safe `setup` function call.

--- a/packages/permissionless/lib/src/utils/erc20.dart
+++ b/packages/permissionless/lib/src/utils/erc20.dart
@@ -72,10 +72,7 @@ Call encodeErc20Approve({
     AbiEncoder.encodeUint256(amount),
   ]);
 
-  return Call(
-    to: token,
-    data: callData,
-  );
+  return Call(to: token, data: callData);
 }
 
 /// Encodes an ERC-20 transfer(to, amount) call.
@@ -102,10 +99,7 @@ Call encodeErc20Transfer({
     AbiEncoder.encodeUint256(amount),
   ]);
 
-  return Call(
-    to: token,
-    data: callData,
-  );
+  return Call(to: token, data: callData);
 }
 
 /// Encodes an ERC-20 allowance(owner, spender) call for eth_call.
@@ -151,13 +145,8 @@ String encodeErc20AllowanceCall({
 /// ));
 /// final balance = decodeUint256Result(result);
 /// ```
-String encodeErc20BalanceOfCall({
-  required EthereumAddress account,
-}) =>
-    Hex.concat([
-      Erc20Selectors.balanceOf,
-      AbiEncoder.encodeAddress(account),
-    ]);
+String encodeErc20BalanceOfCall({required EthereumAddress account}) =>
+    Hex.concat([Erc20Selectors.balanceOf, AbiEncoder.encodeAddress(account)]);
 
 /// Decodes a uint256 result from an eth_call response.
 ///
@@ -195,10 +184,7 @@ class StateDiff {
   ///
   /// - [slot]: The storage slot to override (32-byte hex string)
   /// - [value]: The value to set at this slot (32-byte hex string)
-  const StateDiff({
-    required this.slot,
-    required this.value,
-  });
+  const StateDiff({required this.slot, required this.value});
 
   /// The storage slot (32-byte hex string).
   final String slot;
@@ -361,10 +347,7 @@ List<StateOverride> erc20AllowanceOverride({
 
   // Then: keccak256(abi.encode(spender, innerHash))
   final spenderInnerData = Hex.decode(
-    Hex.concat([
-      AbiEncoder.encodeAddress(spender),
-      Hex.fromBytes(innerHash),
-    ]),
+    Hex.concat([AbiEncoder.encodeAddress(spender), Hex.fromBytes(innerHash)]),
   );
   final storageSlot = keccak256(spenderInnerData);
 

--- a/packages/permissionless/lib/src/utils/erc7579.dart
+++ b/packages/permissionless/lib/src/utils/erc7579.dart
@@ -724,10 +724,7 @@ class Decoded7579Calls {
   ///
   /// - [mode]: The execution mode (call type, revert behavior, etc.)
   /// - [calls]: The decoded list of calls to execute
-  const Decoded7579Calls({
-    required this.mode,
-    required this.calls,
-  });
+  const Decoded7579Calls({required this.mode, required this.calls});
 
   /// The execution mode used.
   final ExecutionMode mode;
@@ -888,32 +885,42 @@ List<Call> _decodeBatchCalls(String executionHex) {
 
     // Each Execution struct: (address, uint256, bytes)
     // Address (32 bytes padded)
-    final addressHex =
-        executionHex.substring(structStart + 24, structStart + 64);
+    final addressHex = executionHex.substring(
+      structStart + 24,
+      structStart + 64,
+    );
     final to = EthereumAddress.fromHex('0x$addressHex');
 
     // Value (32 bytes)
-    final valueHex =
-        executionHex.substring(structStart + 64, structStart + 128);
+    final valueHex = executionHex.substring(
+      structStart + 64,
+      structStart + 128,
+    );
     final value = BigInt.parse(valueHex, radix: 16);
 
     // Bytes offset (32 bytes) - points to bytes data relative to struct start
-    final bytesOffsetHex =
-        executionHex.substring(structStart + 128, structStart + 192);
+    final bytesOffsetHex = executionHex.substring(
+      structStart + 128,
+      structStart + 192,
+    );
     final bytesOffset = int.parse(bytesOffsetHex, radix: 16);
 
     // Bytes length
     final bytesLengthStart = structStart + (bytesOffset * 2);
-    final bytesLengthHex =
-        executionHex.substring(bytesLengthStart, bytesLengthStart + 64);
+    final bytesLengthHex = executionHex.substring(
+      bytesLengthStart,
+      bytesLengthStart + 64,
+    );
     final bytesLength = int.parse(bytesLengthHex, radix: 16);
 
     // Bytes data
     var data = '0x';
     if (bytesLength > 0) {
       final dataStart = bytesLengthStart + 64;
-      final dataHex =
-          executionHex.substring(dataStart, dataStart + bytesLength * 2);
+      final dataHex = executionHex.substring(
+        dataStart,
+        dataStart + bytesLength * 2,
+      );
       data = '0x$dataHex';
     }
 

--- a/packages/permissionless/lib/src/utils/gas.dart
+++ b/packages/permissionless/lib/src/utils/gas.dart
@@ -119,10 +119,7 @@ extension GasEstimateMultipliers on UserOperationGasEstimate {
           verificationGasLimit,
           multipliers.verificationGasLimit,
         ),
-        callGasLimit: _applyMultiplier(
-          callGasLimit,
-          multipliers.callGasLimit,
-        ),
+        callGasLimit: _applyMultiplier(callGasLimit, multipliers.callGasLimit),
         paymasterVerificationGasLimit: paymasterVerificationGasLimit != null
             ? _applyMultiplier(
                 paymasterVerificationGasLimit!,
@@ -162,9 +159,7 @@ extension GasEstimateMultipliers on UserOperationGasEstimate {
   /// final estimate = await bundler.estimateUserOperationGas(userOp);
   /// final adjusted = estimate.withMinimumVerificationGas();
   /// ```
-  UserOperationGasEstimate withMinimumVerificationGas({
-    BigInt? minimum,
-  }) {
+  UserOperationGasEstimate withMinimumVerificationGas({BigInt? minimum}) {
     // Default: 900k gas for P256 on-chain verification with buffer
     final minGas = minimum ?? BigInt.from(900000);
 

--- a/packages/permissionless/lib/src/utils/message_hash.dart
+++ b/packages/permissionless/lib/src/utils/message_hash.dart
@@ -80,8 +80,9 @@ String computeDomainSeparator(TypedDataDomain domain) {
   if (domain.salt != null) fields.add('bytes32 salt');
 
   final domainTypeString = 'EIP712Domain(${fields.join(',')})';
-  final domainTypeHash =
-      keccak256(Uint8List.fromList(domainTypeString.codeUnits));
+  final domainTypeHash = keccak256(
+    Uint8List.fromList(domainTypeString.codeUnits),
+  );
 
   // Encode domain values in order
   final encodedParts = <String>[Hex.fromBytes(domainTypeHash)];

--- a/packages/permissionless/lib/src/utils/multisend.dart
+++ b/packages/permissionless/lib/src/utils/multisend.dart
@@ -134,8 +134,10 @@ List<Call> decodeMultiSend(String multiSendData) {
   final dataLength = _bytes32ToBigInt(Uint8List.fromList(lengthBytes)).toInt();
 
   // Read packed transactions
-  final transactionsData =
-      fullData.sublist(dataStart + 32, dataStart + 32 + dataLength);
+  final transactionsData = fullData.sublist(
+    dataStart + 32,
+    dataStart + 32 + dataLength,
+  );
 
   return _unpackTransactions(Uint8List.fromList(transactionsData));
 }
@@ -150,8 +152,9 @@ List<Call> _unpackTransactions(Uint8List data) {
 
     // To address (20 bytes)
     final toBytes = data.sublist(offset, offset + 20);
-    final to =
-        EthereumAddress.fromHex(Hex.fromBytes(Uint8List.fromList(toBytes)));
+    final to = EthereumAddress.fromHex(
+      Hex.fromBytes(Uint8List.fromList(toBytes)),
+    );
     offset += 20;
 
     // Value (32 bytes)
@@ -161,8 +164,9 @@ List<Call> _unpackTransactions(Uint8List data) {
 
     // Data length (32 bytes)
     final lengthBytes = data.sublist(offset, offset + 32);
-    final dataLength =
-        _bytes32ToBigInt(Uint8List.fromList(lengthBytes)).toInt();
+    final dataLength = _bytes32ToBigInt(
+      Uint8List.fromList(lengthBytes),
+    ).toInt();
     offset += 32;
 
     // Data

--- a/packages/permissionless/lib/src/utils/packed_user_operation.dart
+++ b/packages/permissionless/lib/src/utils/packed_user_operation.dart
@@ -197,10 +197,7 @@ class UnpackedInitCode {
   /// Creates an unpacked initCode result.
   ///
   /// Both fields are null if the account is already deployed.
-  const UnpackedInitCode({
-    this.factory,
-    this.factoryData,
-  });
+  const UnpackedInitCode({this.factory, this.factoryData});
 
   /// The factory address, or null if no factory.
   final EthereumAddress? factory;
@@ -359,8 +356,10 @@ UnpackedPaymasterAndData unpackPaymasterAndData(String paymasterAndData) {
 
   return UnpackedPaymasterAndData(
     paymaster: EthereumAddress.fromHex('0x${hex.substring(0, 40)}'),
-    paymasterVerificationGasLimit:
-        BigInt.parse(hex.substring(40, 72), radix: 16),
+    paymasterVerificationGasLimit: BigInt.parse(
+      hex.substring(40, 72),
+      radix: 16,
+    ),
     paymasterPostOpGasLimit: BigInt.parse(hex.substring(72, 104), radix: 16),
     paymasterData: hex.length > 104 ? '0x${hex.substring(104)}' : '0x',
   );

--- a/packages/permissionless/lib/src/utils/paymaster_signature.dart
+++ b/packages/permissionless/lib/src/utils/paymaster_signature.dart
@@ -1,0 +1,50 @@
+import '../types/hex.dart';
+
+/// ERC-4337 v0.9 paymaster signature magic suffix.
+const String paymasterSignatureMagic = '0x22e325a297439656';
+
+/// Appends an ERC-4337 v0.9 paymaster signature suffix to paymaster data.
+///
+/// The returned value is encoded as:
+///
+/// `paymasterData || paymasterSignature || uint16(signatureSize) || magic`
+String appendPaymasterSignature({
+  required String paymasterData,
+  required String paymasterSignature,
+}) {
+  _validateHexData(paymasterData, name: 'paymasterData');
+  _validateHexData(paymasterSignature, name: 'paymasterSignature');
+
+  final signatureSize = Hex.byteLength(paymasterSignature);
+  if (signatureSize == 0) {
+    throw ArgumentError.value(
+      paymasterSignature,
+      'paymasterSignature',
+      'must not be empty',
+    );
+  }
+  if (signatureSize > 0xffff) {
+    throw ArgumentError.value(
+      paymasterSignature,
+      'paymasterSignature',
+      'must fit in uint16 length encoding',
+    );
+  }
+
+  return Hex.concat([
+    paymasterData,
+    paymasterSignature,
+    Hex.fromBigInt(BigInt.from(signatureSize), byteLength: 2),
+    paymasterSignatureMagic,
+  ]);
+}
+
+void _validateHexData(String value, {required String name}) {
+  final clean = Hex.strip0x(value);
+  if (!Hex.isValid(value)) {
+    throw ArgumentError.value(value, name, 'must be valid hex data');
+  }
+  if (clean.length.isOdd) {
+    throw ArgumentError.value(value, name, 'must contain whole bytes');
+  }
+}

--- a/packages/permissionless/lib/src/utils/rip7212.dart
+++ b/packages/permissionless/lib/src/utils/rip7212.dart
@@ -40,152 +40,110 @@ const Set<int> rip7212SupportedChainIds = {
   1, // Ethereum Mainnet (EIP-7951 via Fusaka upgrade, Dec 3 2025)
   11155111, // Sepolia
   17000, // Holesky
-
   // ── Optimism (OP Stack - Fjord release) ───────────────────────────────────
   10, // OP Mainnet
   11155420, // OP Sepolia
-
   // ── Base (OP Stack) ───────────────────────────────────────────────────────
   8453, // Base Mainnet
   84532, // Base Sepolia
-
   // ── Unichain (OP Stack) ───────────────────────────────────────────────────
   130, // Unichain Mainnet
   1301, // Unichain Sepolia
-
   // ── Mode (OP Stack) ───────────────────────────────────────────────────────
   34443, // Mode Mainnet
   919, // Mode Sepolia
-
   // ── Zora (OP Stack) ───────────────────────────────────────────────────────
   7777777, // Zora Mainnet
   999999999, // Zora Sepolia
-
   // ── World Chain (OP Stack) ────────────────────────────────────────────────
   480, // World Chain Mainnet
-
   // ── Cyber (OP Stack) ──────────────────────────────────────────────────────
   7560, // Cyber Mainnet
-
   // ── Fraxtal (OP Stack) ────────────────────────────────────────────────────
   252, // Fraxtal Mainnet
-
   // ── Ink (OP Stack) ────────────────────────────────────────────────────────
   57073, // Ink Mainnet
   763373, // Ink Sepolia
-
   // ── Shape (OP Stack) ──────────────────────────────────────────────────────
   360, // Shape Mainnet
-
   // ── Polynomial (OP Stack) ─────────────────────────────────────────────────
   8008, // Polynomial Mainnet
-
   // ── Mint (OP Stack) ───────────────────────────────────────────────────────
   185, // Mint Mainnet
-
   // ── Katana (OP Stack) ─────────────────────────────────────────────────────
   747474, // Katana Mainnet
-
   // ── Degen (OP Stack) ──────────────────────────────────────────────────────
   666666666, // Degen Mainnet
-
   // ── BOB (OP Stack) ────────────────────────────────────────────────────────
   60808, // BOB Mainnet
-
   // ── Onyx (OP Stack) ───────────────────────────────────────────────────────
   80888, // Onyx Mainnet
-
   // ── BNB Smart Chain ───────────────────────────────────────────────────────
   56, // BNB Smart Chain Mainnet
   204, // opBNB Mainnet
   97, // BNB Smart Chain Testnet
-
   // ── Polygon ───────────────────────────────────────────────────────────────
   137, // Polygon Mainnet
   80002, // Polygon Amoy
-
   // ── Arbitrum ──────────────────────────────────────────────────────────────
   42161, // Arbitrum One
   42170, // Arbitrum Nova
   421614, // Arbitrum Sepolia
-
   // ── Scroll ────────────────────────────────────────────────────────────────
   534352, // Scroll Mainnet
   534351, // Scroll Sepolia
-
   // ── Linea ─────────────────────────────────────────────────────────────────
   59144, // Linea Mainnet
   59141, // Linea Sepolia
-
   // ── zkSync Era ────────────────────────────────────────────────────────────
   324, // zkSync Era Mainnet
   300, // zkSync Sepolia
-
   // ── Avalanche ─────────────────────────────────────────────────────────────
   43114, // Avalanche C-Chain
   43113, // Avalanche Fuji
-
   // ── Mantle ────────────────────────────────────────────────────────────────
   5000, // Mantle Mainnet
   5003, // Mantle Sepolia
-
   // ── Celo ──────────────────────────────────────────────────────────────────
   42220, // Celo Mainnet
-
   // ── X Layer ───────────────────────────────────────────────────────────────
   196, // X Layer Mainnet
   195, // X Layer Testnet
-
   // ── Flow ──────────────────────────────────────────────────────────────────
   747, // Flow Mainnet
-
   // ── Story ─────────────────────────────────────────────────────────────────
   1514, // Story Mainnet
   1315, // Story Aeneid (testnet)
-
   // ── Monad ─────────────────────────────────────────────────────────────────
   143, // Monad Mainnet
   10143, // Monad Testnet
-
   // ── Abstract ──────────────────────────────────────────────────────────────
   2741, // Abstract Mainnet
-
   // ── Hemi ──────────────────────────────────────────────────────────────────
   43111, // Hemi Network Mainnet
   743111, // Hemi Sepolia
-
   // ── Plume ─────────────────────────────────────────────────────────────────
   98866, // Plume Mainnet
   98867, // Plume Testnet
-
   // ── Ethernity ─────────────────────────────────────────────────────────────
   183, // Ethernity Mainnet
-
   // ── Apechain ──────────────────────────────────────────────────────────────
   33139, // Apechain Mainnet
   33111, // Curtis Testnet (Apechain)
-
   // ── ZetaChain ─────────────────────────────────────────────────────────────
   7000, // ZetaChain Mainnet
-
   // ── B3 ────────────────────────────────────────────────────────────────────
   8333, // B3 Mainnet
-
   // ── Warden Protocol ───────────────────────────────────────────────────────
   8765, // Warden Protocol Mainnet
-
   // ── Edge ──────────────────────────────────────────────────────────────────
   3343, // Edge Mainnet
-
   // ── Perennial ─────────────────────────────────────────────────────────────
   1424, // Perennial Mainnet
-
   // ── MegaETH ───────────────────────────────────────────────────────────────
   6343, // MegaETH Testnet v2
-
   // ── Open Campus ───────────────────────────────────────────────────────────
   656476, // Open Campus Codex
-
   // ── Incentiv ──────────────────────────────────────────────────────────────
   28802, // Incentiv Testnet
 };
@@ -292,10 +250,7 @@ Future<bool> isRip7212Supported(PublicClient client) async {
 
   try {
     final result = await client.call(
-      Call(
-        to: EthereumAddress.fromHex(p256PrecompileAddress),
-        data: calldata,
-      ),
+      Call(to: EthereumAddress.fromHex(p256PrecompileAddress), data: calldata),
     );
 
     // Success: precompile returns uint256(1) for valid signature

--- a/packages/permissionless/lib/src/utils/units.dart
+++ b/packages/permissionless/lib/src/utils/units.dart
@@ -90,8 +90,9 @@ class GasUnits {
     final trimmed = value.trim().toLowerCase();
 
     // Try to extract number and unit
-    final match =
-        RegExp(r'^([\d.]+)\s*(gwei|eth|ether|wei)?$').firstMatch(trimmed);
+    final match = RegExp(
+      r'^([\d.]+)\s*(gwei|eth|ether|wei)?$',
+    ).firstMatch(trimmed);
 
     if (match == null) {
       throw FormatException('Invalid gas unit format: $value');

--- a/packages/permissionless/test/accounts/etherspot/etherspot_account_test.dart
+++ b/packages/permissionless/test/accounts/etherspot/etherspot_account_test.dart
@@ -85,8 +85,9 @@ void main() {
     late EtherspotSmartAccount account;
 
     // Mock account address (would normally be computed via getSenderAddress)
-    final mockAddress =
-        EthereumAddress.fromHex('0x1234567890123456789012345678901234567890');
+    final mockAddress = EthereumAddress.fromHex(
+      '0x1234567890123456789012345678901234567890',
+    );
 
     setUp(() {
       owner = PrivateKeyOwner(testPrivateKey);
@@ -130,10 +131,7 @@ void main() {
           chainId: BigInt.from(1),
         );
 
-        expect(
-          accountWithoutAddress.getAddress,
-          throwsA(isA<StateError>()),
-        );
+        expect(accountWithoutAddress.getAddress, throwsA(isA<StateError>()));
       });
 
       test('returns provided address', () async {
@@ -268,10 +266,7 @@ void main() {
       });
 
       test('throws on empty calls list', () {
-        expect(
-          () => account.encodeCalls([]),
-          throwsA(isA<ArgumentError>()),
-        );
+        expect(() => account.encodeCalls([]), throwsA(isA<ArgumentError>()));
       });
     });
 
@@ -366,9 +361,7 @@ void main() {
         final customAccount = createEtherspotSmartAccount(
           owner: owner,
           chainId: BigInt.from(1),
-          customAddresses: EtherspotCustomAddresses(
-            factory: customFactory,
-          ),
+          customAddresses: EtherspotCustomAddresses(factory: customFactory),
         );
 
         expect(customAccount.factory.hex, equals(customFactory.hex));

--- a/packages/permissionless/test/accounts/kernel/kernel_account_test.dart
+++ b/packages/permissionless/test/accounts/kernel/kernel_account_test.dart
@@ -8,8 +8,9 @@ void main() {
   const testOwnerAddress = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266';
 
   // Mock address for unit tests (avoids RPC calls)
-  final mockAddress =
-      EthereumAddress.fromHex('0x1234567890123456789012345678901234567890');
+  final mockAddress = EthereumAddress.fromHex(
+    '0x1234567890123456789012345678901234567890',
+  );
 
   group('KernelVersion', () {
     test('v0_2_4 has correct value', () {
@@ -39,16 +40,18 @@ void main() {
 
   group('KernelVersionAddresses', () {
     test('returns addresses for v0.2.4', () {
-      final addresses =
-          KernelVersionAddresses.getAddresses(KernelVersion.v0_2_4);
+      final addresses = KernelVersionAddresses.getAddresses(
+        KernelVersion.v0_2_4,
+      );
       expect(addresses, isNotNull);
       expect(addresses!.factory.hex, isNotEmpty);
       expect(addresses.accountImplementation.hex, isNotEmpty);
     });
 
     test('returns addresses for v0.3.1', () {
-      final addresses =
-          KernelVersionAddresses.getAddresses(KernelVersion.v0_3_1);
+      final addresses = KernelVersionAddresses.getAddresses(
+        KernelVersion.v0_3_1,
+      );
       expect(addresses, isNotNull);
       expect(addresses!.factory.hex, isNotEmpty);
       expect(addresses.metaFactory, isNotNull);
@@ -56,8 +59,9 @@ void main() {
     });
 
     test('v0.3.1 has meta factory', () {
-      final addresses =
-          KernelVersionAddresses.getAddresses(KernelVersion.v0_3_1);
+      final addresses = KernelVersionAddresses.getAddresses(
+        KernelVersion.v0_3_1,
+      );
       expect(addresses!.metaFactory, isNotNull);
       expect(
         addresses.metaFactory!.hex.toLowerCase(),
@@ -66,8 +70,9 @@ void main() {
     });
 
     test('v0.3.1 has ECDSA validator', () {
-      final addresses =
-          KernelVersionAddresses.getAddresses(KernelVersion.v0_3_1);
+      final addresses = KernelVersionAddresses.getAddresses(
+        KernelVersion.v0_3_1,
+      );
       expect(addresses!.ecdsaValidator, isNotNull);
       expect(
         addresses.ecdsaValidator!.hex.toLowerCase(),
@@ -205,8 +210,9 @@ void main() {
 
       test('uses meta factory for v0.3.1', () async {
         final factoryData = await account.getFactoryData();
-        final addresses =
-            KernelVersionAddresses.getAddresses(KernelVersion.v0_3_1);
+        final addresses = KernelVersionAddresses.getAddresses(
+          KernelVersion.v0_3_1,
+        );
         expect(
           factoryData!.factory.hex.toLowerCase(),
           equals(addresses!.metaFactory!.hex.toLowerCase()),
@@ -304,10 +310,7 @@ void main() {
       });
 
       test('throws on empty calls list', () {
-        expect(
-          () => account.encodeCalls([]),
-          throwsArgumentError,
-        );
+        expect(() => account.encodeCalls([]), throwsArgumentError);
       });
     });
 
@@ -461,8 +464,9 @@ void main() {
 
       test('uses direct factory for v0.2.4', () async {
         final factoryData = await account.getFactoryData();
-        final addresses =
-            KernelVersionAddresses.getAddresses(KernelVersion.v0_2_4);
+        final addresses = KernelVersionAddresses.getAddresses(
+          KernelVersion.v0_2_4,
+        );
         expect(
           factoryData!.factory.hex.toLowerCase(),
           equals(addresses!.factory.hex.toLowerCase()),
@@ -621,99 +625,104 @@ void main() {
       expect(stub.length, equals(140));
     });
 
-    test('signUserOperation works without publicClient for ECDSA v0.3.1',
-        () async {
-      // Creating an account without publicClient should still allow ECDSA
-      // signing, since _shouldUsePrecompile is only invoked on the WebAuthn
-      // path. This test ensures the async precompile check does not regress
-      // the ECDSA flow.
-      final account = createKernelSmartAccount(
-        owner: owner,
-        chainId: BigInt.from(1),
-        version: KernelVersion.v0_3_1,
-        address: mockAddress,
-      );
+    test(
+      'signUserOperation works without publicClient for ECDSA v0.3.1',
+      () async {
+        // Creating an account without publicClient should still allow ECDSA
+        // signing, since _shouldUsePrecompile is only invoked on the WebAuthn
+        // path. This test ensures the async precompile check does not regress
+        // the ECDSA flow.
+        final account = createKernelSmartAccount(
+          owner: owner,
+          chainId: BigInt.from(1),
+          version: KernelVersion.v0_3_1,
+          address: mockAddress,
+        );
 
-      final address = await account.getAddress();
-      final userOp = UserOperationV07(
-        sender: address,
-        nonce: BigInt.zero,
-        callData: '0x',
-        callGasLimit: BigInt.from(100000),
-        verificationGasLimit: BigInt.from(100000),
-        preVerificationGas: BigInt.from(21000),
-        maxFeePerGas: BigInt.from(1000000000),
-        maxPriorityFeePerGas: BigInt.from(1000000000),
-      );
+        final address = await account.getAddress();
+        final userOp = UserOperationV07(
+          sender: address,
+          nonce: BigInt.zero,
+          callData: '0x',
+          callGasLimit: BigInt.from(100000),
+          verificationGasLimit: BigInt.from(100000),
+          preVerificationGas: BigInt.from(21000),
+          maxFeePerGas: BigInt.from(1000000000),
+          maxPriorityFeePerGas: BigInt.from(1000000000),
+        );
 
-      final signature = await account.signUserOperation(userOp);
+        final signature = await account.signUserOperation(userOp);
 
-      // ECDSA signature: 65 bytes = 130 hex + 0x prefix
-      expect(signature, startsWith('0x'));
-      expect(signature.length, equals(132));
-    });
-
-    test('signUserOperation works without publicClient for ECDSA v0.2.4',
-        () async {
-      final account = createKernelSmartAccount(
-        owner: owner,
-        chainId: BigInt.from(1),
-        version: KernelVersion.v0_2_4,
-        address: mockAddress,
-      );
-
-      final address = await account.getAddress();
-      final userOp = UserOperationV07(
-        sender: address,
-        nonce: BigInt.zero,
-        callData: '0x',
-        callGasLimit: BigInt.from(100000),
-        verificationGasLimit: BigInt.from(100000),
-        preVerificationGas: BigInt.from(21000),
-        maxFeePerGas: BigInt.from(1000000000),
-        maxPriorityFeePerGas: BigInt.from(1000000000),
-      );
-
-      final signature = await account.signUserOperation(userOp);
-
-      // ROOT_MODE prefix + 65-byte ECDSA = 69 bytes = 138 hex + 0x
-      expect(signature, startsWith('0x00000000'));
-      expect(signature.length, equals(140));
-    });
+        // ECDSA signature: 65 bytes = 130 hex + 0x prefix
+        expect(signature, startsWith('0x'));
+        expect(signature.length, equals(132));
+      },
+    );
 
     test(
-        'ECDSA signing produces deterministic results regardless of publicClient absence',
-        () async {
-      final account1 = createKernelSmartAccount(
-        owner: owner,
-        chainId: BigInt.from(1),
-        version: KernelVersion.v0_3_1,
-        address: mockAddress,
-      );
-      final account2 = createKernelSmartAccount(
-        owner: owner,
-        chainId: BigInt.from(1),
-        version: KernelVersion.v0_3_1,
-        address: mockAddress,
-      );
+      'signUserOperation works without publicClient for ECDSA v0.2.4',
+      () async {
+        final account = createKernelSmartAccount(
+          owner: owner,
+          chainId: BigInt.from(1),
+          version: KernelVersion.v0_2_4,
+          address: mockAddress,
+        );
 
-      final address = await account1.getAddress();
-      final userOp = UserOperationV07(
-        sender: address,
-        nonce: BigInt.zero,
-        callData: '0x',
-        callGasLimit: BigInt.from(100000),
-        verificationGasLimit: BigInt.from(100000),
-        preVerificationGas: BigInt.from(21000),
-        maxFeePerGas: BigInt.from(1000000000),
-        maxPriorityFeePerGas: BigInt.from(1000000000),
-      );
+        final address = await account.getAddress();
+        final userOp = UserOperationV07(
+          sender: address,
+          nonce: BigInt.zero,
+          callData: '0x',
+          callGasLimit: BigInt.from(100000),
+          verificationGasLimit: BigInt.from(100000),
+          preVerificationGas: BigInt.from(21000),
+          maxFeePerGas: BigInt.from(1000000000),
+          maxPriorityFeePerGas: BigInt.from(1000000000),
+        );
 
-      final sig1 = await account1.signUserOperation(userOp);
-      final sig2 = await account2.signUserOperation(userOp);
+        final signature = await account.signUserOperation(userOp);
 
-      expect(sig1, equals(sig2));
-    });
+        // ROOT_MODE prefix + 65-byte ECDSA = 69 bytes = 138 hex + 0x
+        expect(signature, startsWith('0x00000000'));
+        expect(signature.length, equals(140));
+      },
+    );
+
+    test(
+      'ECDSA signing produces deterministic results regardless of publicClient absence',
+      () async {
+        final account1 = createKernelSmartAccount(
+          owner: owner,
+          chainId: BigInt.from(1),
+          version: KernelVersion.v0_3_1,
+          address: mockAddress,
+        );
+        final account2 = createKernelSmartAccount(
+          owner: owner,
+          chainId: BigInt.from(1),
+          version: KernelVersion.v0_3_1,
+          address: mockAddress,
+        );
+
+        final address = await account1.getAddress();
+        final userOp = UserOperationV07(
+          sender: address,
+          nonce: BigInt.zero,
+          callData: '0x',
+          callGasLimit: BigInt.from(100000),
+          verificationGasLimit: BigInt.from(100000),
+          preVerificationGas: BigInt.from(21000),
+          maxFeePerGas: BigInt.from(1000000000),
+          maxPriorityFeePerGas: BigInt.from(1000000000),
+        );
+
+        final sig1 = await account1.signUserOperation(userOp);
+        final sig2 = await account2.signUserOperation(userOp);
+
+        expect(sig1, equals(sig2));
+      },
+    );
 
     test('isWebAuthn is false for PrivateKeyOwner', () {
       final account = createKernelSmartAccount(

--- a/packages/permissionless/test/accounts/light/light_account_test.dart
+++ b/packages/permissionless/test/accounts/light/light_account_test.dart
@@ -3,8 +3,9 @@ import 'package:test/test.dart';
 
 void main() {
   // Mock address for unit tests (avoids RPC calls)
-  final mockAddress =
-      EthereumAddress.fromHex('0x1234567890123456789012345678901234567890');
+  final mockAddress = EthereumAddress.fromHex(
+    '0x1234567890123456789012345678901234567890',
+  );
 
   group('Light Account', () {
     group('LightAccountVersion', () {
@@ -62,18 +63,18 @@ void main() {
 
       test('fromVersion returns correct factory for v1.1.0', () {
         expect(
-          LightAccountFactoryAddresses.fromVersion(LightAccountVersion.v110)
-              .hex
-              .toLowerCase(),
+          LightAccountFactoryAddresses.fromVersion(
+            LightAccountVersion.v110,
+          ).hex.toLowerCase(),
           equals(LightAccountFactoryAddresses.v110.hex.toLowerCase()),
         );
       });
 
       test('fromVersion returns correct factory for v2.0.0', () {
         expect(
-          LightAccountFactoryAddresses.fromVersion(LightAccountVersion.v200)
-              .hex
-              .toLowerCase(),
+          LightAccountFactoryAddresses.fromVersion(
+            LightAccountVersion.v200,
+          ).hex.toLowerCase(),
           equals(LightAccountFactoryAddresses.v200.hex.toLowerCase()),
         );
       });
@@ -439,40 +440,42 @@ void main() {
         );
       });
 
-      test('same owner produces different addresses for v0.6 vs v0.7',
-          () async {
-        final mockAddress06 = EthereumAddress.fromHex(
-          '0x1111111111111111111111111111111111111111',
-        );
-        final mockAddress07 = EthereumAddress.fromHex(
-          '0x2222222222222222222222222222222222222222',
-        );
+      test(
+        'same owner produces different addresses for v0.6 vs v0.7',
+        () async {
+          final mockAddress06 = EthereumAddress.fromHex(
+            '0x1111111111111111111111111111111111111111',
+          );
+          final mockAddress07 = EthereumAddress.fromHex(
+            '0x2222222222222222222222222222222222222222',
+          );
 
-        final account06 = createLightSmartAccount(
-          owner: owner,
-          chainId: BigInt.from(1),
-          salt: BigInt.zero,
-          entryPointVersion: EntryPointVersion.v06,
-          address: mockAddress06,
-        );
+          final account06 = createLightSmartAccount(
+            owner: owner,
+            chainId: BigInt.from(1),
+            salt: BigInt.zero,
+            entryPointVersion: EntryPointVersion.v06,
+            address: mockAddress06,
+          );
 
-        final account07 = createLightSmartAccount(
-          owner: owner,
-          chainId: BigInt.from(1),
-          salt: BigInt.zero,
-          entryPointVersion: EntryPointVersion.v07,
-          address: mockAddress07,
-        );
+          final account07 = createLightSmartAccount(
+            owner: owner,
+            chainId: BigInt.from(1),
+            salt: BigInt.zero,
+            entryPointVersion: EntryPointVersion.v07,
+            address: mockAddress07,
+          );
 
-        final address06 = await account06.getAddress();
-        final address07 = await account07.getAddress();
+          final address06 = await account06.getAddress();
+          final address07 = await account07.getAddress();
 
-        // Different factories = different addresses
-        expect(
-          address06.hex.toLowerCase(),
-          isNot(equals(address07.hex.toLowerCase())),
-        );
-      });
+          // Different factories = different addresses
+          expect(
+            address06.hex.toLowerCase(),
+            isNot(equals(address07.hex.toLowerCase())),
+          );
+        },
+      );
     });
   });
 }

--- a/packages/permissionless/test/accounts/light/light_account_test.dart
+++ b/packages/permissionless/test/accounts/light/light_account_test.dart
@@ -22,6 +22,20 @@ void main() {
         );
       });
 
+      test('EntryPoint v0.8 is unsupported', () {
+        expect(
+          () => LightAccountVersion.forEntryPoint(EntryPointVersion.v08),
+          throwsArgumentError,
+        );
+      });
+
+      test('EntryPoint v0.9 is unsupported', () {
+        expect(
+          () => LightAccountVersion.forEntryPoint(EntryPointVersion.v09),
+          throwsArgumentError,
+        );
+      });
+
       test('v110 has version string "1.1.0"', () {
         expect(LightAccountVersion.v110.version, equals('1.1.0'));
       });

--- a/packages/permissionless/test/accounts/light/light_account_test.dart
+++ b/packages/permissionless/test/accounts/light/light_account_test.dart
@@ -22,6 +22,13 @@ void main() {
         );
       });
 
+      test('v0.9 does not auto-select an official Light version', () {
+        expect(
+          () => LightAccountVersion.forEntryPoint(EntryPointVersion.v09),
+          throwsArgumentError,
+        );
+      });
+
       test('v110 has version string "1.1.0"', () {
         expect(LightAccountVersion.v110.version, equals('1.1.0'));
       });
@@ -161,6 +168,36 @@ void main() {
         );
 
         expect(account.entryPointVersion, equals(EntryPointVersion.v06));
+      });
+
+      test('rejects EntryPoint v0.9 without explicit custom configuration', () {
+        expect(
+          () => createLightSmartAccount(
+            owner: owner,
+            chainId: BigInt.from(1),
+            entryPointVersion: EntryPointVersion.v09,
+            address: mockAddress,
+          ),
+          throwsArgumentError,
+        );
+      });
+
+      test('allows custom EntryPoint v0.9 factory experimentation', () {
+        final customFactory = EthereumAddress.fromHex(
+          '0x1234567890123456789012345678901234567890',
+        );
+
+        final account = createLightSmartAccount(
+          owner: owner,
+          chainId: BigInt.from(1),
+          entryPointVersion: EntryPointVersion.v09,
+          version: LightAccountVersion.v200,
+          customFactoryAddress: customFactory,
+          address: mockAddress,
+        );
+
+        expect(account.entryPointVersion, equals(EntryPointVersion.v09));
+        expect(account.entryPoint, equals(EntryPointAddresses.v09));
       });
 
       test('address is deterministic', () async {

--- a/packages/permissionless/test/accounts/safe/safe_account_test.dart
+++ b/packages/permissionless/test/accounts/safe/safe_account_test.dart
@@ -32,12 +32,14 @@ void main() {
   // This is a well-known test key from Foundry/Hardhat
   const testPrivateKey =
       '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
-  final testOwnerAddress =
-      EthereumAddress.fromHex('0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266');
+  final testOwnerAddress = EthereumAddress.fromHex(
+    '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+  );
 
   // Mock address for unit tests (avoids RPC calls)
-  final mockAddress =
-      EthereumAddress.fromHex('0x1234567890123456789012345678901234567890');
+  final mockAddress = EthereumAddress.fromHex(
+    '0x1234567890123456789012345678901234567890',
+  );
 
   group('SafeSmartAccount', () {
     group('creation', () {
@@ -75,10 +77,7 @@ void main() {
 
       test('throws when no owners provided', () {
         expect(
-          () => createSafeSmartAccount(
-            owners: [],
-            chainId: BigInt.from(1),
-          ),
+          () => createSafeSmartAccount(owners: [], chainId: BigInt.from(1)),
           throwsArgumentError,
         );
       });
@@ -401,10 +400,7 @@ void main() {
           address: mockAddress,
         );
 
-        expect(
-          () => account.encodeCalls([]),
-          throwsArgumentError,
-        );
+        expect(() => account.encodeCalls([]), throwsArgumentError);
       });
     });
 
@@ -593,9 +589,7 @@ void main() {
           final webAuthnOwner = _TestWebAuthnOwner(
             BigInt.from(0x1234),
             BigInt.from(0x5678),
-            Uint8List.fromList(
-              List<int>.generate(16, (i) => i),
-            ),
+            Uint8List.fromList(List<int>.generate(16, (i) => i)),
           );
 
           final accountTrue = createSafeSmartAccount(
@@ -709,8 +703,9 @@ void main() {
     // Test private key (DO NOT use in production!)
     const testPrivateKey =
         '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
-    final mockAddress =
-        EthereumAddress.fromHex('0x1234567890123456789012345678901234567890');
+    final mockAddress = EthereumAddress.fromHex(
+      '0x1234567890123456789012345678901234567890',
+    );
 
     group('creation', () {
       test('creates account with ERC-7579 enabled', () {

--- a/packages/permissionless/test/accounts/safe/safe_account_test.dart
+++ b/packages/permissionless/test/accounts/safe/safe_account_test.dart
@@ -133,6 +133,19 @@ void main() {
           throwsArgumentError,
         );
       });
+
+      test('throws for unsupported EntryPoint v0.9 combination', () {
+        final owner = PrivateKeyOwner(testPrivateKey);
+
+        expect(
+          () => createSafeSmartAccount(
+            owners: [owner],
+            entryPointVersion: EntryPointVersion.v09,
+            chainId: BigInt.from(1),
+          ),
+          throwsArgumentError,
+        );
+      });
     });
 
     group('getAddress', () {

--- a/packages/permissionless/test/accounts/simple/simple_account_test.dart
+++ b/packages/permissionless/test/accounts/simple/simple_account_test.dart
@@ -621,7 +621,8 @@ void main() {
 
       expect(account.entryPointVersion, equals(EntryPointVersion.v08));
       expect(account.entryPoint, equals(EntryPointAddresses.v08));
-      expect(account.accountLogicAddress, equals(Simple7702AccountAddresses.v08));
+      expect(
+          account.accountLogicAddress, equals(Simple7702AccountAddresses.v08));
     });
 
     test('supports explicit EntryPoint v0.9 logic', () {
@@ -633,7 +634,8 @@ void main() {
 
       expect(account.entryPointVersion, equals(EntryPointVersion.v09));
       expect(account.entryPoint, equals(EntryPointAddresses.v09));
-      expect(account.accountLogicAddress, equals(Simple7702AccountAddresses.v09));
+      expect(
+          account.accountLogicAddress, equals(Simple7702AccountAddresses.v09));
     });
 
     test('rejects older EntryPoint versions', () {

--- a/packages/permissionless/test/accounts/simple/simple_account_test.dart
+++ b/packages/permissionless/test/accounts/simple/simple_account_test.dart
@@ -69,6 +69,35 @@ void main() {
         // We can verify this through getFactoryData
         expect(account, isNotNull);
       });
+
+      test('rejects built-in EntryPoint v0.9 factory selection', () {
+        expect(
+          () => createSimpleSmartAccount(
+            owner: owner,
+            chainId: BigInt.from(1),
+            entryPointVersion: EntryPointVersion.v09,
+            address: mockAddress,
+          ),
+          throwsA(isA<UnsupportedError>()),
+        );
+      });
+
+      test('allows custom EntryPoint v0.9 factory experimentation', () {
+        final customFactory = EthereumAddress.fromHex(
+          '0x1234567890123456789012345678901234567890',
+        );
+
+        account = createSimpleSmartAccount(
+          owner: owner,
+          chainId: BigInt.from(1),
+          entryPointVersion: EntryPointVersion.v09,
+          customFactoryAddress: customFactory,
+          address: mockAddress,
+        );
+
+        expect(account.entryPointVersion, equals(EntryPointVersion.v09));
+        expect(account.entryPoint, equals(EntryPointAddresses.v09));
+      });
     });
 
     group('getAddress', () {
@@ -540,6 +569,81 @@ void main() {
       expect(
         SimpleAccountFactoryAddresses.fromVersion(EntryPointVersion.v07),
         equals(SimpleAccountFactoryAddresses.v07),
+      );
+    });
+
+    test('fromVersion rejects v0.9 without a verified factory', () {
+      expect(
+        () => SimpleAccountFactoryAddresses.fromVersion(EntryPointVersion.v09),
+        throwsA(isA<UnsupportedError>()),
+      );
+    });
+  });
+
+  group('Simple7702AccountAddresses', () {
+    test('selects v0.8 and v0.9 logic addresses', () {
+      expect(
+        Simple7702AccountAddresses.fromVersion(EntryPointVersion.v08),
+        equals(Simple7702AccountAddresses.v08),
+      );
+      expect(
+        Simple7702AccountAddresses.fromVersion(EntryPointVersion.v09),
+        equals(Simple7702AccountAddresses.v09),
+      );
+      expect(
+        Simple7702AccountAddresses.v09.hex.toLowerCase(),
+        equals('0xa46cc63ebf4bd77888aa327837d20b23a63a56b5'),
+      );
+    });
+
+    test('rejects non-EIP-7702 EntryPoint versions', () {
+      expect(
+        () => Simple7702AccountAddresses.fromVersion(EntryPointVersion.v07),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('Eip7702SimpleSmartAccount', () {
+    late PrivateKeyEip7702Owner owner;
+
+    setUp(() {
+      owner = PrivateKeyEip7702Owner(
+        '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80',
+      );
+    });
+
+    test('defaults to EntryPoint v0.8 logic', () {
+      final account = createEip7702SimpleSmartAccount(
+        owner: owner,
+        chainId: BigInt.from(1),
+      );
+
+      expect(account.entryPointVersion, equals(EntryPointVersion.v08));
+      expect(account.entryPoint, equals(EntryPointAddresses.v08));
+      expect(account.accountLogicAddress, equals(Simple7702AccountAddresses.v08));
+    });
+
+    test('supports explicit EntryPoint v0.9 logic', () {
+      final account = createEip7702SimpleSmartAccount(
+        owner: owner,
+        chainId: BigInt.from(1),
+        entryPointVersion: EntryPointVersion.v09,
+      );
+
+      expect(account.entryPointVersion, equals(EntryPointVersion.v09));
+      expect(account.entryPoint, equals(EntryPointAddresses.v09));
+      expect(account.accountLogicAddress, equals(Simple7702AccountAddresses.v09));
+    });
+
+    test('rejects older EntryPoint versions', () {
+      expect(
+        () => createEip7702SimpleSmartAccount(
+          owner: owner,
+          chainId: BigInt.from(1),
+          entryPointVersion: EntryPointVersion.v07,
+        ),
+        throwsArgumentError,
       );
     });
   });

--- a/packages/permissionless/test/accounts/simple/simple_account_test.dart
+++ b/packages/permissionless/test/accounts/simple/simple_account_test.dart
@@ -7,8 +7,9 @@ void main() {
     late PrivateKeyOwner owner;
 
     // Mock address for unit tests (avoids RPC calls)
-    final mockAddress =
-        EthereumAddress.fromHex('0x1234567890123456789012345678901234567890');
+    final mockAddress = EthereumAddress.fromHex(
+      '0x1234567890123456789012345678901234567890',
+    );
 
     setUp(() {
       // Test private key (do not use in production!)
@@ -314,10 +315,7 @@ void main() {
           address: mockAddress,
         );
 
-        expect(
-          () => account.encodeCalls([]),
-          throwsA(isA<ArgumentError>()),
-        );
+        expect(() => account.encodeCalls([]), throwsA(isA<ArgumentError>()));
       });
     });
 
@@ -616,24 +614,18 @@ void main() {
 
     test('selects implementation address by EntryPoint version', () {
       expect(
-        Simple7702AccountAddresses.fromVersion(
-          EntryPointVersion.v08,
-        ),
+        Simple7702AccountAddresses.fromVersion(EntryPointVersion.v08),
         equals(Simple7702AccountAddresses.v08),
       );
       expect(
-        Simple7702AccountAddresses.fromVersion(
-          EntryPointVersion.v09,
-        ),
+        Simple7702AccountAddresses.fromVersion(EntryPointVersion.v09),
         equals(Simple7702AccountAddresses.v09),
       );
     });
 
     test('rejects unsupported EntryPoint versions', () {
       expect(
-        () => Simple7702AccountAddresses.fromVersion(
-          EntryPointVersion.v07,
-        ),
+        () => Simple7702AccountAddresses.fromVersion(EntryPointVersion.v07),
         throwsArgumentError,
       );
     });
@@ -777,7 +769,9 @@ void main() {
       expect(account.entryPointVersion, equals(EntryPointVersion.v08));
       expect(account.entryPoint, equals(EntryPointAddresses.v08));
       expect(
-          account.accountLogicAddress, equals(Simple7702AccountAddresses.v08));
+        account.accountLogicAddress,
+        equals(Simple7702AccountAddresses.v08),
+      );
     });
 
     test('supports explicit EntryPoint v0.9 logic', () {
@@ -790,7 +784,9 @@ void main() {
       expect(account.entryPointVersion, equals(EntryPointVersion.v09));
       expect(account.entryPoint, equals(EntryPointAddresses.v09));
       expect(
-          account.accountLogicAddress, equals(Simple7702AccountAddresses.v09));
+        account.accountLogicAddress,
+        equals(Simple7702AccountAddresses.v09),
+      );
     });
 
     test('rejects older EntryPoint versions', () {

--- a/packages/permissionless/test/accounts/simple/simple_account_test.dart
+++ b/packages/permissionless/test/accounts/simple/simple_account_test.dart
@@ -544,6 +544,150 @@ void main() {
     });
   });
 
+  group('Simple7702AccountAddresses', () {
+    test('maps EntryPoint v0.9 to the official singleton address', () {
+      expect(
+        EntryPointAddresses.fromVersion(EntryPointVersion.v09),
+        equals(EntryPointAddresses.v09),
+      );
+      expect(
+        EntryPointAddresses.v09.hex.toLowerCase(),
+        equals('0x433709009b8330fda32311df1c2afa402ed8d009'),
+      );
+    });
+
+    test('defaults to the v0.8 implementation address', () {
+      expect(
+        Simple7702AccountAddresses.defaultLogic,
+        equals(Simple7702AccountAddresses.v08),
+      );
+      expect(
+        Simple7702AccountAddresses.defaultLogic.hex.toLowerCase(),
+        equals('0xe6cae83bde06e4c305530e199d7217f42808555b'),
+      );
+    });
+
+    test('has the v0.9 implementation address', () {
+      expect(
+        Simple7702AccountAddresses.v09.hex.toLowerCase(),
+        equals('0xa46cc63ebf4bd77888aa327837d20b23a63a56b5'),
+      );
+    });
+
+    test('selects implementation address by EntryPoint version', () {
+      expect(
+        Simple7702AccountAddresses.fromEntryPointVersion(
+          EntryPointVersion.v08,
+        ),
+        equals(Simple7702AccountAddresses.v08),
+      );
+      expect(
+        Simple7702AccountAddresses.fromEntryPointVersion(
+          EntryPointVersion.v09,
+        ),
+        equals(Simple7702AccountAddresses.v09),
+      );
+    });
+
+    test('rejects unsupported EntryPoint versions', () {
+      expect(
+        () => Simple7702AccountAddresses.fromEntryPointVersion(
+          EntryPointVersion.v07,
+        ),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('Eip7702SimpleSmartAccount', () {
+    late _FakeEip7702Owner owner;
+
+    setUp(() {
+      owner = _FakeEip7702Owner(
+        EthereumAddress.fromHex('0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'),
+      );
+    });
+
+    test('defaults to EntryPoint v0.8 for backward compatibility', () {
+      final account = createEip7702SimpleSmartAccount(
+        owner: owner,
+        chainId: BigInt.from(11155111),
+      );
+
+      expect(account.entryPointVersion, equals(EntryPointVersion.v08));
+      expect(account.entryPoint, equals(EntryPointAddresses.v08));
+      expect(
+        account.accountLogicAddress,
+        equals(Simple7702AccountAddresses.v08),
+      );
+    });
+
+    test('selects EntryPoint v0.9 implementation when opted in', () {
+      final account = createEip7702SimpleSmartAccount(
+        owner: owner,
+        chainId: BigInt.from(11155111),
+        entryPointVersion: EntryPointVersion.v09,
+      );
+
+      expect(account.entryPointVersion, equals(EntryPointVersion.v09));
+      expect(account.entryPoint, equals(EntryPointAddresses.v09));
+      expect(
+        account.accountLogicAddress,
+        equals(Simple7702AccountAddresses.v09),
+      );
+    });
+
+    test('keeps account address equal to the owner EOA address', () async {
+      final account = createEip7702SimpleSmartAccount(
+        owner: owner,
+        chainId: BigInt.from(11155111),
+        entryPointVersion: EntryPointVersion.v09,
+      );
+
+      expect(await account.getAddress(), equals(owner.address));
+    });
+
+    test('allows a custom logic address for supported EntryPoint versions', () {
+      final customLogic = EthereumAddress.fromHex(
+        '0x1234567890123456789012345678901234567890',
+      );
+
+      final account = createEip7702SimpleSmartAccount(
+        owner: owner,
+        chainId: BigInt.from(11155111),
+        entryPointVersion: EntryPointVersion.v09,
+        accountLogicAddress: customLogic,
+      );
+
+      expect(account.accountLogicAddress, equals(customLogic));
+    });
+
+    test('rejects unsupported EntryPoint versions', () {
+      expect(
+        () => createEip7702SimpleSmartAccount(
+          owner: owner,
+          chainId: BigInt.from(11155111),
+          entryPointVersion: EntryPointVersion.v07,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('creates v0.9 authorization for configured logic address', () async {
+      final account = createEip7702SimpleSmartAccount(
+        owner: owner,
+        chainId: BigInt.from(11155111),
+        entryPointVersion: EntryPointVersion.v09,
+      );
+
+      final auth = await account.getAuthorization(nonce: BigInt.from(7));
+
+      expect(auth.chainId, equals(BigInt.from(11155111)));
+      expect(auth.address, equals(Simple7702AccountAddresses.v09));
+      expect(auth.nonce, equals(BigInt.from(7)));
+    });
+  });
+
   group('SimpleAccountSelectors', () {
     test('has correct execute selector', () {
       expect(SimpleAccountSelectors.execute, equals('0xb61d27f6'));
@@ -557,4 +701,34 @@ void main() {
       expect(SimpleAccountSelectors.createAccount, equals('0x5fbfb9cf'));
     });
   });
+}
+
+class _FakeEip7702Owner extends Eip7702SimpleAccountOwner {
+  const _FakeEip7702Owner(this.address);
+
+  @override
+  final EthereumAddress address;
+
+  @override
+  Future<Eip7702Authorization> createAuthorization({
+    required BigInt chainId,
+    required EthereumAddress contractAddress,
+    required BigInt nonce,
+  }) async =>
+      Eip7702Authorization(
+        chainId: chainId,
+        address: contractAddress,
+        nonce: nonce,
+        v: 27,
+        r: '0x${List.filled(32, '11').join()}',
+        s: '0x${List.filled(32, '22').join()}',
+      );
+
+  @override
+  Future<String> signHash(String messageHash) async =>
+      '0x${List.filled(65, '11').join()}';
+
+  @override
+  Future<String> signTypedData(TypedData typedData) async =>
+      '0x${List.filled(65, '22').join()}';
 }

--- a/packages/permissionless/test/accounts/simple/simple_account_test.dart
+++ b/packages/permissionless/test/accounts/simple/simple_account_test.dart
@@ -541,6 +541,17 @@ void main() {
         SimpleAccountFactoryAddresses.fromVersion(EntryPointVersion.v07),
         equals(SimpleAccountFactoryAddresses.v07),
       );
+      expect(
+        SimpleAccountFactoryAddresses.fromVersion(EntryPointVersion.v08),
+        equals(SimpleAccountFactoryAddresses.v08),
+      );
+    });
+
+    test('EntryPoint v0.9 is unsupported without a custom factory', () {
+      expect(
+        () => SimpleAccountFactoryAddresses.fromVersion(EntryPointVersion.v09),
+        throwsArgumentError,
+      );
     });
   });
 

--- a/packages/permissionless/test/accounts/simple/simple_account_test.dart
+++ b/packages/permissionless/test/accounts/simple/simple_account_test.dart
@@ -542,6 +542,112 @@ void main() {
         equals(SimpleAccountFactoryAddresses.v07),
       );
     });
+
+    test('fromVersion rejects EntryPoint v0.9', () {
+      expect(
+        () => SimpleAccountFactoryAddresses.fromVersion(EntryPointVersion.v09),
+        throwsA(isA<UnsupportedError>()),
+      );
+    });
+  });
+
+  group('Simple7702AccountAddresses', () {
+    test('has v0.8 logic address', () {
+      expect(
+        Simple7702AccountAddresses.v08.hex.toLowerCase(),
+        equals('0xe6cae83bde06e4c305530e199d7217f42808555b'),
+      );
+    });
+
+    test('has v0.9 logic address', () {
+      expect(
+        Simple7702AccountAddresses.v09.hex.toLowerCase(),
+        equals('0xa46cc63ebf4bd77888aa327837d20b23a63a56b5'),
+      );
+    });
+
+    test('default logic remains v0.8', () {
+      expect(
+        Simple7702AccountAddresses.defaultLogic,
+        equals(Simple7702AccountAddresses.v08),
+      );
+    });
+
+    test('fromVersion selects v0.8 and v0.9 logic addresses', () {
+      expect(
+        Simple7702AccountAddresses.fromVersion(EntryPointVersion.v08),
+        equals(Simple7702AccountAddresses.v08),
+      );
+      expect(
+        Simple7702AccountAddresses.fromVersion(EntryPointVersion.v09),
+        equals(Simple7702AccountAddresses.v09),
+      );
+    });
+
+    test('fromVersion rejects unsupported EntryPoint versions', () {
+      expect(
+        () => Simple7702AccountAddresses.fromVersion(EntryPointVersion.v06),
+        throwsArgumentError,
+      );
+      expect(
+        () => Simple7702AccountAddresses.fromVersion(EntryPointVersion.v07),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('Eip7702SimpleSmartAccount', () {
+    late PrivateKeyEip7702Owner owner;
+
+    setUp(() {
+      owner = PrivateKeyEip7702Owner(
+        '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80',
+      );
+    });
+
+    test('defaults remain EntryPoint v0.8', () {
+      final account = createEip7702SimpleSmartAccount(
+        owner: owner,
+        chainId: BigInt.from(11155111),
+      );
+
+      expect(account.entryPointVersion, equals(EntryPointVersion.v08));
+      expect(account.entryPoint, equals(EntryPointAddresses.v08));
+      expect(
+        account.accountLogicAddress,
+        equals(Simple7702AccountAddresses.v08),
+      );
+    });
+
+    test('uses official Simple7702Account v0.9 address when opted in', () {
+      final account = createEip7702SimpleSmartAccount(
+        owner: owner,
+        chainId: BigInt.from(11155111),
+        entryPointVersion: EntryPointVersion.v09,
+      );
+
+      expect(account.entryPointVersion, equals(EntryPointVersion.v09));
+      expect(account.entryPoint, equals(EntryPointAddresses.v09));
+      expect(
+        account.accountLogicAddress,
+        equals(Simple7702AccountAddresses.v09),
+      );
+    });
+
+    test('keeps custom logic address support for v0.9 experiments', () {
+      final customLogic = EthereumAddress.fromHex(
+        '0x1234567890123456789012345678901234567890',
+      );
+      final account = createEip7702SimpleSmartAccount(
+        owner: owner,
+        chainId: BigInt.from(11155111),
+        entryPointVersion: EntryPointVersion.v09,
+        accountLogicAddress: customLogic,
+      );
+
+      expect(account.entryPointVersion, equals(EntryPointVersion.v09));
+      expect(account.accountLogicAddress, equals(customLogic));
+    });
   });
 
   group('SimpleAccountSelectors', () {

--- a/packages/permissionless/test/accounts/thirdweb/thirdweb_account_test.dart
+++ b/packages/permissionless/test/accounts/thirdweb/thirdweb_account_test.dart
@@ -5,8 +5,9 @@ void main() {
   group('ThirdwebSmartAccount', () {
     late PrivateKeyOwner owner;
 
-    final mockAddress =
-        EthereumAddress.fromHex('0x1234567890123456789012345678901234567890');
+    final mockAddress = EthereumAddress.fromHex(
+      '0x1234567890123456789012345678901234567890',
+    );
 
     setUp(() {
       owner = PrivateKeyOwner(

--- a/packages/permissionless/test/accounts/thirdweb/thirdweb_account_test.dart
+++ b/packages/permissionless/test/accounts/thirdweb/thirdweb_account_test.dart
@@ -1,0 +1,46 @@
+import 'package:permissionless/permissionless.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ThirdwebSmartAccount', () {
+    late PrivateKeyOwner owner;
+
+    final mockAddress =
+        EthereumAddress.fromHex('0x1234567890123456789012345678901234567890');
+
+    setUp(() {
+      owner = PrivateKeyOwner(
+        '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80',
+      );
+    });
+
+    test('rejects built-in EntryPoint v0.9 factory selection', () {
+      expect(
+        () => createThirdwebSmartAccount(
+          owner: owner,
+          chainId: BigInt.from(1),
+          entryPointVersion: EntryPointVersion.v09,
+          address: mockAddress,
+        ),
+        throwsA(isA<UnsupportedError>()),
+      );
+    });
+
+    test('allows custom EntryPoint v0.9 factory experimentation', () {
+      final customFactory = EthereumAddress.fromHex(
+        '0x1234567890123456789012345678901234567890',
+      );
+
+      final account = createThirdwebSmartAccount(
+        owner: owner,
+        chainId: BigInt.from(1),
+        entryPointVersion: EntryPointVersion.v09,
+        customFactoryAddress: customFactory,
+        address: mockAddress,
+      );
+
+      expect(account.entryPointVersion, equals(EntryPointVersion.v09));
+      expect(account.entryPoint, equals(EntryPointAddresses.v09));
+    });
+  });
+}

--- a/packages/permissionless/test/clients/bundler/bundler_client_test.dart
+++ b/packages/permissionless/test/clients/bundler/bundler_client_test.dart
@@ -351,6 +351,82 @@ void main() {
         expect(capturedRequests[0]['method'], equals('eth_chainId'));
       });
     });
+
+    group('EIP-7702 v0.9 authorization payloads', () {
+      final authorization = Eip7702Authorization(
+        chainId: BigInt.from(11155111),
+        address: Simple7702AccountAddresses.v09,
+        nonce: BigInt.from(7),
+        v: 27,
+        r: '0x${List.filled(32, '11').join()}',
+        s: '0x${List.filled(32, '22').join()}',
+      );
+
+      UserOperationV07 userOperation() => UserOperationV07(
+            sender: EthereumAddress.fromHex(
+              '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
+            ),
+            nonce: BigInt.zero,
+            factory: EthereumAddress.fromHex(
+              '0x7702000000000000000000000000000000000000',
+            ),
+            factoryData: '0x',
+            callData: '0x',
+            callGasLimit: BigInt.from(100000),
+            verificationGasLimit: BigInt.from(100000),
+            preVerificationGas: BigInt.from(21000),
+            maxFeePerGas: BigInt.from(1000000000),
+            maxPriorityFeePerGas: BigInt.from(1000000000),
+          );
+
+      test('sends with v0.9 EntryPoint and eip7702Auth', () async {
+        const expectedHash =
+            '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef';
+        final mockClient = createMockClient((_) => expectedHash);
+        client = createBundlerClient(
+          url: 'http://localhost:3000/rpc',
+          entryPoint: EntryPointAddresses.v09,
+          httpClient: mockClient,
+        );
+
+        await client.sendUserOperationWithAuthorization(
+          userOperation(),
+          [authorization],
+        );
+
+        final params = capturedRequests.single['params'] as List<dynamic>;
+        final userOpJson = params[0] as Map<String, dynamic>;
+        expect(params[1], equals(EntryPointAddresses.v09.hex));
+        expect(userOpJson['factory'], equals('0x7702'));
+        expect(userOpJson['eip7702Auth'], equals(authorization.toRpcFormat()));
+      });
+
+      test('estimates with v0.9 EntryPoint and eip7702Auth', () async {
+        final mockClient = createMockClient(
+          (_) => {
+            'preVerificationGas': '0x5208',
+            'verificationGasLimit': '0x186a0',
+            'callGasLimit': '0x186a0',
+          },
+        );
+        client = createBundlerClient(
+          url: 'http://localhost:3000/rpc',
+          entryPoint: EntryPointAddresses.v09,
+          httpClient: mockClient,
+        );
+
+        await client.estimateUserOperationGasWithAuthorization(
+          userOperation(),
+          [authorization],
+        );
+
+        final params = capturedRequests.single['params'] as List<dynamic>;
+        final userOpJson = params[0] as Map<String, dynamic>;
+        expect(params[1], equals(EntryPointAddresses.v09.hex));
+        expect(userOpJson['factory'], equals('0x7702'));
+        expect(userOpJson['eip7702Auth'], equals(authorization.toRpcFormat()));
+      });
+    });
   });
 
   group('JsonRpcClient', () {

--- a/packages/permissionless/test/clients/bundler/bundler_client_test.dart
+++ b/packages/permissionless/test/clients/bundler/bundler_client_test.dart
@@ -88,6 +88,43 @@ void main() {
         );
       });
 
+      test('uses configured v0.9 EntryPoint address', () async {
+        const expectedHash =
+            '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef';
+
+        final mockClient = createMockClient((_) => expectedHash);
+        client = createBundlerClient(
+          url: 'http://localhost:3000/rpc',
+          entryPoint: EntryPointAddresses.v09,
+          httpClient: mockClient,
+        );
+
+        final userOp = UserOperationV07(
+          sender: EthereumAddress.fromHex(
+            '0x1234567890123456789012345678901234567890',
+          ),
+          nonce: BigInt.zero,
+          callData: '0x',
+          callGasLimit: BigInt.from(100000),
+          verificationGasLimit: BigInt.from(100000),
+          preVerificationGas: BigInt.from(21000),
+          maxFeePerGas: BigInt.from(1000000000),
+          maxPriorityFeePerGas: BigInt.from(1000000000),
+        );
+
+        final result = await client.sendUserOperation(userOp);
+
+        expect(result, equals(expectedHash));
+        expect(
+          capturedRequests.single['method'],
+          equals('eth_sendUserOperation'),
+        );
+        expect(
+          capturedRequests.single['params'][1],
+          equals(EntryPointAddresses.v09.hex),
+        );
+      });
+
       test('throws BundlerRpcError on validation failure', () async {
         final mockClient = createErrorMockClient(
           -32602,
@@ -170,6 +207,46 @@ void main() {
         expect(
           capturedRequests[0]['method'],
           equals('eth_estimateUserOperationGas'),
+        );
+      });
+
+      test('uses configured v0.9 EntryPoint address', () async {
+        final mockClient = createMockClient(
+          (_) => {
+            'preVerificationGas': '0x5208',
+            'verificationGasLimit': '0x186a0',
+            'callGasLimit': '0x186a0',
+          },
+        );
+        client = createBundlerClient(
+          url: 'http://localhost:3000/rpc',
+          entryPoint: EntryPointAddresses.v09,
+          httpClient: mockClient,
+        );
+
+        final userOp = UserOperationV07(
+          sender: EthereumAddress.fromHex(
+            '0x1234567890123456789012345678901234567890',
+          ),
+          nonce: BigInt.zero,
+          callData: '0x',
+          callGasLimit: BigInt.zero,
+          verificationGasLimit: BigInt.zero,
+          preVerificationGas: BigInt.zero,
+          maxFeePerGas: BigInt.from(1000000000),
+          maxPriorityFeePerGas: BigInt.from(1000000000),
+        );
+
+        final estimate = await client.estimateUserOperationGas(userOp);
+
+        expect(estimate.preVerificationGas, equals(BigInt.from(21000)));
+        expect(
+          capturedRequests.single['method'],
+          equals('eth_estimateUserOperationGas'),
+        );
+        expect(
+          capturedRequests.single['params'][1],
+          equals(EntryPointAddresses.v09.hex),
         );
       });
 

--- a/packages/permissionless/test/clients/bundler/bundler_client_test.dart
+++ b/packages/permissionless/test/clients/bundler/bundler_client_test.dart
@@ -20,11 +20,7 @@ void main() {
         capturedRequests.add(body);
         final response = responseFactory(body);
         return http.Response(
-          jsonEncode({
-            'jsonrpc': '2.0',
-            'id': body['id'],
-            'result': response,
-          }),
+          jsonEncode({'jsonrpc': '2.0', 'id': body['id'], 'result': response}),
           200,
         );
       });
@@ -466,10 +462,9 @@ void main() {
           httpClient: mockClient,
         );
 
-        await client.sendUserOperationWithAuthorization(
-          userOperation(),
-          [authorization],
-        );
+        await client.sendUserOperationWithAuthorization(userOperation(), [
+          authorization,
+        ]);
 
         final params = capturedRequests.single['params'] as List<dynamic>;
         final userOpJson = params[0] as Map<String, dynamic>;
@@ -602,10 +597,7 @@ void main() {
     });
 
     test('returns null for non-AA errors', () {
-      const error = BundlerRpcError(
-        code: -32600,
-        message: 'Invalid Request',
-      );
+      const error = BundlerRpcError(code: -32600, message: 'Invalid Request');
 
       expect(error.aaErrorCode, isNull);
     });

--- a/packages/permissionless/test/clients/etherspot/etherspot_client_test.dart
+++ b/packages/permissionless/test/clients/etherspot/etherspot_client_test.dart
@@ -19,11 +19,7 @@ void main() {
         capturedRequests.add(body);
         final response = responseFactory(body);
         return http.Response(
-          jsonEncode({
-            'jsonrpc': '2.0',
-            'id': body['id'],
-            'result': response,
-          }),
+          jsonEncode({'jsonrpc': '2.0', 'id': body['id'], 'result': response}),
           200,
         );
       });
@@ -47,10 +43,7 @@ void main() {
 
         expect(gasPrice.maxFeePerGas, equals(BigInt.from(2000000000)));
         expect(gasPrice.maxPriorityFeePerGas, equals(BigInt.from(1000000000)));
-        expect(
-          capturedRequests[0]['method'],
-          equals('skandha_getGasPrice'),
-        );
+        expect(capturedRequests[0]['method'], equals('skandha_getGasPrice'));
       });
 
       test('handles decimal string values', () async {

--- a/packages/permissionless/test/clients/paymaster/paymaster_client_test.dart
+++ b/packages/permissionless/test/clients/paymaster/paymaster_client_test.dart
@@ -167,6 +167,47 @@ void main() {
         expect(result.paymasterData, equals('0xsigneddata123456'));
         expect(capturedRequests[0]['method'], equals('pm_getPaymasterData'));
       });
+
+      test(
+        'keeps v0.8 paymaster data unchanged without suffix helper',
+        () async {
+          final mockClient = createMockClient(
+            (_) => {
+              'paymaster': '0x1234567890123456789012345678901234567890',
+              'paymasterData': '0xv08signeddata',
+            },
+          );
+          client = createPaymasterClient(
+            url: 'http://localhost:3000/rpc',
+            httpClient: mockClient,
+          );
+
+          final userOp = UserOperationV07(
+            sender: EthereumAddress.fromHex(
+              '0x1234567890123456789012345678901234567890',
+            ),
+            nonce: BigInt.zero,
+            callData: '0x',
+            callGasLimit: BigInt.from(100000),
+            verificationGasLimit: BigInt.from(100000),
+            preVerificationGas: BigInt.from(21000),
+            maxFeePerGas: BigInt.from(1000000000),
+            maxPriorityFeePerGas: BigInt.from(1000000000),
+          );
+
+          final result = await client.getPaymasterData(
+            userOp: userOp,
+            entryPoint: EntryPointAddresses.v08,
+            chainId: BigInt.one,
+          );
+
+          expect(result.paymasterData, equals('0xv08signeddata'));
+          expect(
+            capturedRequests[0]['params'][1],
+            equals(EntryPointAddresses.v08.hex),
+          );
+        },
+      );
     });
 
     group('sponsorUserOperation', () {

--- a/packages/permissionless/test/clients/paymaster/paymaster_client_test.dart
+++ b/packages/permissionless/test/clients/paymaster/paymaster_client_test.dart
@@ -20,11 +20,7 @@ void main() {
         capturedRequests.add(body);
         final response = responseFactory(body);
         return http.Response(
-          jsonEncode({
-            'jsonrpc': '2.0',
-            'id': body['id'],
-            'result': response,
-          }),
+          jsonEncode({'jsonrpc': '2.0', 'id': body['id'], 'result': response}),
           200,
         );
       });

--- a/packages/permissionless/test/clients/pimlico/pimlico_client_test.dart
+++ b/packages/permissionless/test/clients/pimlico/pimlico_client_test.dart
@@ -19,11 +19,7 @@ void main() {
         capturedRequests.add(body);
         final response = responseFactory(body);
         return http.Response(
-          jsonEncode({
-            'jsonrpc': '2.0',
-            'id': body['id'],
-            'result': response,
-          }),
+          jsonEncode({'jsonrpc': '2.0', 'id': body['id'], 'result': response}),
           200,
         );
       });
@@ -69,10 +65,7 @@ void main() {
 
       test('returns submitted status without receipt', () async {
         final mockClient = createMockClient(
-          (_) => {
-            'status': 'submitted',
-            'transactionHash': '0xpending',
-          },
+          (_) => {'status': 'submitted', 'transactionHash': '0xpending'},
         );
         client = createPimlicoClient(
           url: 'http://localhost:8545',
@@ -91,9 +84,7 @@ void main() {
       });
 
       test('returns not_found status', () async {
-        final mockClient = createMockClient(
-          (_) => {'status': 'not_found'},
-        );
+        final mockClient = createMockClient((_) => {'status': 'not_found'});
         client = createPimlicoClient(
           url: 'http://localhost:8545',
           entryPoint: EntryPointAddresses.v07,
@@ -109,9 +100,7 @@ void main() {
       });
 
       test('returns rejected status', () async {
-        final mockClient = createMockClient(
-          (_) => {'status': 'rejected'},
-        );
+        final mockClient = createMockClient((_) => {'status': 'rejected'});
         client = createPimlicoClient(
           url: 'http://localhost:8545',
           entryPoint: EntryPointAddresses.v07,
@@ -126,9 +115,7 @@ void main() {
       });
 
       test('returns reverted status', () async {
-        final mockClient = createMockClient(
-          (_) => {'status': 'reverted'},
-        );
+        final mockClient = createMockClient((_) => {'status': 'reverted'});
         client = createPimlicoClient(
           url: 'http://localhost:8545',
           entryPoint: EntryPointAddresses.v07,
@@ -502,11 +489,7 @@ void main() {
         capturedRequests.add(body);
         final response = responseFactory(body);
         return http.Response(
-          jsonEncode({
-            'jsonrpc': '2.0',
-            'id': body['id'],
-            'result': response,
-          }),
+          jsonEncode({'jsonrpc': '2.0', 'id': body['id'], 'result': response}),
           200,
         );
       });
@@ -610,11 +593,7 @@ void main() {
         capturedRequests.add(body);
         final response = responseFactory(body);
         return http.Response(
-          jsonEncode({
-            'jsonrpc': '2.0',
-            'id': body['id'],
-            'result': response,
-          }),
+          jsonEncode({'jsonrpc': '2.0', 'id': body['id'], 'result': response}),
           200,
         );
       });
@@ -820,10 +799,7 @@ void main() {
     test('PimlicoSponsorshipPolicy fromJson', () {
       final policy = PimlicoSponsorshipPolicy.fromJson({
         'sponsorshipPolicyId': 'sp_123',
-        'data': {
-          'name': 'Test',
-          'author': 'Author',
-        },
+        'data': {'name': 'Test', 'author': 'Author'},
       });
 
       expect(policy.sponsorshipPolicyId, equals('sp_123'));
@@ -834,10 +810,7 @@ void main() {
     test('PimlicoSponsorshipPolicy toString', () {
       const policy = PimlicoSponsorshipPolicy(
         sponsorshipPolicyId: 'sp_test',
-        data: PimlicoSponsorshipPolicyData(
-          name: 'Test',
-          author: 'Author',
-        ),
+        data: PimlicoSponsorshipPolicyData(name: 'Test', author: 'Author'),
       );
       expect(policy.toString(), equals('PimlicoSponsorshipPolicy(sp_test)'));
     });

--- a/packages/permissionless/test/clients/public/public_client_test.dart
+++ b/packages/permissionless/test/clients/public/public_client_test.dart
@@ -19,11 +19,7 @@ void main() {
         capturedRequests.add(body);
         final response = responseFactory(body);
         return http.Response(
-          jsonEncode({
-            'jsonrpc': '2.0',
-            'id': body['id'],
-            'result': response,
-          }),
+          jsonEncode({'jsonrpc': '2.0', 'id': body['id'], 'result': response}),
           200,
         );
       });
@@ -430,35 +426,37 @@ void main() {
         );
       });
 
-      test('throws PublicRpcError for non-SenderAddressResult revert',
-          () async {
-        final mockClient = MockClient(
-          (request) async => http.Response(
-            jsonEncode({
-              'jsonrpc': '2.0',
-              'id': 1,
-              'error': {
-                'code': -32000,
-                'message': 'execution reverted: invalid initCode',
-                'data': '0x08c379a0',
-              },
-            }),
-            200,
-          ),
-        );
-        final client = createPublicClient(
-          url: 'http://localhost:8545',
-          httpClient: mockClient,
-        );
+      test(
+        'throws PublicRpcError for non-SenderAddressResult revert',
+        () async {
+          final mockClient = MockClient(
+            (request) async => http.Response(
+              jsonEncode({
+                'jsonrpc': '2.0',
+                'id': 1,
+                'error': {
+                  'code': -32000,
+                  'message': 'execution reverted: invalid initCode',
+                  'data': '0x08c379a0',
+                },
+              }),
+              200,
+            ),
+          );
+          final client = createPublicClient(
+            url: 'http://localhost:8545',
+            httpClient: mockClient,
+          );
 
-        expect(
-          () => client.getSenderAddress(
-            initCode: '0xinvalid',
-            entryPoint: EntryPointAddresses.v07,
-          ),
-          throwsA(isA<PublicRpcError>()),
-        );
-      });
+          expect(
+            () => client.getSenderAddress(
+              initCode: '0xinvalid',
+              entryPoint: EntryPointAddresses.v07,
+            ),
+            throwsA(isA<PublicRpcError>()),
+          );
+        },
+      );
 
       test('encodes initCode correctly in call data', () async {
         String? capturedData;
@@ -547,10 +545,7 @@ void main() {
     });
 
     test('formats error without data', () {
-      const error = PublicRpcError(
-        code: -32602,
-        message: 'invalid params',
-      );
+      const error = PublicRpcError(code: -32602, message: 'invalid params');
 
       expect(
         error.toString(),

--- a/packages/permissionless/test/clients/smart_account/smart_account_client_test.dart
+++ b/packages/permissionless/test/clients/smart_account/smart_account_client_test.dart
@@ -11,8 +11,9 @@ void main() {
         '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
 
     // Mock address for unit tests (avoids RPC calls)
-    final mockAddress =
-        EthereumAddress.fromHex('0x1234567890123456789012345678901234567890');
+    final mockAddress = EthereumAddress.fromHex(
+      '0x1234567890123456789012345678901234567890',
+    );
 
     late SafeSmartAccount account;
     late List<Map<String, dynamic>> bundlerRequests;
@@ -62,11 +63,7 @@ void main() {
           }
 
           return http.Response(
-            jsonEncode({
-              'jsonrpc': '2.0',
-              'id': body['id'],
-              'result': result,
-            }),
+            jsonEncode({'jsonrpc': '2.0', 'id': body['id'], 'result': result}),
             200,
           );
         });
@@ -106,11 +103,7 @@ void main() {
           };
 
           return http.Response(
-            jsonEncode({
-              'jsonrpc': '2.0',
-              'id': body['id'],
-              'result': result,
-            }),
+            jsonEncode({'jsonrpc': '2.0', 'id': body['id'], 'result': result}),
             200,
           );
         });
@@ -133,11 +126,7 @@ void main() {
         }
 
         return http.Response(
-          jsonEncode({
-            'jsonrpc': '2.0',
-            'id': body['id'],
-            'result': result,
-          }),
+          jsonEncode({'jsonrpc': '2.0', 'id': body['id'], 'result': result}),
           200,
         );
       });
@@ -215,53 +204,55 @@ void main() {
         );
       });
 
-      test('applies paymaster stub and final data when paymaster provided',
-          () async {
-        final bundler = createBundlerClient(
-          url: 'http://localhost:3000/rpc',
-          entryPoint: EntryPointAddresses.v07,
-          httpClient: createBundlerMock(),
-        );
-        final paymaster = createPaymasterClient(
-          url: 'http://localhost:3001/rpc',
-          httpClient: createPaymasterMock(),
-        );
+      test(
+        'applies paymaster stub and final data when paymaster provided',
+        () async {
+          final bundler = createBundlerClient(
+            url: 'http://localhost:3000/rpc',
+            entryPoint: EntryPointAddresses.v07,
+            httpClient: createBundlerMock(),
+          );
+          final paymaster = createPaymasterClient(
+            url: 'http://localhost:3001/rpc',
+            httpClient: createPaymasterMock(),
+          );
 
-        final client = SmartAccountClient(
-          account: account,
-          bundler: bundler,
-          paymaster: paymaster,
-          publicClient: createPublicClientMock(),
-        );
+          final client = SmartAccountClient(
+            account: account,
+            bundler: bundler,
+            paymaster: paymaster,
+            publicClient: createPublicClientMock(),
+          );
 
-        final userOp = await client.prepareUserOperation(
-          calls: [
-            Call(
-              to: EthereumAddress.fromHex(
-                '0x1234567890123456789012345678901234567890',
+          final userOp = await client.prepareUserOperation(
+            calls: [
+              Call(
+                to: EthereumAddress.fromHex(
+                  '0x1234567890123456789012345678901234567890',
+                ),
+                value: BigInt.zero,
               ),
-              value: BigInt.zero,
-            ),
-          ],
-          maxFeePerGas: BigInt.from(1000000000),
-          maxPriorityFeePerGas: BigInt.from(1000000000),
-        );
+            ],
+            maxFeePerGas: BigInt.from(1000000000),
+            maxPriorityFeePerGas: BigInt.from(1000000000),
+          );
 
-        // Check paymaster data was applied
-        expect(
-          userOp.paymaster?.hex,
-          equals('0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
-        );
-        expect(userOp.paymasterData, equals('0xfedcba9876543210'));
+          // Check paymaster data was applied
+          expect(
+            userOp.paymaster?.hex,
+            equals('0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
+          );
+          expect(userOp.paymasterData, equals('0xfedcba9876543210'));
 
-        // Check both paymaster calls were made (stub + final)
-        expect(paymasterRequests.length, equals(2));
-        expect(
-          paymasterRequests[0]['method'],
-          equals('pm_getPaymasterStubData'),
-        );
-        expect(paymasterRequests[1]['method'], equals('pm_getPaymasterData'));
-      });
+          // Check both paymaster calls were made (stub + final)
+          expect(paymasterRequests.length, equals(2));
+          expect(
+            paymasterRequests[0]['method'],
+            equals('pm_getPaymasterStubData'),
+          );
+          expect(paymasterRequests[1]['method'], equals('pm_getPaymasterData'));
+        },
+      );
 
       test('skips final paymaster call when isFinal is true', () async {
         final bundler = createBundlerClient(
@@ -338,11 +329,7 @@ void main() {
           }
 
           return http.Response(
-            jsonEncode({
-              'jsonrpc': '2.0',
-              'id': body['id'],
-              'result': result,
-            }),
+            jsonEncode({'jsonrpc': '2.0', 'id': body['id'], 'result': result}),
             200,
           );
         });
@@ -444,10 +431,7 @@ void main() {
         final hash = await client.sendPreparedUserOperation(userOp);
 
         expect(hash, equals('0xabcdef1234567890'));
-        expect(
-          bundlerRequests.last['method'],
-          equals('eth_sendUserOperation'),
-        );
+        expect(bundlerRequests.last['method'], equals('eth_sendUserOperation'));
       });
     });
 
@@ -518,8 +502,9 @@ void main() {
           ],
           maxFeePerGas: BigInt.from(1000000000),
           maxPriorityFeePerGas: BigInt.from(1000000000),
-          paymasterContext:
-              const PaymasterContext(sponsorshipPolicyId: 'policy-123'),
+          paymasterContext: const PaymasterContext(
+            sponsorshipPolicyId: 'policy-123',
+          ),
         );
 
         // Check context was passed to paymaster
@@ -580,8 +565,9 @@ void main() {
     test('SafeSmartAccount implements SmartAccount', () {
       const testPrivateKey =
           '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
-      final mockAddress =
-          EthereumAddress.fromHex('0x1234567890123456789012345678901234567890');
+      final mockAddress = EthereumAddress.fromHex(
+        '0x1234567890123456789012345678901234567890',
+      );
 
       final account = createSafeSmartAccount(
         owners: [PrivateKeyOwner(testPrivateKey)],

--- a/packages/permissionless/test/constants/entry_point_test.dart
+++ b/packages/permissionless/test/constants/entry_point_test.dart
@@ -1,0 +1,48 @@
+import 'package:permissionless/permissionless.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('EntryPointAddresses', () {
+    test('exposes official EntryPoint addresses', () {
+      expect(
+        EntryPointAddresses.v06.hex.toLowerCase(),
+        equals('0x5ff137d4b0fdcd49dca30c7cf57e578a026d2789'),
+      );
+      expect(
+        EntryPointAddresses.v07.hex.toLowerCase(),
+        equals('0x0000000071727de22e5e9d8baf0edac6f37da032'),
+      );
+      expect(
+        EntryPointAddresses.v08.hex.toLowerCase(),
+        equals('0x4337084d9e255ff0702461cf8895ce9e3b5ff108'),
+      );
+      expect(
+        EntryPointAddresses.v09.hex.toLowerCase(),
+        equals('0x433709009b8330fda32311df1c2afa402ed8d009'),
+      );
+    });
+
+    test('maps EntryPoint versions to addresses', () {
+      expect(
+        EntryPointAddresses.fromVersion(EntryPointVersion.v06),
+        equals(EntryPointAddresses.v06),
+      );
+      expect(
+        EntryPointAddresses.fromVersion(EntryPointVersion.v07),
+        equals(EntryPointAddresses.v07),
+      );
+      expect(
+        EntryPointAddresses.fromVersion(EntryPointVersion.v08),
+        equals(EntryPointAddresses.v08),
+      );
+      expect(
+        EntryPointAddresses.fromVersion(EntryPointVersion.v09),
+        equals(EntryPointAddresses.v09),
+      );
+    });
+
+    test('exposes EntryPoint v0.9 version value', () {
+      expect(EntryPointVersion.v09.value, equals('0.9'));
+    });
+  });
+}

--- a/packages/permissionless/test/constants/entry_point_test.dart
+++ b/packages/permissionless/test/constants/entry_point_test.dart
@@ -1,0 +1,32 @@
+import 'package:permissionless/permissionless.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('EntryPointAddresses', () {
+    test('maps all supported EntryPoint versions', () {
+      expect(
+        EntryPointAddresses.fromVersion(EntryPointVersion.v06),
+        equals(EntryPointAddresses.v06),
+      );
+      expect(
+        EntryPointAddresses.fromVersion(EntryPointVersion.v07),
+        equals(EntryPointAddresses.v07),
+      );
+      expect(
+        EntryPointAddresses.fromVersion(EntryPointVersion.v08),
+        equals(EntryPointAddresses.v08),
+      );
+      expect(
+        EntryPointAddresses.fromVersion(EntryPointVersion.v09),
+        equals(EntryPointAddresses.v09),
+      );
+    });
+
+    test('has official v0.9 EntryPoint address', () {
+      expect(
+        EntryPointAddresses.v09.hex.toLowerCase(),
+        equals('0x433709009b8330fda32311df1c2afa402ed8d009'),
+      );
+    });
+  });
+}

--- a/packages/permissionless/test/constants/entry_point_test.dart
+++ b/packages/permissionless/test/constants/entry_point_test.dart
@@ -1,0 +1,38 @@
+import 'package:permissionless/permissionless.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('EntryPointAddresses', () {
+    test('maps EntryPoint v0.6', () {
+      expect(
+        EntryPointAddresses.fromVersion(EntryPointVersion.v06),
+        equals(EntryPointAddresses.v06),
+      );
+    });
+
+    test('maps EntryPoint v0.7', () {
+      expect(
+        EntryPointAddresses.fromVersion(EntryPointVersion.v07),
+        equals(EntryPointAddresses.v07),
+      );
+    });
+
+    test('maps EntryPoint v0.8', () {
+      expect(
+        EntryPointAddresses.fromVersion(EntryPointVersion.v08),
+        equals(EntryPointAddresses.v08),
+      );
+    });
+
+    test('maps EntryPoint v0.9', () {
+      expect(
+        EntryPointAddresses.v09.hex.toLowerCase(),
+        equals('0x433709009b8330fda32311df1c2afa402ed8d009'),
+      );
+      expect(
+        EntryPointAddresses.fromVersion(EntryPointVersion.v09),
+        equals(EntryPointAddresses.v09),
+      );
+    });
+  });
+}

--- a/packages/permissionless/test/integration/accounts/address_calculation_test.dart
+++ b/packages/permissionless/test/integration/accounts/address_calculation_test.dart
@@ -101,8 +101,9 @@ void main() {
             );
 
             try {
-              final isDeployed =
-                  await client.isDeployed(addresses.safeProxyFactoryAddress);
+              final isDeployed = await client.isDeployed(
+                addresses.safeProxyFactoryAddress,
+              );
               expect(isDeployed, isTrue);
             } finally {
               client.close();
@@ -125,8 +126,9 @@ void main() {
             );
 
             try {
-              final isDeployed =
-                  await client.isDeployed(addresses.safeSingletonAddress);
+              final isDeployed = await client.isDeployed(
+                addresses.safeSingletonAddress,
+              );
               expect(isDeployed, isTrue);
             } finally {
               client.close();

--- a/packages/permissionless/test/integration/config/test_config.dart
+++ b/packages/permissionless/test/integration/config/test_config.dart
@@ -8,6 +8,8 @@ import 'package:permissionless/permissionless.dart';
 /// - `PIMLICO_API_KEY`: Required for bundler/paymaster access
 /// - `TEST_PRIVATE_KEY`: Optional, for funded account tests
 /// - `FUNDED_ACCOUNT_ADDRESS`: Optional, pre-computed address of funded account
+/// - `SEPOLIA_RPC_URL`: Required for live Sepolia v0.9 EIP-7702 tests
+/// - `PIMLICO_SPONSORSHIP_POLICY_ID`: Required for sponsored live v0.9 tests
 class TestConfig {
   TestConfig._();
 
@@ -16,6 +18,13 @@ class TestConfig {
 
   /// Private key for funded tests (optional).
   static String? get testPrivateKey => Platform.environment['TEST_PRIVATE_KEY'];
+
+  /// Sepolia RPC URL for live v0.9 EIP-7702 tests.
+  static String? get sepoliaRpcUrl => Platform.environment['SEPOLIA_RPC_URL'];
+
+  /// Pimlico sponsorship policy ID for sponsored live v0.9 tests.
+  static String? get pimlicoSponsorshipPolicyId =>
+      Platform.environment['PIMLICO_SPONSORSHIP_POLICY_ID'];
 
   /// Pre-funded account address (optional).
   static String? get fundedAccountAddress =>
@@ -31,6 +40,20 @@ class TestConfig {
       testPrivateKey!.isNotEmpty &&
       fundedAccountAddress != null;
 
+  /// Whether the live Sepolia v0.9 test can run its base flow.
+  static bool get hasLiveV09BaseEnv =>
+      hasApiKeys &&
+      testPrivateKey != null &&
+      testPrivateKey!.isNotEmpty &&
+      sepoliaRpcUrl != null &&
+      sepoliaRpcUrl!.isNotEmpty;
+
+  /// Whether the live Sepolia v0.9 test can run its sponsored flow.
+  static bool get hasLiveV09SponsoredEnv =>
+      hasLiveV09BaseEnv &&
+      pimlicoSponsorshipPolicyId != null &&
+      pimlicoSponsorshipPolicyId!.isNotEmpty;
+
   /// Skip message for missing API keys.
   static const String skipNoApiKey =
       'Skipping: PIMLICO_API_KEY environment variable not set';
@@ -38,6 +61,16 @@ class TestConfig {
   /// Skip message for missing funded account.
   static const String skipNoFundedAccount =
       'Skipping: TEST_PRIVATE_KEY and FUNDED_ACCOUNT_ADDRESS not set';
+
+  /// Skip message for missing live Sepolia v0.9 base environment.
+  static const String skipNoLiveV09BaseEnv =
+      'Skipping: PIMLICO_API_KEY, TEST_PRIVATE_KEY, and SEPOLIA_RPC_URL '
+      'environment variables are required for live Sepolia v0.9 tests';
+
+  /// Skip message for missing live Sepolia v0.9 sponsorship policy.
+  static const String skipNoLiveV09SponsoredEnv =
+      'Skipping sponsored path: PIMLICO_SPONSORSHIP_POLICY_ID environment '
+      'variable not set';
 
   /// Well-known test private key (Foundry/Hardhat account 0).
   /// DO NOT use in production!
@@ -94,4 +127,7 @@ enum TestChain {
 
   /// EntryPoint v0.7 address (same across all chains).
   EthereumAddress get entryPointV07 => EntryPointAddresses.v07;
+
+  /// EntryPoint v0.9 address (same across all chains).
+  EthereumAddress get entryPointV09 => EntryPointAddresses.v09;
 }

--- a/packages/permissionless/test/integration/config/test_utils.dart
+++ b/packages/permissionless/test/integration/config/test_utils.dart
@@ -16,6 +16,24 @@ void requireFundedAccount() {
   }
 }
 
+/// Skips the current test if the live Sepolia v0.9 base env is not configured.
+void requireLiveV09BaseEnv() {
+  if (!TestConfig.hasLiveV09BaseEnv) {
+    markTestSkipped(TestConfig.skipNoLiveV09BaseEnv);
+  }
+}
+
+/// Skips the current test if live v0.9 sponsorship env is not configured.
+void requireLiveV09SponsoredEnv() {
+  if (!TestConfig.hasLiveV09BaseEnv) {
+    markTestSkipped(TestConfig.skipNoLiveV09BaseEnv);
+    return;
+  }
+  if (!TestConfig.hasLiveV09SponsoredEnv) {
+    markTestSkipped(TestConfig.skipNoLiveV09SponsoredEnv);
+  }
+}
+
 /// Retry wrapper for flaky network tests.
 ///
 /// Retries the action up to [maxAttempts] times with [delay] between attempts.

--- a/packages/permissionless/test/integration/e2e/eip7702_v09_pimlico_sepolia_live_test.dart
+++ b/packages/permissionless/test/integration/e2e/eip7702_v09_pimlico_sepolia_live_test.dart
@@ -1,0 +1,286 @@
+@Tags(['integration', 'funded'])
+library;
+
+import 'package:permissionless/permissionless.dart';
+import 'package:test/test.dart';
+
+import '../config/test_config.dart';
+import '../config/test_utils.dart';
+
+/// Live Pimlico Sepolia coverage for EntryPoint v0.9 + Simple7702Account.
+///
+/// Required base environment:
+/// - PIMLICO_API_KEY
+/// - TEST_PRIVATE_KEY
+/// - SEPOLIA_RPC_URL
+///
+/// Sponsored path additionally requires:
+/// - PIMLICO_SPONSORSHIP_POLICY_ID
+void main() {
+  group('Pimlico Sepolia Simple7702 v0.9 live flow', () {
+    test(
+      'self-funded prepare/sign/submit/receipt succeeds',
+      () async {
+        if (!TestConfig.hasLiveV09BaseEnv) {
+          requireLiveV09BaseEnv();
+          return;
+        }
+
+        final clients = _createClients();
+        try {
+          await _runLiveV09Flow(
+            clients: clients,
+            paymasterContext: null,
+            requiresNativeBalance: true,
+          );
+        } finally {
+          clients.close();
+        }
+      },
+      timeout: const Timeout(TestTimeouts.e2eFlow),
+    );
+
+    test(
+      'sponsored prepare/sign/submit/receipt succeeds',
+      () async {
+        if (!TestConfig.hasLiveV09SponsoredEnv) {
+          requireLiveV09SponsoredEnv();
+          return;
+        }
+
+        final clients = _createClients(withPaymaster: true);
+        try {
+          await _runLiveV09Flow(
+            clients: clients,
+            paymasterContext: PaymasterContext(
+              sponsorshipPolicyId: TestConfig.pimlicoSponsorshipPolicyId!,
+            ),
+            requiresNativeBalance: false,
+          );
+        } finally {
+          clients.close();
+        }
+      },
+      timeout: const Timeout(TestTimeouts.e2eFlow),
+    );
+  });
+}
+
+_LiveV09Clients _createClients({bool withPaymaster = false}) {
+  const chain = TestChain.sepolia;
+  final owner = PrivateKeyEip7702Owner(TestConfig.testPrivateKey!);
+  final publicClient = createPublicClient(
+    url: TestConfig.sepoliaRpcUrl!,
+    timeout: TestTimeouts.longNetwork,
+  );
+  final bundler = createPimlicoClient(
+    url: chain.pimlicoUrl,
+    entryPoint: EntryPointAddresses.v09,
+    timeout: TestTimeouts.longNetwork,
+  );
+  final paymaster = withPaymaster
+      ? createPaymasterClient(
+          url: chain.pimlicoUrl,
+          timeout: TestTimeouts.longNetwork,
+        )
+      : null;
+  final account = createEip7702SimpleSmartAccount(
+    owner: owner,
+    chainId: chain.chainIdBigInt,
+    publicClient: publicClient,
+    entryPointVersion: EntryPointVersion.v09,
+  );
+
+  return _LiveV09Clients(
+    owner: owner,
+    publicClient: publicClient,
+    bundler: bundler,
+    paymaster: paymaster,
+    account: account,
+  );
+}
+
+Future<void> _runLiveV09Flow({
+  required _LiveV09Clients clients,
+  required PaymasterContext? paymasterContext,
+  required bool requiresNativeBalance,
+}) async {
+  const chain = TestChain.sepolia;
+  final accountAddress = await clients.account.getAddress();
+
+  expect(accountAddress, equals(clients.owner.address));
+  expect(chain.entryPointV09, equals(EntryPointAddresses.v09));
+  expect(clients.account.entryPointVersion, equals(EntryPointVersion.v09));
+  expect(clients.account.entryPoint, equals(EntryPointAddresses.v09));
+  expect(
+    clients.account.accountLogicAddress,
+    equals(Simple7702AccountAddresses.v09),
+  );
+  expect(
+    EntryPointAddresses.v09.hex.toLowerCase(),
+    equals('0x433709009b8330fda32311df1c2afa402ed8d009'),
+  );
+  expect(
+    Simple7702AccountAddresses.v09.hex.toLowerCase(),
+    equals('0xa46cc63ebf4bd77888aa327837d20b23a63a56b5'),
+  );
+
+  final delegation = await _assertSupportedDelegation(
+    clients.publicClient,
+    accountAddress,
+  );
+  if (delegation == _DelegationState.undelegated) {
+    final eoaNonce = await clients.publicClient.getTransactionCount(
+      accountAddress,
+    );
+    final authorization = await clients.account.getAuthorization(
+      nonce: eoaNonce,
+    );
+
+    expect(authorization.chainId, equals(chain.chainIdBigInt));
+    expect(authorization.address, equals(Simple7702AccountAddresses.v09));
+    expect(authorization.nonce, equals(eoaNonce));
+  }
+
+  if (requiresNativeBalance) {
+    final balance = await clients.publicClient.getBalance(accountAddress);
+    if (balance == BigInt.zero) {
+      fail(
+        'Setup error: TEST_PRIVATE_KEY EOA ${accountAddress.checksummed} '
+        'has zero Sepolia ETH. Fund it before running the self-funded '
+        'EntryPoint v0.9 live flow.',
+      );
+    }
+  }
+
+  final smartAccountClient = createSmartAccountClient(
+    account: clients.account,
+    bundler: clients.bundler,
+    publicClient: clients.publicClient,
+    paymaster: clients.paymaster,
+  );
+  final gasPrices = await clients.bundler.getUserOperationGasPrice();
+  final call = Call(to: accountAddress, value: BigInt.zero, data: '0x');
+
+  final prepared = await smartAccountClient.prepareUserOperationWithAuth(
+    calls: [call],
+    maxFeePerGas: gasPrices.fast.maxFeePerGas,
+    maxPriorityFeePerGas: gasPrices.fast.maxPriorityFeePerGas,
+    paymasterContext: paymasterContext,
+  );
+
+  expect(prepared.userOp.sender, equals(accountAddress));
+  expect(prepared.userOp.callData, isNot(equals('0x')));
+  expect(prepared.userOp.callGasLimit, greaterThanBigInt(BigInt.zero));
+  expect(prepared.userOp.verificationGasLimit, greaterThanBigInt(BigInt.zero));
+  expect(prepared.userOp.preVerificationGas, greaterThanBigInt(BigInt.zero));
+
+  if (delegation == _DelegationState.undelegated) {
+    expect(prepared.authorization, isNotNull);
+    expect(
+      prepared.authorization!.address,
+      equals(Simple7702AccountAddresses.v09),
+    );
+  } else {
+    expect(prepared.authorization, isNull);
+  }
+
+  if (paymasterContext == null) {
+    expect(prepared.userOp.paymaster, isNull);
+  } else {
+    expect(prepared.userOp.paymaster, isNotNull);
+    expect(prepared.userOp.paymasterData, isNotNull);
+  }
+
+  final signed = await smartAccountClient.signUserOperation(prepared.userOp);
+  expect(signed.signature, startsWith('0x'));
+  expect(signed.signature, isNot(equals(prepared.userOp.signature)));
+
+  final hash = await smartAccountClient.sendPreparedUserOperationWithAuth(
+    signed,
+    prepared.authorization,
+  );
+  expect(hash, startsWith('0x'));
+  expect(hash.length, equals(66));
+
+  final receipt = await smartAccountClient.waitForReceipt(
+    hash,
+    timeout: TestTimeouts.e2eFlow,
+  );
+  expect(receipt, isNotNull);
+  expect(receipt!.success, isTrue);
+  expect(receipt.receipt?.transactionHash, startsWith('0x'));
+}
+
+Future<_DelegationState> _assertSupportedDelegation(
+  PublicClient publicClient,
+  EthereumAddress accountAddress,
+) async {
+  final code = await publicClient.getCode(accountAddress);
+  final lowerCode = code.toLowerCase();
+  if (lowerCode == '0x') {
+    return _DelegationState.undelegated;
+  }
+
+  final stripped = Hex.strip0x(lowerCode);
+  if (!stripped.startsWith(_eip7702DelegationPrefix)) {
+    fail(
+      'Setup error: TEST_PRIVATE_KEY EOA ${accountAddress.checksummed} '
+      'already has non-EIP-7702 code ${_previewHex(lowerCode)}. Use a fresh '
+      'Sepolia EOA or one delegated to Simple7702Account v0.9 '
+      '(${Simple7702AccountAddresses.v09.checksummed}).',
+    );
+  }
+
+  if (stripped.length < _eip7702DelegationPrefix.length + 40) {
+    fail(
+      'Setup error: TEST_PRIVATE_KEY EOA ${accountAddress.checksummed} '
+      'has malformed EIP-7702 delegation code ${_previewHex(lowerCode)}.',
+    );
+  }
+
+  final delegatedTo = EthereumAddress.fromHex(
+    '0x${stripped.substring(_eip7702DelegationPrefix.length, _eip7702DelegationPrefix.length + 40)}',
+  );
+  if (delegatedTo.hex.toLowerCase() !=
+      Simple7702AccountAddresses.v09.hex.toLowerCase()) {
+    fail(
+      'Setup error: TEST_PRIVATE_KEY EOA ${accountAddress.checksummed} '
+      'is already delegated to ${delegatedTo.checksummed}. Expected '
+      'Simple7702Account v0.9 '
+      '(${Simple7702AccountAddresses.v09.checksummed}). Use a fresh Sepolia '
+      'EOA or clear the incompatible delegation before running this test.',
+    );
+  }
+
+  return _DelegationState.delegatedToSimple7702V09;
+}
+
+String _previewHex(String value) =>
+    value.length <= 66 ? value : '${value.substring(0, 66)}...';
+
+const _eip7702DelegationPrefix = 'ef0100';
+
+enum _DelegationState { undelegated, delegatedToSimple7702V09 }
+
+class _LiveV09Clients {
+  _LiveV09Clients({
+    required this.owner,
+    required this.publicClient,
+    required this.bundler,
+    required this.paymaster,
+    required this.account,
+  });
+
+  final PrivateKeyEip7702Owner owner;
+  final PublicClient publicClient;
+  final PimlicoClient bundler;
+  final PaymasterClient? paymaster;
+  final Eip7702SimpleSmartAccount account;
+
+  void close() {
+    bundler.close();
+    paymaster?.close();
+    publicClient.close();
+  }
+}

--- a/packages/permissionless/test/integration/e2e/user_operation_flow_test.dart
+++ b/packages/permissionless/test/integration/e2e/user_operation_flow_test.dart
@@ -142,13 +142,7 @@ void main() {
 
             // 3. Send a minimal transaction (0 ETH to self)
             final hash = await smartAccountClient!.sendUserOperation(
-              calls: [
-                Call(
-                  to: address,
-                  value: BigInt.zero,
-                  data: '0x',
-                ),
-              ],
+              calls: [Call(to: address, value: BigInt.zero, data: '0x')],
               maxFeePerGas: gasPrices.fast.maxFeePerGas,
               maxPriorityFeePerGas: gasPrices.fast.maxPriorityFeePerGas,
             );
@@ -208,11 +202,7 @@ void main() {
             // Send batch of 2 calls
             final hash = await smartAccountClient!.sendUserOperation(
               calls: [
-                Call(
-                  to: address,
-                  value: BigInt.zero,
-                  data: '0x',
-                ),
+                Call(to: address, value: BigInt.zero, data: '0x'),
                 Call(
                   to: EthereumAddress.fromHex(
                     '0x0000000000000000000000000000000000000001',

--- a/packages/permissionless/test/integration/gas/gas_estimation_test.dart
+++ b/packages/permissionless/test/integration/gas/gas_estimation_test.dart
@@ -122,10 +122,7 @@ void main() {
                 estimate.verificationGasLimit,
                 greaterThanBigInt(BigInt.zero),
               );
-              expect(
-                estimate.callGasLimit,
-                greaterThanBigInt(BigInt.zero),
-              );
+              expect(estimate.callGasLimit, greaterThanBigInt(BigInt.zero));
 
               // Verification gas for Safe is typically higher due to module
               expect(
@@ -178,18 +175,16 @@ void main() {
               final estimate = await bundler!.estimateUserOperationGas(userOp);
 
               // Apply conservative multipliers
-              final buffered =
-                  estimate.withMultipliers(GasMultipliers.conservative);
+              final buffered = estimate.withMultipliers(
+                GasMultipliers.conservative,
+              );
 
               // Buffered values should be larger
               expect(
                 buffered.verificationGasLimit,
                 greaterThan(estimate.verificationGasLimit),
               );
-              expect(
-                buffered.callGasLimit,
-                greaterThan(estimate.callGasLimit),
-              );
+              expect(buffered.callGasLimit, greaterThan(estimate.callGasLimit));
             },
             timeout: const Timeout(TestTimeouts.mediumNetwork),
           );
@@ -247,10 +242,7 @@ void main() {
                 estimate.verificationGasLimit,
                 greaterThanBigInt(BigInt.zero),
               );
-              expect(
-                estimate.callGasLimit,
-                greaterThanBigInt(BigInt.zero),
-              );
+              expect(estimate.callGasLimit, greaterThanBigInt(BigInt.zero));
             },
             timeout: const Timeout(TestTimeouts.mediumNetwork),
           );
@@ -362,9 +354,7 @@ void main() {
             // Verify calculation
             expect(
               costEstimate.maxGasCost,
-              equals(
-                costEstimate.totalGasLimit * gasPrices.fast.maxFeePerGas,
-              ),
+              equals(costEstimate.totalGasLimit * gasPrices.fast.maxFeePerGas),
             );
 
             // Max cost should be reasonable (less than 1 ETH for a simple tx)

--- a/packages/permissionless/test/integration/pimlico/pimlico_integration_test.dart
+++ b/packages/permissionless/test/integration/pimlico/pimlico_integration_test.dart
@@ -138,8 +138,9 @@ void main() {
             // Gas prices should be in a reasonable range
             // L2s like Base can have very low gas (~0.001 gwei = 1,000,000 wei)
             // L1s like Sepolia typically have higher gas (1+ gwei)
-            final minGas =
-                BigInt.from(1000); // 0.000001 gwei (very low for L2s)
+            final minGas = BigInt.from(
+              1000,
+            ); // 0.000001 gwei (very low for L2s)
             final maxGas = BigInt.from(10000000000000); // 10000 gwei
 
             expect(prices.standard.maxFeePerGas, greaterThanBigInt(minGas));

--- a/packages/permissionless/test/integration/public/public_integration_test.dart
+++ b/packages/permissionless/test/integration/public/public_integration_test.dart
@@ -102,8 +102,9 @@ void main() {
         test(
           'getCode returns code for SimpleAccount Factory v0.7',
           () async {
-            final code =
-                await client.getCode(SimpleAccountFactoryAddresses.v07);
+            final code = await client.getCode(
+              SimpleAccountFactoryAddresses.v07,
+            );
 
             expect(code, isNot(equals('0x')));
             expect(code.length, greaterThan(100));

--- a/packages/permissionless/test/types/address_test.dart
+++ b/packages/permissionless/test/types/address_test.dart
@@ -19,16 +19,14 @@ void main() {
       });
 
       test('creates from address without 0x prefix', () {
-        final addr =
-            EthereumAddress.fromHex('d8da6bf26964af9d7eed9e03e53415d37aa96045');
+        final addr = EthereumAddress.fromHex(
+          'd8da6bf26964af9d7eed9e03e53415d37aa96045',
+        );
         expect(addr.hex, equals('0xd8da6bf26964af9d7eed9e03e53415d37aa96045'));
       });
 
       test('throws on invalid address length', () {
-        expect(
-          () => EthereumAddress.fromHex('0x1234'),
-          throwsArgumentError,
-        );
+        expect(() => EthereumAddress.fromHex('0x1234'), throwsArgumentError);
       });
 
       test('throws on invalid characters', () {
@@ -166,9 +164,7 @@ void main() {
     group('isValidAddress', () {
       test('validates correct address', () {
         expect(
-          isValidEthereumAddress(
-            '0xd8da6bf26964af9d7eed9e03e53415d37aa96045',
-          ),
+          isValidEthereumAddress('0xd8da6bf26964af9d7eed9e03e53415d37aa96045'),
           isTrue,
         );
       });
@@ -179,9 +175,7 @@ void main() {
 
       test('rejects invalid characters', () {
         expect(
-          isValidEthereumAddress(
-            '0xgggggggggggggggggggggggggggggggggggggggg',
-          ),
+          isValidEthereumAddress('0xgggggggggggggggggggggggggggggggggggggggg'),
           isFalse,
         );
       });

--- a/packages/permissionless/test/utils/erc20_test.dart
+++ b/packages/permissionless/test/utils/erc20_test.dart
@@ -31,10 +31,12 @@ void main() {
 
   group('encodeErc20Approve', () {
     test('encodes approve call correctly', () {
-      final token =
-          EthereumAddress.fromHex('0x1234567890123456789012345678901234567890');
-      final spender =
-          EthereumAddress.fromHex('0xabcdefabcdefabcdefabcdefabcdefabcdefabcd');
+      final token = EthereumAddress.fromHex(
+        '0x1234567890123456789012345678901234567890',
+      );
+      final spender = EthereumAddress.fromHex(
+        '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
+      );
       final amount = BigInt.from(1000000);
 
       final call = encodeErc20Approve(
@@ -55,10 +57,12 @@ void main() {
     });
 
     test('encodes maxUint256 approval', () {
-      final token =
-          EthereumAddress.fromHex('0x1234567890123456789012345678901234567890');
-      final spender =
-          EthereumAddress.fromHex('0xabcdefabcdefabcdefabcdefabcdefabcdefabcd');
+      final token = EthereumAddress.fromHex(
+        '0x1234567890123456789012345678901234567890',
+      );
+      final spender = EthereumAddress.fromHex(
+        '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
+      );
 
       final call = encodeErc20Approve(
         token: token,
@@ -76,17 +80,15 @@ void main() {
 
   group('encodeErc20Transfer', () {
     test('encodes transfer call correctly', () {
-      final token =
-          EthereumAddress.fromHex('0x1234567890123456789012345678901234567890');
-      final to =
-          EthereumAddress.fromHex('0xabcdefabcdefabcdefabcdefabcdefabcdefabcd');
+      final token = EthereumAddress.fromHex(
+        '0x1234567890123456789012345678901234567890',
+      );
+      final to = EthereumAddress.fromHex(
+        '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
+      );
       final amount = BigInt.from(1000000);
 
-      final call = encodeErc20Transfer(
-        token: token,
-        to: to,
-        amount: amount,
-      );
+      final call = encodeErc20Transfer(token: token, to: to, amount: amount);
 
       expect(call.to.hex, equals(token.hex));
       expect(call.value, equals(BigInt.zero));
@@ -96,15 +98,14 @@ void main() {
 
   group('encodeErc20AllowanceCall', () {
     test('encodes allowance call correctly', () {
-      final owner =
-          EthereumAddress.fromHex('0x1234567890123456789012345678901234567890');
-      final spender =
-          EthereumAddress.fromHex('0xabcdefabcdefabcdefabcdefabcdefabcdefabcd');
-
-      final callData = encodeErc20AllowanceCall(
-        owner: owner,
-        spender: spender,
+      final owner = EthereumAddress.fromHex(
+        '0x1234567890123456789012345678901234567890',
       );
+      final spender = EthereumAddress.fromHex(
+        '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
+      );
+
+      final callData = encodeErc20AllowanceCall(owner: owner, spender: spender);
 
       expect(callData.substring(0, 10), equals(Erc20Selectors.allowance));
       // selector + address + address = 4 + 32 + 32 = 68 bytes
@@ -114,8 +115,9 @@ void main() {
 
   group('encodeErc20BalanceOfCall', () {
     test('encodes balanceOf call correctly', () {
-      final account =
-          EthereumAddress.fromHex('0x1234567890123456789012345678901234567890');
+      final account = EthereumAddress.fromHex(
+        '0x1234567890123456789012345678901234567890',
+      );
 
       final callData = encodeErc20BalanceOfCall(account: account);
 
@@ -158,10 +160,12 @@ void main() {
 
   group('createPaymasterApprovalCall', () {
     test('creates approval with default maxUint256', () {
-      final token =
-          EthereumAddress.fromHex('0x1234567890123456789012345678901234567890');
-      final paymaster =
-          EthereumAddress.fromHex('0xabcdefabcdefabcdefabcdefabcdefabcdefabcd');
+      final token = EthereumAddress.fromHex(
+        '0x1234567890123456789012345678901234567890',
+      );
+      final paymaster = EthereumAddress.fromHex(
+        '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
+      );
 
       final call = createPaymasterApprovalCall(
         token: token,
@@ -175,10 +179,12 @@ void main() {
     });
 
     test('creates approval with custom amount', () {
-      final token =
-          EthereumAddress.fromHex('0x1234567890123456789012345678901234567890');
-      final paymaster =
-          EthereumAddress.fromHex('0xabcdefabcdefabcdefabcdefabcdefabcdefabcd');
+      final token = EthereumAddress.fromHex(
+        '0x1234567890123456789012345678901234567890',
+      );
+      final paymaster = EthereumAddress.fromHex(
+        '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
+      );
       final amount = BigInt.from(1000000);
 
       final call = createPaymasterApprovalCall(
@@ -203,8 +209,9 @@ void main() {
         ),
         postOpGas: BigInt.from(75000),
         exchangeRate: BigInt.from(10).pow(18), // 1:1 rate for simplicity
-        exchangeRateNativeToUsd:
-            BigInt.from(2000000000), // $2000 with 6 decimals
+        exchangeRateNativeToUsd: BigInt.from(
+          2000000000,
+        ), // $2000 with 6 decimals
       );
 
       final userOp = UserOperationV07(
@@ -234,29 +241,26 @@ void main() {
   // =========================================================================
 
   group('ERC-20 State Override Utilities', () {
-    final tokenAddress =
-        EthereumAddress.fromHex('0x1234567890123456789012345678901234567890');
-    final ownerAddress =
-        EthereumAddress.fromHex('0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
-    final spenderAddress =
-        EthereumAddress.fromHex('0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb');
+    final tokenAddress = EthereumAddress.fromHex(
+      '0x1234567890123456789012345678901234567890',
+    );
+    final ownerAddress = EthereumAddress.fromHex(
+      '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    );
+    final spenderAddress = EthereumAddress.fromHex(
+      '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+    );
 
     group('StateDiff', () {
       test('creates with slot and value', () {
-        final diff = StateDiff(
-          slot: '0x${'00' * 32}',
-          value: '0x${'01' * 32}',
-        );
+        final diff = StateDiff(slot: '0x${'00' * 32}', value: '0x${'01' * 32}');
 
         expect(diff.slot, equals('0x${'00' * 32}'));
         expect(diff.value, equals('0x${'01' * 32}'));
       });
 
       test('toJson returns slot-value map', () {
-        const diff = StateDiff(
-          slot: '0xabc123',
-          value: '0xdef456',
-        );
+        const diff = StateDiff(slot: '0xabc123', value: '0xdef456');
 
         final json = diff.toJson();
         expect(json, equals({'0xabc123': '0xdef456'}));
@@ -280,9 +284,7 @@ void main() {
           balance: BigInt.from(1000),
           nonce: BigInt.from(5),
           code: '0x1234',
-          stateDiff: [
-            const StateDiff(slot: '0xabc', value: '0xdef'),
-          ],
+          stateDiff: [const StateDiff(slot: '0xabc', value: '0xdef')],
         );
 
         expect(override.balance, equals(BigInt.from(1000)));
@@ -345,10 +347,7 @@ void main() {
     group('stateOverridesToJson', () {
       test('converts single override', () {
         final overrides = [
-          StateOverride(
-            address: tokenAddress,
-            balance: BigInt.from(100),
-          ),
+          StateOverride(address: tokenAddress, balance: BigInt.from(100)),
         ];
 
         final json = stateOverridesToJson(overrides);
@@ -359,14 +358,8 @@ void main() {
 
       test('converts multiple overrides', () {
         final overrides = [
-          StateOverride(
-            address: tokenAddress,
-            balance: BigInt.from(100),
-          ),
-          StateOverride(
-            address: ownerAddress,
-            nonce: BigInt.from(10),
-          ),
+          StateOverride(address: tokenAddress, balance: BigInt.from(100)),
+          StateOverride(address: ownerAddress, nonce: BigInt.from(10)),
         ];
 
         final json = stateOverridesToJson(overrides);

--- a/packages/permissionless/test/utils/erc7579_test.dart
+++ b/packages/permissionless/test/utils/erc7579_test.dart
@@ -47,8 +47,9 @@ void main() {
       });
 
       test('encodes delegate call mode correctly', () {
-        final mode =
-            encode7579ExecuteMode(callType: Erc7579CallType.delegateCall);
+        final mode = encode7579ExecuteMode(
+          callType: Erc7579CallType.delegateCall,
+        );
 
         expect(mode.substring(2, 4), equals('ff'));
       });
@@ -143,10 +144,7 @@ void main() {
 
     group('encode7579BatchCallData', () {
       test('throws on empty calls', () {
-        expect(
-          () => encode7579BatchCallData([]),
-          throwsArgumentError,
-        );
+        expect(() => encode7579BatchCallData([]), throwsArgumentError);
       });
 
       test('encodes single call in batch format', () {
@@ -234,10 +232,7 @@ void main() {
 
     group('encode7579ExecuteBatch', () {
       test('throws on empty calls', () {
-        expect(
-          () => encode7579ExecuteBatch([]),
-          throwsArgumentError,
-        );
+        expect(() => encode7579ExecuteBatch([]), throwsArgumentError);
       });
 
       test('optimizes single call to non-batch encoding', () {
@@ -921,8 +916,10 @@ void main() {
       });
 
       test('encodes key and sequence', () {
-        final nonce =
-            encodeNonce(key: BigInt.from(5), sequence: BigInt.from(10));
+        final nonce = encodeNonce(
+          key: BigInt.from(5),
+          sequence: BigInt.from(10),
+        );
         // Expected: (5 << 64) + 10
         expect(nonce, equals((BigInt.from(5) << 64) + BigInt.from(10)));
       });
@@ -931,8 +928,10 @@ void main() {
         final originalKey = BigInt.parse('abcdef123456', radix: 16);
         final originalSequence = BigInt.from(999);
 
-        final encoded =
-            encodeNonce(key: originalKey, sequence: originalSequence);
+        final encoded = encodeNonce(
+          key: originalKey,
+          sequence: originalSequence,
+        );
         final decoded = decodeNonce(encoded);
 
         expect(decoded.key, equals(originalKey));
@@ -1100,10 +1099,7 @@ void main() {
         // Random calldata that doesn't start with execute selector
         const invalidCallData = '0x12345678aabbccdd';
 
-        expect(
-          () => decode7579Calls(invalidCallData),
-          throwsArgumentError,
-        );
+        expect(() => decode7579Calls(invalidCallData), throwsArgumentError);
       });
 
       test('throws for invalid call type', () {
@@ -1122,8 +1118,10 @@ void main() {
 
     group('DecodedNonce', () {
       test('toString returns readable format', () {
-        final decoded =
-            DecodedNonce(key: BigInt.from(5), sequence: BigInt.from(10));
+        final decoded = DecodedNonce(
+          key: BigInt.from(5),
+          sequence: BigInt.from(10),
+        );
         expect(decoded.toString(), contains('key: 5'));
         expect(decoded.toString(), contains('sequence: 10'));
       });

--- a/packages/permissionless/test/utils/gas_test.dart
+++ b/packages/permissionless/test/utils/gas_test.dart
@@ -414,10 +414,7 @@ void main() {
         buffered.verificationGasLimit,
         equals(BigInt.parse('2600000000000')),
       );
-      expect(
-        buffered.callGasLimit,
-        equals(BigInt.parse('3600000000000')),
-      );
+      expect(buffered.callGasLimit, equals(BigInt.parse('3600000000000')));
     });
 
     test('handles fractional multipliers accurately', () {
@@ -455,8 +452,9 @@ void main() {
       const paymasterAndData = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
           'deadbeefcafe';
 
-      final address =
-          getAddressFromInitCodeOrPaymasterAndData(paymasterAndData);
+      final address = getAddressFromInitCodeOrPaymasterAndData(
+        paymasterAndData,
+      );
 
       expect(address, isNotNull);
       expect(
@@ -545,8 +543,9 @@ void main() {
           '00000000000000000000000000000000000000000000000000000000669e8740' // valid after
           'deadbeef'; // signature stub
 
-      final address =
-          getAddressFromInitCodeOrPaymasterAndData(paymasterAndData);
+      final address = getAddressFromInitCodeOrPaymasterAndData(
+        paymasterAndData,
+      );
 
       expect(address, isNotNull);
       expect(

--- a/packages/permissionless/test/utils/message_hash_test.dart
+++ b/packages/permissionless/test/utils/message_hash_test.dart
@@ -63,9 +63,7 @@ void main() {
           chainId: BigInt.from(1),
         ),
         types: {
-          'Message': [
-            const TypedDataField(name: 'content', type: 'string'),
-          ],
+          'Message': [const TypedDataField(name: 'content', type: 'string')],
         },
         primaryType: 'Message',
         message: {'content': 'Hello'},
@@ -173,9 +171,7 @@ void main() {
       const typedData = TypedData(
         domain: TypedDataDomain(name: 'Bool Test', version: '1'),
         types: {
-          'Toggle': [
-            TypedDataField(name: 'enabled', type: 'bool'),
-          ],
+          'Toggle': [TypedDataField(name: 'enabled', type: 'bool')],
         },
         primaryType: 'Toggle',
         message: {'enabled': true},
@@ -190,9 +186,7 @@ void main() {
       const typedData = TypedData(
         domain: TypedDataDomain(name: 'Bytes Test', version: '1'),
         types: {
-          'Hash': [
-            TypedDataField(name: 'value', type: 'bytes32'),
-          ],
+          'Hash': [TypedDataField(name: 'value', type: 'bytes32')],
         },
         primaryType: 'Hash',
         message: {
@@ -287,9 +281,7 @@ void main() {
   group('hashStruct', () {
     test('hashes simple struct', () {
       final types = {
-        'Simple': [
-          const TypedDataField(name: 'value', type: 'uint256'),
-        ],
+        'Simple': [const TypedDataField(name: 'value', type: 'uint256')],
       };
 
       final hash = hashStruct('Simple', {'value': BigInt.from(42)}, types);

--- a/packages/permissionless/test/utils/multisend_test.dart
+++ b/packages/permissionless/test/utils/multisend_test.dart
@@ -44,10 +44,7 @@ void main() {
       });
 
       test('throws on empty calls', () {
-        expect(
-          () => encodeMultiSend([]),
-          throwsArgumentError,
-        );
+        expect(() => encodeMultiSend([]), throwsArgumentError);
       });
 
       test('handles call with data', () {

--- a/packages/permissionless/test/utils/paymaster_signature_test.dart
+++ b/packages/permissionless/test/utils/paymaster_signature_test.dart
@@ -1,0 +1,82 @@
+import 'package:permissionless/permissionless.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('appendPaymasterSignature', () {
+    test('exposes the v0.9 magic value', () {
+      expect(paymasterSignatureMagic, equals('0x22e325a297439656'));
+    });
+
+    test('appends signature size and magic suffix', () {
+      final result = appendPaymasterSignature(
+        paymasterData: '0x1122',
+        paymasterSignature: '0xaabbcc',
+      );
+
+      expect(result, equals('0x1122aabbcc000322e325a297439656'));
+    });
+
+    test('encodes signature size as uint16', () {
+      final signature = '0x${List.filled(256, '12').join()}';
+
+      final result = appendPaymasterSignature(
+        paymasterData: '0x',
+        paymasterSignature: signature,
+      );
+
+      expect(
+        result,
+        equals('${signature}0100${paymasterSignatureMagic.substring(2)}'),
+      );
+    });
+
+    test('preserves existing paymaster data before the suffix', () {
+      final result = appendPaymasterSignature(
+        paymasterData: '0xabcdef1234',
+        paymasterSignature: '0x9876',
+      );
+
+      expect(result, startsWith('0xabcdef1234'));
+      expect(result, equals('0xabcdef12349876000222e325a297439656'));
+    });
+
+    test('rejects empty signatures', () {
+      expect(
+        () => appendPaymasterSignature(
+          paymasterData: '0x',
+          paymasterSignature: '0x',
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('rejects signatures too large for uint16 encoding', () {
+      final signature = '0x${List.filled(65536, '12').join()}';
+
+      expect(
+        () => appendPaymasterSignature(
+          paymasterData: '0x',
+          paymasterSignature: signature,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('rejects invalid hex input', () {
+      expect(
+        () => appendPaymasterSignature(
+          paymasterData: '0xzz',
+          paymasterSignature: '0x12',
+        ),
+        throwsArgumentError,
+      );
+      expect(
+        () => appendPaymasterSignature(
+          paymasterData: '0x',
+          paymasterSignature: '0x123',
+        ),
+        throwsArgumentError,
+      );
+    });
+  });
+}

--- a/packages/permissionless/test/utils/state_override_test.dart
+++ b/packages/permissionless/test/utils/state_override_test.dart
@@ -4,10 +4,12 @@ import 'package:test/test.dart';
 void main() {
   group('erc20BalanceOverride', () {
     test('returns correct structure for valid inputs', () {
-      final token =
-          EthereumAddress.fromHex('0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF');
-      final owner =
-          EthereumAddress.fromHex('0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE');
+      final token = EthereumAddress.fromHex(
+        '0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF',
+      );
+      final owner = EthereumAddress.fromHex(
+        '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
+      );
       final slot = BigInt.one;
       final balance = BigInt.from(1000);
 
@@ -41,10 +43,12 @@ void main() {
     });
 
     test('uses default balance when none provided', () {
-      final token =
-          EthereumAddress.fromHex('0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF');
-      final owner =
-          EthereumAddress.fromHex('0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE');
+      final token = EthereumAddress.fromHex(
+        '0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF',
+      );
+      final owner = EthereumAddress.fromHex(
+        '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
+      );
       final slot = BigInt.one;
 
       final result = erc20BalanceOverride(
@@ -66,10 +70,12 @@ void main() {
     });
 
     test('computes deterministic storage slot', () {
-      final token =
-          EthereumAddress.fromHex('0x1234567890123456789012345678901234567890');
-      final owner =
-          EthereumAddress.fromHex('0x1234567890123456789012345678901234567890');
+      final token = EthereumAddress.fromHex(
+        '0x1234567890123456789012345678901234567890',
+      );
+      final owner = EthereumAddress.fromHex(
+        '0x1234567890123456789012345678901234567890',
+      );
       final slot = BigInt.zero;
 
       final result = erc20BalanceOverride(
@@ -92,12 +98,15 @@ void main() {
     });
 
     test('different owners produce different slots', () {
-      final token =
-          EthereumAddress.fromHex('0x1234567890123456789012345678901234567890');
-      final owner1 =
-          EthereumAddress.fromHex('0x1111111111111111111111111111111111111111');
-      final owner2 =
-          EthereumAddress.fromHex('0x2222222222222222222222222222222222222222');
+      final token = EthereumAddress.fromHex(
+        '0x1234567890123456789012345678901234567890',
+      );
+      final owner1 = EthereumAddress.fromHex(
+        '0x1111111111111111111111111111111111111111',
+      );
+      final owner2 = EthereumAddress.fromHex(
+        '0x2222222222222222222222222222222222222222',
+      );
       final slot = BigInt.zero;
 
       final result1 = erc20BalanceOverride(
@@ -121,12 +130,15 @@ void main() {
 
   group('erc20AllowanceOverride', () {
     test('returns correct structure for valid inputs', () {
-      final token =
-          EthereumAddress.fromHex('0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF');
-      final owner =
-          EthereumAddress.fromHex('0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE');
-      final spender =
-          EthereumAddress.fromHex('0xDDdDddDdDdddDDddDDddDDDDdDdDDdDDdDDDDDDd');
+      final token = EthereumAddress.fromHex(
+        '0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF',
+      );
+      final owner = EthereumAddress.fromHex(
+        '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
+      );
+      final spender = EthereumAddress.fromHex(
+        '0xDDdDddDdDdddDDddDDddDDDDdDdDDdDDdDDDDDDd',
+      );
       final slot = BigInt.one;
       final amount = BigInt.from(100);
 
@@ -161,12 +173,15 @@ void main() {
     });
 
     test('uses default amount when none provided', () {
-      final token =
-          EthereumAddress.fromHex('0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF');
-      final owner =
-          EthereumAddress.fromHex('0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE');
-      final spender =
-          EthereumAddress.fromHex('0xDDdDddDdDdddDDddDDddDDDDdDdDDdDDdDDDDDDd');
+      final token = EthereumAddress.fromHex(
+        '0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF',
+      );
+      final owner = EthereumAddress.fromHex(
+        '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
+      );
+      final spender = EthereumAddress.fromHex(
+        '0xDDdDddDdDdddDDddDDddDDDDdDdDDdDDdDDDDDDd',
+      );
       final slot = BigInt.one;
 
       final result = erc20AllowanceOverride(
@@ -189,12 +204,15 @@ void main() {
     });
 
     test('computes deterministic storage slot for nested mapping', () {
-      final token =
-          EthereumAddress.fromHex('0x1234567890123456789012345678901234567890');
-      final owner =
-          EthereumAddress.fromHex('0x1111111111111111111111111111111111111111');
-      final spender =
-          EthereumAddress.fromHex('0x2222222222222222222222222222222222222222');
+      final token = EthereumAddress.fromHex(
+        '0x1234567890123456789012345678901234567890',
+      );
+      final owner = EthereumAddress.fromHex(
+        '0x1111111111111111111111111111111111111111',
+      );
+      final spender = EthereumAddress.fromHex(
+        '0x2222222222222222222222222222222222222222',
+      );
       final slot = BigInt.one;
 
       final result = erc20AllowanceOverride(
@@ -219,14 +237,18 @@ void main() {
     });
 
     test('different spenders produce different slots', () {
-      final token =
-          EthereumAddress.fromHex('0x1234567890123456789012345678901234567890');
-      final owner =
-          EthereumAddress.fromHex('0x1111111111111111111111111111111111111111');
-      final spender1 =
-          EthereumAddress.fromHex('0x2222222222222222222222222222222222222222');
-      final spender2 =
-          EthereumAddress.fromHex('0x3333333333333333333333333333333333333333');
+      final token = EthereumAddress.fromHex(
+        '0x1234567890123456789012345678901234567890',
+      );
+      final owner = EthereumAddress.fromHex(
+        '0x1111111111111111111111111111111111111111',
+      );
+      final spender1 = EthereumAddress.fromHex(
+        '0x2222222222222222222222222222222222222222',
+      );
+      final spender2 = EthereumAddress.fromHex(
+        '0x3333333333333333333333333333333333333333',
+      );
       final slot = BigInt.one;
 
       final result1 = erc20AllowanceOverride(
@@ -250,10 +272,12 @@ void main() {
     });
 
     test('allowance slot differs from balance slot', () {
-      final token =
-          EthereumAddress.fromHex('0x1234567890123456789012345678901234567890');
-      final owner =
-          EthereumAddress.fromHex('0x1111111111111111111111111111111111111111');
+      final token = EthereumAddress.fromHex(
+        '0x1234567890123456789012345678901234567890',
+      );
+      final owner = EthereumAddress.fromHex(
+        '0x1111111111111111111111111111111111111111',
+      );
       final slot = BigInt.zero;
 
       final balanceResult = erc20BalanceOverride(
@@ -280,12 +304,15 @@ void main() {
 
   group('erc20PaymasterOverride', () {
     test('creates combined balance and allowance overrides', () {
-      final token =
-          EthereumAddress.fromHex('0x1234567890123456789012345678901234567890');
-      final owner =
-          EthereumAddress.fromHex('0x1111111111111111111111111111111111111111');
-      final spender =
-          EthereumAddress.fromHex('0x2222222222222222222222222222222222222222');
+      final token = EthereumAddress.fromHex(
+        '0x1234567890123456789012345678901234567890',
+      );
+      final owner = EthereumAddress.fromHex(
+        '0x1111111111111111111111111111111111111111',
+      );
+      final spender = EthereumAddress.fromHex(
+        '0x2222222222222222222222222222222222222222',
+      );
       final balanceSlot = BigInt.zero;
       final allowanceSlot = BigInt.one;
 
@@ -316,12 +343,15 @@ void main() {
     });
 
     test('uses custom balance and allowance values', () {
-      final token =
-          EthereumAddress.fromHex('0x1234567890123456789012345678901234567890');
-      final owner =
-          EthereumAddress.fromHex('0x1111111111111111111111111111111111111111');
-      final spender =
-          EthereumAddress.fromHex('0x2222222222222222222222222222222222222222');
+      final token = EthereumAddress.fromHex(
+        '0x1234567890123456789012345678901234567890',
+      );
+      final owner = EthereumAddress.fromHex(
+        '0x1111111111111111111111111111111111111111',
+      );
+      final spender = EthereumAddress.fromHex(
+        '0x2222222222222222222222222222222222222222',
+      );
       final balance = BigInt.from(1000000);
       final allowance = BigInt.from(500000);
 
@@ -337,10 +367,7 @@ void main() {
 
       // Verify both values are present (order may vary after merge)
       final values = result[0].stateDiff!.map((d) => d.value).toSet();
-      expect(
-        values.contains(Hex.fromBigInt(balance, byteLength: 32)),
-        isTrue,
-      );
+      expect(values.contains(Hex.fromBigInt(balance, byteLength: 32)), isTrue);
       expect(
         values.contains(Hex.fromBigInt(allowance, byteLength: 32)),
         isTrue,
@@ -350,12 +377,15 @@ void main() {
 
   group('mergeStateOverrides', () {
     test('merges overrides for different addresses', () {
-      final token1 =
-          EthereumAddress.fromHex('0x1111111111111111111111111111111111111111');
-      final token2 =
-          EthereumAddress.fromHex('0x2222222222222222222222222222222222222222');
-      final owner =
-          EthereumAddress.fromHex('0x3333333333333333333333333333333333333333');
+      final token1 = EthereumAddress.fromHex(
+        '0x1111111111111111111111111111111111111111',
+      );
+      final token2 = EthereumAddress.fromHex(
+        '0x2222222222222222222222222222222222222222',
+      );
+      final owner = EthereumAddress.fromHex(
+        '0x3333333333333333333333333333333333333333',
+      );
 
       final override1 = erc20BalanceOverride(
         token: token1,
@@ -377,12 +407,15 @@ void main() {
     });
 
     test('merges stateDiffs for same address', () {
-      final token =
-          EthereumAddress.fromHex('0x1111111111111111111111111111111111111111');
-      final owner =
-          EthereumAddress.fromHex('0x2222222222222222222222222222222222222222');
-      final spender =
-          EthereumAddress.fromHex('0x3333333333333333333333333333333333333333');
+      final token = EthereumAddress.fromHex(
+        '0x1111111111111111111111111111111111111111',
+      );
+      final owner = EthereumAddress.fromHex(
+        '0x2222222222222222222222222222222222222222',
+      );
+      final spender = EthereumAddress.fromHex(
+        '0x3333333333333333333333333333333333333333',
+      );
 
       final balanceOverride = erc20BalanceOverride(
         token: token,
@@ -397,8 +430,10 @@ void main() {
         slot: BigInt.one,
       );
 
-      final merged =
-          mergeStateOverrides([...balanceOverride, ...allowanceOverride]);
+      final merged = mergeStateOverrides([
+        ...balanceOverride,
+        ...allowanceOverride,
+      ]);
 
       expect(merged.length, equals(1)); // Same token, merged into one
       expect(
@@ -410,10 +445,12 @@ void main() {
 
   group('stateOverridesToJson', () {
     test('converts override to JSON format', () {
-      final token =
-          EthereumAddress.fromHex('0x1234567890123456789012345678901234567890');
-      final owner =
-          EthereumAddress.fromHex('0x1111111111111111111111111111111111111111');
+      final token = EthereumAddress.fromHex(
+        '0x1234567890123456789012345678901234567890',
+      );
+      final owner = EthereumAddress.fromHex(
+        '0x1111111111111111111111111111111111111111',
+      );
 
       final override = erc20BalanceOverride(
         token: token,

--- a/packages/permissionless/test/utils/units_test.dart
+++ b/packages/permissionless/test/utils/units_test.dart
@@ -8,10 +8,7 @@ void main() {
     });
 
     test('weiPerEther is 10^18', () {
-      expect(
-        EthUnits.weiPerEther,
-        equals(BigInt.parse('1000000000000000000')),
-      );
+      expect(EthUnits.weiPerEther, equals(BigInt.parse('1000000000000000000')));
     });
 
     test('gweiPerEther is 10^9', () {
@@ -22,17 +19,11 @@ void main() {
   group('GasUnits', () {
     group('gweiToWei', () {
       test('converts integer gwei to wei', () {
-        expect(
-          GasUnits.gweiToWei(50),
-          equals(BigInt.from(50000000000)),
-        );
+        expect(GasUnits.gweiToWei(50), equals(BigInt.from(50000000000)));
       });
 
       test('converts decimal gwei to wei', () {
-        expect(
-          GasUnits.gweiToWei(1.5),
-          equals(BigInt.from(1500000000)),
-        );
+        expect(GasUnits.gweiToWei(1.5), equals(BigInt.from(1500000000)));
       });
 
       test('converts zero', () {
@@ -40,26 +31,17 @@ void main() {
       });
 
       test('handles large values', () {
-        expect(
-          GasUnits.gweiToWei(1000),
-          equals(BigInt.from(1000000000000)),
-        );
+        expect(GasUnits.gweiToWei(1000), equals(BigInt.from(1000000000000)));
       });
     });
 
     group('weiToGwei', () {
       test('converts wei to gwei', () {
-        expect(
-          GasUnits.weiToGwei(BigInt.from(50000000000)),
-          equals(50.0),
-        );
+        expect(GasUnits.weiToGwei(BigInt.from(50000000000)), equals(50.0));
       });
 
       test('handles fractional gwei', () {
-        expect(
-          GasUnits.weiToGwei(BigInt.from(1500000000)),
-          equals(1.5),
-        );
+        expect(GasUnits.weiToGwei(BigInt.from(1500000000)), equals(1.5));
       });
 
       test('converts zero', () {
@@ -119,63 +101,39 @@ void main() {
 
     group('gweiToEther', () {
       test('converts gwei to ether', () {
-        expect(
-          GasUnits.gweiToEther(1000000000),
-          equals(1.0),
-        );
+        expect(GasUnits.gweiToEther(1000000000), equals(1.0));
       });
 
       test('handles small gwei amounts', () {
-        expect(
-          GasUnits.gweiToEther(1000000),
-          closeTo(0.001, 0.0000001),
-        );
+        expect(GasUnits.gweiToEther(1000000), closeTo(0.001, 0.0000001));
       });
     });
 
     group('etherToGwei', () {
       test('converts ether to gwei', () {
-        expect(
-          GasUnits.etherToGwei(1),
-          equals(1000000000.0),
-        );
+        expect(GasUnits.etherToGwei(1), equals(1000000000.0));
       });
 
       test('handles fractional ether', () {
-        expect(
-          GasUnits.etherToGwei(0.001),
-          equals(1000000.0),
-        );
+        expect(GasUnits.etherToGwei(0.001), equals(1000000.0));
       });
     });
 
     group('parse', () {
       test('parses gwei with space', () {
-        expect(
-          GasUnits.parse('50 gwei'),
-          equals(BigInt.from(50000000000)),
-        );
+        expect(GasUnits.parse('50 gwei'), equals(BigInt.from(50000000000)));
       });
 
       test('parses gwei without space', () {
-        expect(
-          GasUnits.parse('50gwei'),
-          equals(BigInt.from(50000000000)),
-        );
+        expect(GasUnits.parse('50gwei'), equals(BigInt.from(50000000000)));
       });
 
       test('parses gwei case-insensitive', () {
-        expect(
-          GasUnits.parse('50 Gwei'),
-          equals(BigInt.from(50000000000)),
-        );
+        expect(GasUnits.parse('50 Gwei'), equals(BigInt.from(50000000000)));
       });
 
       test('parses decimal gwei', () {
-        expect(
-          GasUnits.parse('1.5 gwei'),
-          equals(BigInt.from(1500000000)),
-        );
+        expect(GasUnits.parse('1.5 gwei'), equals(BigInt.from(1500000000)));
       });
 
       test('parses eth', () {
@@ -193,24 +151,15 @@ void main() {
       });
 
       test('parses wei (no unit)', () {
-        expect(
-          GasUnits.parse('1000'),
-          equals(BigInt.from(1000)),
-        );
+        expect(GasUnits.parse('1000'), equals(BigInt.from(1000)));
       });
 
       test('parses explicit wei', () {
-        expect(
-          GasUnits.parse('1000 wei'),
-          equals(BigInt.from(1000)),
-        );
+        expect(GasUnits.parse('1000 wei'), equals(BigInt.from(1000)));
       });
 
       test('handles whitespace', () {
-        expect(
-          GasUnits.parse('  50 gwei  '),
-          equals(BigInt.from(50000000000)),
-        );
+        expect(GasUnits.parse('  50 gwei  '), equals(BigInt.from(50000000000)));
       });
 
       test('throws on invalid format', () {
@@ -221,26 +170,17 @@ void main() {
       });
 
       test('throws on unknown unit', () {
-        expect(
-          () => GasUnits.parse('50 foo'),
-          throwsA(isA<FormatException>()),
-        );
+        expect(() => GasUnits.parse('50 foo'), throwsA(isA<FormatException>()));
       });
     });
 
     group('format', () {
       test('formats small values as wei', () {
-        expect(
-          GasUnits.format(BigInt.from(999)),
-          equals('999 wei'),
-        );
+        expect(GasUnits.format(BigInt.from(999)), equals('999 wei'));
       });
 
       test('formats medium values as gwei', () {
-        expect(
-          GasUnits.format(BigInt.from(50000000000)),
-          equals('50 gwei'),
-        );
+        expect(GasUnits.format(BigInt.from(50000000000)), equals('50 gwei'));
       });
 
       test('formats large values as ETH', () {
@@ -265,10 +205,7 @@ void main() {
       });
 
       test('formats fractional gwei', () {
-        expect(
-          GasUnits.format(BigInt.from(1500000000)),
-          equals('1.5 gwei'),
-        );
+        expect(GasUnits.format(BigInt.from(1500000000)), equals('1.5 gwei'));
       });
     });
   });

--- a/packages/permissionless_passkeys/example/aasa_server/bin/server.dart
+++ b/packages/permissionless_passkeys/example/aasa_server/bin/server.dart
@@ -48,7 +48,7 @@ void main(List<String> args) async {
           if (androidSha256 != 'YOUR_SHA256_FINGERPRINT') androidSha256,
         ],
       },
-    }
+    },
   ];
 
   final server = await HttpServer.bind(InternetAddress.anyIPv4, port);
@@ -59,9 +59,11 @@ void main(List<String> args) async {
   print('');
   print('Verify the files are accessible at:');
   print(
-      '  iOS:     https://28fc478be30e2f.lhr.life/.well-known/apple-app-site-association');
+    '  iOS:     https://28fc478be30e2f.lhr.life/.well-known/apple-app-site-association',
+  );
   print(
-      '  Android: https://28fc478be30e2f.lhr.life/.well-known/assetlinks.json');
+    '  Android: https://28fc478be30e2f.lhr.life/.well-known/assetlinks.json',
+  );
   print('');
   if (teamId == 'YOUR_TEAM_ID') {
     print('WARNING: Update teamId in server.dart with your Apple Team ID!');
@@ -69,7 +71,8 @@ void main(List<String> args) async {
   if (androidSha256 == 'YOUR_SHA256_FINGERPRINT') {
     print('WARNING: Update androidSha256 in server.dart for Android support!');
     print(
-        '  Run: keytool -list -v -keystore ~/.android/debug.keystore -alias androiddebugkey -storepass android');
+      '  Run: keytool -list -v -keystore ~/.android/debug.keystore -alias androiddebugkey -storepass android',
+    );
   }
   print('');
   print('Press Ctrl+C to stop the server.');
@@ -84,16 +87,24 @@ void main(List<String> args) async {
 
     if (path == '/.well-known/apple-app-site-association') {
       // Apple App Site Association file
-      request.response.headers.contentType =
-          ContentType('application', 'json', charset: 'utf-8');
-      request.response
-          .write(const JsonEncoder.withIndent('  ').convert(aasaContent));
+      request.response.headers.contentType = ContentType(
+        'application',
+        'json',
+        charset: 'utf-8',
+      );
+      request.response.write(
+        const JsonEncoder.withIndent('  ').convert(aasaContent),
+      );
     } else if (path == '/.well-known/assetlinks.json') {
       // Android Asset Links file
-      request.response.headers.contentType =
-          ContentType('application', 'json', charset: 'utf-8');
-      request.response
-          .write(const JsonEncoder.withIndent('  ').convert(assetLinksContent));
+      request.response.headers.contentType = ContentType(
+        'application',
+        'json',
+        charset: 'utf-8',
+      );
+      request.response.write(
+        const JsonEncoder.withIndent('  ').convert(assetLinksContent),
+      );
     } else if (path == '/') {
       // Health check / info page
       request.response.headers.contentType = ContentType.html;

--- a/packages/permissionless_passkeys/example/lib/main.dart
+++ b/packages/permissionless_passkeys/example/lib/main.dart
@@ -4,11 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'screens/home_screen.dart';
 
 void main() {
-  runApp(
-    const ProviderScope(
-      child: PasskeysExampleApp(),
-    ),
-  );
+  runApp(const ProviderScope(child: PasskeysExampleApp()));
 }
 
 class PasskeysExampleApp extends StatelessWidget {

--- a/packages/permissionless_passkeys/example/lib/providers/credential_provider.dart
+++ b/packages/permissionless_passkeys/example/lib/providers/credential_provider.dart
@@ -111,10 +111,7 @@ class CredentialNotifier extends Notifier<CredentialState> {
 
       return true;
     } catch (e) {
-      state = state.copyWith(
-        isLoading: false,
-        errorMessage: _formatError(e),
-      );
+      state = state.copyWith(isLoading: false, errorMessage: _formatError(e));
       return false;
     }
   }

--- a/packages/permissionless_passkeys/example/lib/screens/account_screen.dart
+++ b/packages/permissionless_passkeys/example/lib/screens/account_screen.dart
@@ -185,7 +185,9 @@ class _AccountScreenState extends State<AccountScreen> {
               _formatAddress(_account.entryPoint.with0x),
             ),
             _buildInfoRow(
-                'Nonce Key', '0x${_account.nonceKey.toRadixString(16)}'),
+              'Nonce Key',
+              '0x${_account.nonceKey.toRadixString(16)}',
+            ),
           ],
         ),
       ),
@@ -201,10 +203,7 @@ class _AccountScreenState extends State<AccountScreen> {
           children: [
             Row(
               children: [
-                Icon(
-                  Icons.key,
-                  color: Theme.of(context).colorScheme.primary,
-                ),
+                Icon(Icons.key, color: Theme.of(context).colorScheme.primary),
                 const SizedBox(width: 8),
                 Text(
                   'Passkey Credential',
@@ -247,10 +246,7 @@ class _AccountScreenState extends State<AccountScreen> {
           children: [
             Row(
               children: [
-                Icon(
-                  Icons.code,
-                  color: Theme.of(context).colorScheme.primary,
-                ),
+                Icon(Icons.code, color: Theme.of(context).colorScheme.primary),
                 const SizedBox(width: 8),
                 Text(
                   'Encoding Demo',
@@ -334,10 +330,7 @@ class _AccountScreenState extends State<AccountScreen> {
             ),
           ),
           Expanded(
-            child: Text(
-              value,
-              style: const TextStyle(fontFamily: 'monospace'),
-            ),
+            child: Text(value, style: const TextStyle(fontFamily: 'monospace')),
           ),
         ],
       ),
@@ -365,15 +358,14 @@ class _AccountScreenState extends State<AccountScreen> {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text(
-                    label,
-                    style: Theme.of(context).textTheme.labelSmall,
-                  ),
+                  Text(label, style: Theme.of(context).textTheme.labelSmall),
                   const SizedBox(height: 4),
                   Text(
                     displayValue,
-                    style:
-                        const TextStyle(fontFamily: 'monospace', fontSize: 12),
+                    style: const TextStyle(
+                      fontFamily: 'monospace',
+                      fontSize: 12,
+                    ),
                   ),
                 ],
               ),
@@ -387,9 +379,9 @@ class _AccountScreenState extends State<AccountScreen> {
 
   void _copyToClipboard(BuildContext context, String label, String value) {
     Clipboard.setData(ClipboardData(text: value));
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text('$label copied to clipboard')),
-    );
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text('$label copied to clipboard')));
   }
 
   void _exportCredential(BuildContext context) {

--- a/packages/permissionless_passkeys/example/lib/screens/home_screen.dart
+++ b/packages/permissionless_passkeys/example/lib/screens/home_screen.dart
@@ -71,11 +71,9 @@ class _NoCredentialView extends StatelessWidget {
   }
 
   void _navigateToRegister(BuildContext context) {
-    Navigator.of(context).push(
-      MaterialPageRoute(
-        builder: (context) => const RegisterScreen(),
-      ),
-    );
+    Navigator.of(
+      context,
+    ).push(MaterialPageRoute(builder: (context) => const RegisterScreen()));
   }
 }
 
@@ -96,22 +94,16 @@ class _CredentialView extends ConsumerWidget {
             title: 'Kernel Account',
             subtitle: 'ZeroDev Kernel v0.3.x with WebAuthn validator',
             icon: Icons.memory,
-            onTap: () => _navigateToAccount(
-              context,
-              AccountType.kernel,
-              credential,
-            ),
+            onTap: () =>
+                _navigateToAccount(context, AccountType.kernel, credential),
           ),
           const SizedBox(height: 12),
           _AccountTypeCard(
             title: 'Safe Account',
             subtitle: 'Safe v1.4.1 with WebAuthn shared signer',
             icon: Icons.security,
-            onTap: () => _navigateToAccount(
-              context,
-              AccountType.safe,
-              credential,
-            ),
+            onTap: () =>
+                _navigateToAccount(context, AccountType.safe, credential),
           ),
           const SizedBox(height: 24),
           OutlinedButton.icon(
@@ -135,10 +127,8 @@ class _CredentialView extends ConsumerWidget {
   ) {
     Navigator.of(context).push(
       MaterialPageRoute(
-        builder: (context) => AccountScreen(
-          credential: credential,
-          accountType: type,
-        ),
+        builder: (context) =>
+            AccountScreen(credential: credential, accountType: type),
       ),
     );
   }

--- a/packages/permissionless_passkeys/example/lib/screens/register_screen.dart
+++ b/packages/permissionless_passkeys/example/lib/screens/register_screen.dart
@@ -51,9 +51,7 @@ class _RegisterScreenState extends ConsumerState<RegisterScreen> {
     final credentialState = ref.watch(credentialProvider);
 
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Register Passkey'),
-      ),
+      appBar: AppBar(title: const Text('Register Passkey')),
       body: SafeArea(
         child: SingleChildScrollView(
           padding: const EdgeInsets.all(16.0),

--- a/packages/permissionless_passkeys/example/lib/screens/send_transaction_screen.dart
+++ b/packages/permissionless_passkeys/example/lib/screens/send_transaction_screen.dart
@@ -6,10 +6,7 @@ import 'package:permissionless_passkeys/permissionless_passkeys.dart';
 import 'home_screen.dart';
 
 /// Transaction funding mode
-enum FundingMode {
-  sponsored,
-  selfFunded,
-}
+enum FundingMode { sponsored, selfFunded }
 
 class SendTransactionScreen extends StatefulWidget {
   const SendTransactionScreen({
@@ -115,8 +112,9 @@ class _SendTransactionScreenState extends State<SendTransactionScreen> {
     });
 
     try {
-      final recipient =
-          EthereumAddress.fromHex(_recipientController.text.trim());
+      final recipient = EthereumAddress.fromHex(
+        _recipientController.text.trim(),
+      );
       final amountEth = double.parse(_amountController.text.trim());
       final amountWei = BigInt.from(amountEth * 1e18); // Convert ETH to wei
 
@@ -139,9 +137,7 @@ class _SendTransactionScreenState extends State<SendTransactionScreen> {
       if (_fundingMode == FundingMode.sponsored) {
         final paymasterUrl =
             'https://api.pimlico.io/v2/$_chainName/rpc?apikey=$apiKey';
-        paymasterClient = createPaymasterClient(
-          url: paymasterUrl,
-        );
+        paymasterClient = createPaymasterClient(url: paymasterUrl);
       }
 
       // Create smart account client
@@ -159,11 +155,7 @@ class _SendTransactionScreenState extends State<SendTransactionScreen> {
       final gasPrices = await pimlicoClient.getUserOperationGasPrice();
 
       // Create the call
-      final call = Call(
-        to: recipient,
-        value: amountWei,
-        data: '0x',
-      );
+      final call = Call(to: recipient, value: amountWei, data: '0x');
 
       // Send the UserOperation
       setState(() => _status = TransactionStatus.signing);
@@ -247,9 +239,7 @@ class _SendTransactionScreenState extends State<SendTransactionScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Send Transaction'),
-      ),
+      appBar: AppBar(title: const Text('Send Transaction')),
       body: SafeArea(
         child: SingleChildScrollView(
           padding: const EdgeInsets.all(16.0),
@@ -333,7 +323,8 @@ class _SendTransactionScreenState extends State<SendTransactionScreen> {
                           Clipboard.setData(ClipboardData(text: address));
                           ScaffoldMessenger.of(context).showSnackBar(
                             const SnackBar(
-                                content: Text('Address copied to clipboard')),
+                              content: Text('Address copied to clipboard'),
+                            ),
                           );
                         },
                         tooltip: 'Copy address',
@@ -359,10 +350,7 @@ class _SendTransactionScreenState extends State<SendTransactionScreen> {
           children: [
             Row(
               children: [
-                Icon(
-                  Icons.key,
-                  color: Theme.of(context).colorScheme.primary,
-                ),
+                Icon(Icons.key, color: Theme.of(context).colorScheme.primary),
                 const SizedBox(width: 8),
                 Text(
                   'Pimlico API Key',
@@ -459,10 +447,7 @@ class _SendTransactionScreenState extends State<SendTransactionScreen> {
           children: [
             Row(
               children: [
-                Icon(
-                  Icons.send,
-                  color: Theme.of(context).colorScheme.primary,
-                ),
+                Icon(Icons.send, color: Theme.of(context).colorScheme.primary),
                 const SizedBox(width: 8),
                 Text(
                   'Transaction Details',
@@ -500,8 +485,9 @@ class _SendTransactionScreenState extends State<SendTransactionScreen> {
                 prefixIcon: Icon(Icons.attach_money),
                 suffixText: 'ETH',
               ),
-              keyboardType:
-                  const TextInputType.numberWithOptions(decimal: true),
+              keyboardType: const TextInputType.numberWithOptions(
+                decimal: true,
+              ),
               validator: (value) {
                 if (value == null || value.trim().isEmpty) {
                   return 'Amount is required';
@@ -541,19 +527,11 @@ class _SendTransactionScreenState extends State<SendTransactionScreen> {
             Text(_getStatusDescription()),
             if (_userOpHash != null) ...[
               const SizedBox(height: 8),
-              _buildCopyableField(
-                context,
-                'UserOp Hash',
-                _userOpHash!,
-              ),
+              _buildCopyableField(context, 'UserOp Hash', _userOpHash!),
             ],
             if (_txHash != null) ...[
               const SizedBox(height: 8),
-              _buildCopyableField(
-                context,
-                'Transaction Hash',
-                _txHash!,
-              ),
+              _buildCopyableField(context, 'Transaction Hash', _txHash!),
             ],
           ],
         ),
@@ -601,17 +579,13 @@ class _SendTransactionScreenState extends State<SendTransactionScreen> {
     );
   }
 
-  Widget _buildCopyableField(
-    BuildContext context,
-    String label,
-    String value,
-  ) {
+  Widget _buildCopyableField(BuildContext context, String label, String value) {
     return InkWell(
       onTap: () {
         Clipboard.setData(ClipboardData(text: value));
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('$label copied to clipboard')),
-        );
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text('$label copied to clipboard')));
       },
       child: Container(
         padding: const EdgeInsets.all(8),
@@ -625,14 +599,13 @@ class _SendTransactionScreenState extends State<SendTransactionScreen> {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text(
-                    label,
-                    style: Theme.of(context).textTheme.labelSmall,
-                  ),
+                  Text(label, style: Theme.of(context).textTheme.labelSmall),
                   Text(
                     _truncateHash(value),
-                    style:
-                        const TextStyle(fontFamily: 'monospace', fontSize: 12),
+                    style: const TextStyle(
+                      fontFamily: 'monospace',
+                      fontSize: 12,
+                    ),
                   ),
                 ],
               ),

--- a/packages/permissionless_passkeys/example/lib/widgets/credential_card.dart
+++ b/packages/permissionless_passkeys/example/lib/widgets/credential_card.dart
@@ -3,10 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:permissionless_passkeys/permissionless_passkeys.dart';
 
 class CredentialCard extends StatelessWidget {
-  const CredentialCard({
-    super.key,
-    required this.credential,
-  });
+  const CredentialCard({super.key, required this.credential});
 
   final WebAuthnCredential credential;
 
@@ -40,10 +37,10 @@ class CredentialCard extends StatelessWidget {
                     children: [
                       Text(
                         'Passkey Credential',
-                        style:
-                            Theme.of(context).textTheme.titleMedium?.copyWith(
-                                  fontWeight: FontWeight.bold,
-                                ),
+                        style: Theme.of(context)
+                            .textTheme
+                            .titleMedium
+                            ?.copyWith(fontWeight: FontWeight.bold),
                       ),
                       Text(
                         'P-256 (secp256r1)',
@@ -101,10 +98,7 @@ class CredentialCard extends StatelessWidget {
           ),
           child: Text(
             value,
-            style: const TextStyle(
-              fontFamily: 'monospace',
-              fontSize: 13,
-            ),
+            style: const TextStyle(fontFamily: 'monospace', fontSize: 13),
           ),
         ),
       ],

--- a/packages/permissionless_passkeys/example/test/widget_test.dart
+++ b/packages/permissionless_passkeys/example/test/widget_test.dart
@@ -8,11 +8,7 @@ import 'package:permissionless_passkeys_example/main.dart';
 void main() {
   testWidgets('App loads home screen', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(
-      const ProviderScope(
-        child: PasskeysExampleApp(),
-      ),
-    );
+    await tester.pumpWidget(const ProviderScope(child: PasskeysExampleApp()));
 
     // Verify the home screen loads with the expected title
     expect(find.text('Passkeys Smart Account'), findsOneWidget);

--- a/packages/permissionless_passkeys/lib/src/accounts/to_webauthn_account.dart
+++ b/packages/permissionless_passkeys/lib/src/accounts/to_webauthn_account.dart
@@ -209,7 +209,9 @@ class _WebAuthnAccountImpl extends WebAuthnAccount {
 
   /// Creates the return type from a signature.
   WebAuthnSignReturnType _createReturnType(
-      Signature signature, Uint8List hash) {
+    Signature signature,
+    Uint8List hash,
+  ) {
     // Build compact signature (r + s, 64 bytes)
     final rHex = signature.r.toRadixString(16).padLeft(64, '0');
     final sHex = signature.s.toRadixString(16).padLeft(64, '0');

--- a/packages/permissionless_passkeys/lib/src/accounts/webauthn_account.dart
+++ b/packages/permissionless_passkeys/lib/src/accounts/webauthn_account.dart
@@ -32,10 +32,7 @@ class WebAuthnSignMetadata {
   final int typeIndex;
 
   /// Converts to [P256SignatureData] by combining with signature components.
-  P256SignatureData toSignatureData({
-    required BigInt r,
-    required BigInt s,
-  }) {
+  P256SignatureData toSignatureData({required BigInt r, required BigInt s}) {
     return P256SignatureData(
       r: r,
       s: s,

--- a/packages/permissionless_passkeys/lib/src/factory.dart
+++ b/packages/permissionless_passkeys/lib/src/factory.dart
@@ -33,10 +33,7 @@ Future<WebAuthnCredential> createPasskeyCredential({
   required String userName,
   String? displayName,
 }) async {
-  final config = PassKeyConfig(
-    rpId: rpId,
-    rpName: rpName,
-  );
+  final config = PassKeyConfig(rpId: rpId, rpName: rpName);
 
   final publicKey = await generatePassKey(
     config: config,

--- a/packages/permissionless_passkeys/lib/src/types/webauthn_credential.dart
+++ b/packages/permissionless_passkeys/lib/src/types/webauthn_credential.dart
@@ -59,8 +59,9 @@ class WebAuthnCredential {
     final key = PassKeyPublicKey(
       x: Uint256.fromHex(rawData['x'] as String),
       y: Uint256.fromHex(rawData['y'] as String),
-      credentialId:
-          base64Url.decode(_padBase64(rawData['credentialId'] as String)),
+      credentialId: base64Url.decode(
+        _padBase64(rawData['credentialId'] as String),
+      ),
       userName: rawData['userName'] as String? ?? '',
       aaGuid: rawData['aaGuid'] as String? ?? '',
     );

--- a/packages/permissionless_passkeys/test/accounts/webauthn_account_test.dart
+++ b/packages/permissionless_passkeys/test/accounts/webauthn_account_test.dart
@@ -165,7 +165,9 @@ void main() {
         );
 
         expect(
-            result.webauthn.authenticatorData, equals(testAuthenticatorData));
+          result.webauthn.authenticatorData,
+          equals(testAuthenticatorData),
+        );
         expect(result.webauthn.clientDataJSON, equals(testClientDataJSON));
         expect(result.webauthn.typeIndex, equals(testResponseTypeLocation));
       });

--- a/packages/permissionless_passkeys/test/encoding/kernel_encoding_test.dart
+++ b/packages/permissionless_passkeys/test/encoding/kernel_encoding_test.dart
@@ -60,10 +60,7 @@ void main() {
         // Slot 5 (0-indexed) is at position 320-384
         final usePrecompiledHex = hex.substring(320, 384);
 
-        expect(
-          BigInt.parse(usePrecompiledHex, radix: 16),
-          equals(BigInt.one),
-        );
+        expect(BigInt.parse(usePrecompiledHex, radix: 16), equals(BigInt.one));
       });
 
       test('r value is max uint256', () {
@@ -89,7 +86,8 @@ void main() {
         expect(
           sHex,
           equals(
-              '7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a0'),
+            '7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a0',
+          ),
         );
       });
 
@@ -100,8 +98,10 @@ void main() {
         // AuthData starts at offset 192 (0xc0)
         // First 64 chars at that offset are the length
         final authDataStart = 192 * 2; // Convert bytes to hex chars
-        final authDataLengthHex =
-            hex.substring(authDataStart, authDataStart + 64);
+        final authDataLengthHex = hex.substring(
+          authDataStart,
+          authDataStart + 64,
+        );
         final authDataLength = BigInt.parse(authDataLengthHex, radix: 16);
 
         // Dummy authenticator data is 37 bytes
@@ -114,16 +114,20 @@ void main() {
 
         // clientDataJSON offset is in slot 2
         final clientDataOffsetHex = hex.substring(64, 128);
-        final clientDataOffset =
-            BigInt.parse(clientDataOffsetHex, radix: 16).toInt();
+        final clientDataOffset = BigInt.parse(
+          clientDataOffsetHex,
+          radix: 16,
+        ).toInt();
 
         // Read length at that offset
         final clientDataLengthHex = hex.substring(
           clientDataOffset * 2,
           clientDataOffset * 2 + 64,
         );
-        final clientDataLength =
-            BigInt.parse(clientDataLengthHex, radix: 16).toInt();
+        final clientDataLength = BigInt.parse(
+          clientDataLengthHex,
+          radix: 16,
+        ).toInt();
 
         // Client data JSON should be reasonable length
         expect(clientDataLength, greaterThan(50));

--- a/packages/permissionless_passkeys/test/encoding/safe_encoding_test.dart
+++ b/packages/permissionless_passkeys/test/encoding/safe_encoding_test.dart
@@ -123,9 +123,9 @@ void main() {
         final verifierHex = hex.substring(128);
         expect(verifierHex.length, equals(44));
         expect(
-          verifierHex
-              .toLowerCase()
-              .endsWith('a86e0054c51e4894d88762a017ecc5e5235f5dba'),
+          verifierHex.toLowerCase().endsWith(
+                'a86e0054c51e4894d88762a017ecc5e5235f5dba',
+              ),
           isTrue,
         );
       });
@@ -137,8 +137,10 @@ void main() {
           p256VerifierAddress: '0x1234567890123456789012345678901234567890',
         );
 
-        expect(result.contains('1234567890123456789012345678901234567890'),
-            isTrue);
+        expect(
+          result.contains('1234567890123456789012345678901234567890'),
+          isTrue,
+        );
       });
 
       test('handles verifier address without 0x prefix', () {
@@ -148,8 +150,10 @@ void main() {
           p256VerifierAddress: '1234567890123456789012345678901234567890',
         );
 
-        expect(result.contains('1234567890123456789012345678901234567890'),
-            isTrue);
+        expect(
+          result.contains('1234567890123456789012345678901234567890'),
+          isTrue,
+        );
       });
     });
 

--- a/packages/permissionless_passkeys/test/helpers/test_fixtures.dart
+++ b/packages/permissionless_passkeys/test/helpers/test_fixtures.dart
@@ -64,8 +64,9 @@ const String testClientDataJSON = '{"type":"webauthn.get",'
 const int testResponseTypeLocation = 1;
 
 /// Creates a mock Ethereum address for testing.
-EthereumAddress testAddress(
-    [String hex = '0x1234567890123456789012345678901234567890']) {
+EthereumAddress testAddress([
+  String hex = '0x1234567890123456789012345678901234567890',
+]) {
   return EthereumAddress.fromHex(hex);
 }
 
@@ -91,16 +92,8 @@ String bytesToHex(Uint8List bytes) {
 }
 
 /// Mock Call for transaction encoding tests.
-Call testCall({
-  EthereumAddress? to,
-  BigInt? value,
-  String data = '0x',
-}) {
-  return Call(
-    to: to ?? testAddress(),
-    value: value ?? BigInt.zero,
-    data: data,
-  );
+Call testCall({EthereumAddress? to, BigInt? value, String data = '0x'}) {
+  return Call(to: to ?? testAddress(), value: value ?? BigInt.zero, data: data);
 }
 
 /// Mock calls for batch transaction tests.

--- a/tool/changeset.dart
+++ b/tool/changeset.dart
@@ -58,8 +58,10 @@ Future<void> _run() async {
     throw Exception('title cannot be empty');
   }
 
-  stdout.writeln('\nEnter a longer description (markdown allowed). '
-      'End input with a single "." on its own line:');
+  stdout.writeln(
+    '\nEnter a longer description (markdown allowed). '
+    'End input with a single "." on its own line:',
+  );
   final note = _promptMultiline();
 
   final now = DateTime.now();
@@ -85,8 +87,9 @@ Future<void> _run() async {
 List<int> _promptPackageSelection(int packageCount) {
   stdout
     ..writeln(
-        '\nSelect affected packages by number (space or comma-separated). '
-        'Example: 1 3 4')
+      '\nSelect affected packages by number (space or comma-separated). '
+      'Example: 1 3 4',
+    )
     ..write('Selection: ');
   final line = stdin.readLineSync() ?? '';
   final tokens = line.split(RegExp(r'[,\s]+')).where((t) => t.isNotEmpty);

--- a/tool/changeset_lib.dart
+++ b/tool/changeset_lib.dart
@@ -148,11 +148,7 @@ List<PackageInfo> discoverPackages() {
 
     final name = _readPubspecName(pubspec) ?? _basename(entity.path);
     packages.add(
-      PackageInfo(
-        name: name,
-        path: entity.path,
-        pubspecPath: pubspec.path,
-      ),
+      PackageInfo(name: name, path: entity.path, pubspecPath: pubspec.path),
     );
   }
 


### PR DESCRIPTION
Refs #26

## Summary
- Aggregates the Ralph draft PRs for issues #21-#25 while preserving their original commits as ancestors.
- Adds live Pimlico Sepolia EntryPoint v0.9 + Simple7702Account verification for self-funded and sponsored zero-value self-call flows.
- Extends integration test config for `SEPOLIA_RPC_URL` and `PIMLICO_SPONSORSHIP_POLICY_ID` with deterministic skip helpers.

## Preserved Draft PR Commits
- #27 / issue #21: `bbda57b`
- #28 / issue #22: `a2ff735`
- #29 / issue #23: `6757b27`
- #30 / issue #24: `792226e`, `a2daf4b`
- #31 / issue #25: `d4298a7`, `f4b1951`

## Verification
- `dart format --set-exit-if-changed .`
- `dart analyze`
- `dart test -P quick --reporter expanded` from `packages/permissionless`
- `env -u PIMLICO_API_KEY -u TEST_PRIVATE_KEY -u SEPOLIA_RPC_URL -u PIMLICO_SPONSORSHIP_POLICY_ID dart test test/integration/e2e/eip7702_v09_pimlico_sepolia_live_test.dart --reporter expanded` from `packages/permissionless`

Note: running `dart test -P quick --reporter expanded` from the workspace root exits because the root package has no `test/` directory, so the package command above is the meaningful quick-suite run.
