### PR TITLE
fix: correct P0 parity bugs — selectors, addresses, signatures, pimlico actions

### DIFF
--- a/packages/permissionless/lib/src/accounts/kernel/constants.dart
+++ b/packages/permissionless/lib/src/accounts/kernel/constants.dart
@@ -128,11 +128,15 @@ class KernelVersionAddresses {
 class KernelSelectors {
   KernelSelectors._();
 
-  /// v0.2.x: execute(address,uint256,bytes,uint8)
-  static const String executeV2 = '0xb61d27f6';
+  /// v0.2.x: execute(address to, uint256 value, bytes data, uint8 operation)
+  /// `keccak256("execute(address,uint256,bytes,uint8)")[0:4]` = 0x51945447
+  /// (not SimpleAccount's 3-arg execute `0xb61d27f6`)
+  static const String executeV2 = '0x51945447';
 
-  /// v0.2.x: executeBatch((address,uint256,bytes)[])
-  static const String executeBatchV2 = '0x47e1da2a';
+  /// v0.2.x: executeBatch((address to, uint256 value, bytes data)[] calls)
+  /// `keccak256("executeBatch((address,uint256,bytes)[])")[0:4]` = 0x34fcd5be
+  /// (not SimpleAccount's 3-array executeBatch `0x47e1da2a`)
+  static const String executeBatchV2 = '0x34fcd5be';
 
   /// v0.3.x: execute(bytes32,bytes) - ERC-7579 standard
   /// `keccak256("execute(bytes32,bytes)")[0:4]` = 0xe9ae5c53

--- a/packages/permissionless/lib/src/accounts/nexus/constants.dart
+++ b/packages/permissionless/lib/src/accounts/nexus/constants.dart
@@ -25,5 +25,6 @@ class NexusSelectors {
   static const String createAccount = '0x0d51f0b7';
 
   /// computeAccountAddress(address eoaOwner, uint256 index, address[] attesters, uint8 threshold)
-  static const String computeAccountAddress = '0x8b97fea1';
+  /// `keccak256("computeAccountAddress(address,uint256,address[],uint8)")[0:4]` = 0x322cc8ca
+  static const String computeAccountAddress = '0x322cc8ca';
 }

--- a/packages/permissionless/lib/src/accounts/nexus/nexus_account.dart
+++ b/packages/permissionless/lib/src/accounts/nexus/nexus_account.dart
@@ -256,22 +256,19 @@ class NexusSmartAccount implements SmartAccount {
   /// The signing flow for Nexus K1 validator:
   /// 1. Compute userOpHash
   /// 2. Sign with EIP-191 personal message
-  /// 3. Pack as: validatorAddress (20 bytes) + signature (65 bytes)
+  /// 3. Return the bare 65-byte ECDSA signature
   ///
-  /// Note: Nexus expects the signature to be packed with validator address
-  /// as the first 20 bytes, followed by the validator-specific signature.
+  /// Nexus selects the validator via the **nonce key** and forwards
+  /// `userOp.signature` untouched to K1Validator's ECDSA recover — so the
+  /// signature must be the bare 65-byte personal signature (no validator
+  /// address prefix). The validator prefix is only used for ERC-1271
+  /// [signMessage] / [signTypedData] packing.
   @override
   Future<String> signUserOperation(UserOperationV07 userOp) async {
     final userOpHash = _computeUserOpHash(userOp);
 
-    // K1 validator uses EIP-191 personal sign of userOpHash
-    final signature = await _config.owner.signPersonalMessage(userOpHash);
-
-    // Pack: validator address + signature (85 bytes total)
-    return Hex.concat([
-      _validatorAddress.hex,
-      Hex.strip0x(signature),
-    ]);
+    // K1 validator uses EIP-191 personal sign of userOpHash (bare, 65 bytes)
+    return _config.owner.signPersonalMessage(userOpHash);
   }
 
   /// Signs a personal message (EIP-191) with Nexus wrapper.

--- a/packages/permissionless/lib/src/accounts/safe/constants.dart
+++ b/packages/permissionless/lib/src/accounts/safe/constants.dart
@@ -194,7 +194,7 @@ class SafeVersionAddresses {
           '0x218543288004CD07832472D464648173c77D7eB7',
         ),
         multiSendCallOnlyAddress: EthereumAddress.fromHex(
-          '0x0c28E9886f79618371c5Af86aA7e5Cf62dddd8dC',
+          '0xA83c336B20401Af773B6219BA5027174338D1836',
         ),
         webAuthnSharedSignerAddress: EthereumAddress.fromHex(
           '0x94a4F6affBd8975951142c3999aEAB7ecee555c2',

--- a/packages/permissionless/lib/src/accounts/thirdweb/thirdweb_account.dart
+++ b/packages/permissionless/lib/src/accounts/thirdweb/thirdweb_account.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:web3dart/web3dart.dart';
@@ -22,7 +23,9 @@ class ThirdwebSmartAccountConfig {
   ///
   /// - [owner]: The account owner who controls the account
   /// - [chainId]: Chain ID for the network
-  /// - [salt]: Salt for deterministic address generation (defaults to "0x")
+  /// - [salt]: Salt for deterministic address generation. Treated as a UTF-8
+  ///   string (matching permissionless.js `toHex(salt)`), not as hex. Empty or
+  ///   the historical default `"0x"` produce empty salt bytes.
   /// - [entryPointVersion]: EntryPoint version (defaults to v0.7)
   /// - [nonceKey]: Custom nonce key for parallel transaction support
   /// - [publicClient]: For RPC-based address computation (recommended)
@@ -45,6 +48,8 @@ class ThirdwebSmartAccountConfig {
   final BigInt chainId;
 
   /// Salt for deterministic address generation.
+  ///
+  /// Encoded as UTF-8 bytes (permissionless.js `toHex(salt)`), not hex-decoded.
   final String salt;
 
   /// EntryPoint version (default: v0.7).
@@ -170,8 +175,8 @@ class ThirdwebSmartAccount implements SmartAccount {
   /// Encodes the createAccount factory call.
   String _encodeCreateAccount() {
     // createAccount(address _admin, bytes _salt)
-    final salt = _config.salt.isEmpty ? '0x' : _config.salt;
-    final saltBytes = Hex.decode(salt);
+    // JS: salt ? toHex(salt) : "0x" — toHex UTF-8-encodes the string.
+    final saltBytes = _saltToBytes(_config.salt);
 
     return Hex.concat([
       ThirdwebSelectors.createAccount,
@@ -186,6 +191,18 @@ class ThirdwebSmartAccount implements SmartAccount {
           ),
         ),
     ]);
+  }
+
+  /// Converts the salt config string to bytes matching permissionless.js.
+  ///
+  /// JS uses `salt ? toHex(salt) : "0x"` where `toHex` on a string is UTF-8.
+  /// Empty string and the historical Dart default `"0x"` map to empty bytes
+  /// (JS omitted / falsy salt).
+  static Uint8List _saltToBytes(String salt) {
+    if (salt.isEmpty || salt == '0x') {
+      return Uint8List(0);
+    }
+    return Uint8List.fromList(utf8.encode(salt));
   }
 
   /// Encodes a single call.
@@ -446,6 +463,9 @@ class ThirdwebSmartAccount implements SmartAccount {
 /// You must provide either [publicClient] or [address] for address computation:
 /// - [publicClient] - Address will be computed automatically via RPC (recommended)
 /// - [address] - Use a pre-computed address
+///
+/// [salt] is a plain UTF-8 string (not hex), matching permissionless.js
+/// `toHex(salt)`. Omit or pass empty/`"0x"` for empty salt bytes.
 ///
 /// Example with publicClient (recommended):
 /// ```dart

--- a/packages/permissionless/lib/src/clients/pimlico/pimlico_client.dart
+++ b/packages/permissionless/lib/src/clients/pimlico/pimlico_client.dart
@@ -3,6 +3,7 @@ import 'package:http/http.dart' as http;
 import '../../types/address.dart';
 import '../../types/hex.dart';
 import '../../types/user_operation.dart';
+import '../../utils/gas.dart';
 import '../bundler/bundler_client.dart';
 import '../bundler/rpc_client.dart';
 import 'types.dart';
@@ -82,25 +83,30 @@ class PimlicoClient extends BundlerClient {
   /// Compressed UserOps use an inflator contract to decompress
   /// the calldata on-chain, significantly reducing costs.
   ///
-  /// [userOp] is the UserOperation to send.
+  /// **Deprecated:** `pimlico_sendCompressedUserOperation` has been
+  /// deprecated due to EIP-4844 blobs. Prefer [sendUserOperation] instead.
+  ///
+  /// RPC params match permissionless.js / Pimlico schema:
+  /// `[compressedUserOperation, inflatorAddress, entryPointAddress]`.
+  ///
+  /// [compressedUserOperation] is the pre-compressed UserOperation hex.
   /// [inflator] is the address of the inflator contract on the target chain.
-  /// [compressedCalldata] is the pre-compressed calldata.
   ///
   /// Returns the UserOperation hash.
+  @Deprecated(
+    'pimlico_sendCompressedUserOperation has been deprecated due to '
+    'EIP-4844 blobs. Please use sendUserOperation instead.',
+  )
   Future<String> sendCompressedUserOperation(
-    UserOperationV07 userOp,
+    String compressedUserOperation,
     EthereumAddress inflator,
-    String compressedCalldata,
   ) async {
-    final packedUserOp = _packUserOperationV07(userOp);
-
     final result = await rpcClient.call(
       'pimlico_sendCompressedUserOperation',
       [
-        packedUserOp,
-        entryPoint.hex,
-        compressedCalldata,
+        compressedUserOperation,
         inflator.hex,
+        entryPoint.hex,
       ],
     );
     return result as String;
@@ -219,11 +225,11 @@ class PimlicoClient extends BundlerClient {
 
   /// Estimates the cost to pay gas with an ERC-20 token.
   ///
-  /// Returns the estimated token cost for the given UserOperation.
-  /// This is useful for showing users the expected cost before
-  /// they submit a transaction.
+  /// Computes the max cost locally from [getTokenQuotes] and
+  /// [getRequiredPrefund] / [getRequiredPrefundV06], matching
+  /// permissionless.js `estimateErc20PaymasterCost` (no dedicated RPC).
   ///
-  /// [userOperation] is the UserOperation to estimate cost for.
+  /// [userOperation] is the UserOperation to estimate cost for (v0.6 or v0.7).
   /// [token] is the ERC-20 token to pay gas with.
   ///
   /// Example:
@@ -233,25 +239,54 @@ class PimlicoClient extends BundlerClient {
   ///   token: usdcAddress,
   /// );
   ///
-  /// final usdAmount = cost.costInUsd.toDouble() / 1e8;
+  /// final usdAmount = cost.costInUsd.toDouble() / 1e6;
   /// print('Estimated cost: \$${usdAmount.toStringAsFixed(2)}');
   /// ```
   Future<PimlicoErc20PaymasterCost> estimateErc20PaymasterCost({
-    required UserOperationV07 userOperation,
+    required UserOperation userOperation,
     required EthereumAddress token,
   }) async {
-    final packedUserOp = _packUserOperationV07(userOperation);
+    final quotes = await getTokenQuotes([token]);
+    if (quotes.isEmpty) {
+      throw ArgumentError(
+        'Token $token is not supported by the Pimlico ERC-20 paymaster',
+      );
+    }
 
-    final result = await rpcClient.call(
-      'pimlico_estimateErc20PaymasterCost',
-      [
-        packedUserOp,
-        entryPoint.hex,
-        token.hex,
-      ],
+    final quote = quotes.first;
+    final BigInt userOperationMaxCost;
+    final BigInt maxFeePerGas;
+
+    if (userOperation is UserOperationV07) {
+      userOperationMaxCost = getRequiredPrefund(userOperation);
+      maxFeePerGas = userOperation.maxFeePerGas;
+    } else if (userOperation is UserOperationV06) {
+      userOperationMaxCost = getRequiredPrefundV06(userOperation);
+      maxFeePerGas = userOperation.maxFeePerGas;
+    } else {
+      throw ArgumentError(
+        'Unsupported UserOperation type: ${userOperation.runtimeType}',
+      );
+    }
+
+    // max cost in wei including paymaster postOp gas
+    final maxCostInWei =
+        userOperationMaxCost + quote.postOpGas * maxFeePerGas;
+
+    // cost in token denomination (wei-scale exchange rate)
+    final costInToken =
+        (maxCostInWei * quote.exchangeRate) ~/ BigInt.from(10).pow(18);
+
+    // cost in USD with 6 decimals of precision (matches permissionless.js)
+    final exchangeRateNativeToUsd =
+        quote.exchangeRateNativeToUsd ?? BigInt.zero;
+    final costInUsd =
+        (maxCostInWei * exchangeRateNativeToUsd) ~/ BigInt.from(10).pow(18);
+
+    return PimlicoErc20PaymasterCost(
+      costInToken: costInToken,
+      costInUsd: costInUsd,
     );
-
-    return PimlicoErc20PaymasterCost.fromJson(result as Map<String, dynamic>);
   }
 
   // ================================================================
@@ -266,7 +301,10 @@ class PimlicoClient extends BundlerClient {
   /// Use this to verify that a sponsorship policy will cover a
   /// UserOperation before submitting it.
   ///
-  /// [userOperation] is the UserOperation to validate against policies.
+  /// RPC method: `pm_validateSponsorshipPolicies` (matches permissionless.js).
+  ///
+  /// [userOperation] is the UserOperation to validate against policies
+  /// (v0.6 or v0.7).
   /// [sponsorshipPolicyIds] is a list of policy IDs to check.
   ///
   /// Returns a list of valid policies with their metadata.
@@ -284,19 +322,17 @@ class PimlicoClient extends BundlerClient {
   /// }
   /// ```
   Future<List<PimlicoSponsorshipPolicy>> validateSponsorshipPolicies({
-    required UserOperationV07 userOperation,
+    required UserOperation userOperation,
     required List<String> sponsorshipPolicyIds,
   }) async {
     if (sponsorshipPolicyIds.isEmpty) {
       return [];
     }
 
-    final packedUserOp = _packUserOperationV07(userOperation);
-
     final result = await rpcClient.call(
-      'pimlico_validateSponsorshipPolicies',
+      'pm_validateSponsorshipPolicies',
       [
-        packedUserOp,
+        userOperation.toJson(),
         entryPoint.hex,
         sponsorshipPolicyIds,
       ],
@@ -335,35 +371,4 @@ PimlicoClient createPimlicoClient({
       entryPoint: entryPoint,
     );
 
-/// Packs a UserOperationV07 for RPC transmission.
-Map<String, dynamic> _packUserOperationV07(UserOperationV07 userOp) {
-  final packed = <String, dynamic>{
-    'sender': userOp.sender.hex,
-    'nonce': Hex.fromBigInt(userOp.nonce),
-    'callData': userOp.callData,
-    'callGasLimit': Hex.fromBigInt(userOp.callGasLimit),
-    'verificationGasLimit': Hex.fromBigInt(userOp.verificationGasLimit),
-    'preVerificationGas': Hex.fromBigInt(userOp.preVerificationGas),
-    'maxFeePerGas': Hex.fromBigInt(userOp.maxFeePerGas),
-    'maxPriorityFeePerGas': Hex.fromBigInt(userOp.maxPriorityFeePerGas),
-    'signature': userOp.signature,
-  };
 
-  // Factory data (v0.7 style)
-  if (userOp.factory != null) {
-    packed['factory'] = userOp.factory!.hex;
-    packed['factoryData'] = userOp.factoryData ?? '0x';
-  }
-
-  // Paymaster data (v0.7 style)
-  if (userOp.paymaster != null) {
-    packed['paymaster'] = userOp.paymaster!.hex;
-    packed['paymasterVerificationGasLimit'] =
-        Hex.fromBigInt(userOp.paymasterVerificationGasLimit ?? BigInt.zero);
-    packed['paymasterPostOpGasLimit'] =
-        Hex.fromBigInt(userOp.paymasterPostOpGasLimit ?? BigInt.zero);
-    packed['paymasterData'] = userOp.paymasterData ?? '0x';
-  }
-
-  return packed;
-}

--- a/packages/permissionless/lib/src/clients/pimlico/pimlico_client.dart
+++ b/packages/permissionless/lib/src/clients/pimlico/pimlico_client.dart
@@ -270,8 +270,7 @@ class PimlicoClient extends BundlerClient {
     }
 
     // max cost in wei including paymaster postOp gas
-    final maxCostInWei =
-        userOperationMaxCost + quote.postOpGas * maxFeePerGas;
+    final maxCostInWei = userOperationMaxCost + quote.postOpGas * maxFeePerGas;
 
     // cost in token denomination (wei-scale exchange rate)
     final costInToken =
@@ -370,5 +369,3 @@ PimlicoClient createPimlicoClient({
       ),
       entryPoint: entryPoint,
     );
-
-

--- a/packages/permissionless/lib/src/clients/pimlico/types.dart
+++ b/packages/permissionless/lib/src/clients/pimlico/types.dart
@@ -283,8 +283,8 @@ class PimlicoSponsorshipPolicyData {
   ///
   /// Use [PimlicoSponsorshipPolicyData.fromJson] for parsing API responses.
   const PimlicoSponsorshipPolicyData({
-    required this.name,
-    required this.author,
+    this.name,
+    this.author,
     this.icon,
     this.description,
   });
@@ -292,19 +292,20 @@ class PimlicoSponsorshipPolicyData {
   /// Creates a [PimlicoSponsorshipPolicyData] from a JSON response.
   ///
   /// Parses the nested `data` field from sponsorship policy responses.
+  /// All fields are nullable to match the Pimlico API / permissionless.js types.
   factory PimlicoSponsorshipPolicyData.fromJson(Map<String, dynamic> json) =>
       PimlicoSponsorshipPolicyData(
-        name: json['name'] as String,
-        author: json['author'] as String,
+        name: json['name'] as String?,
+        author: json['author'] as String?,
         icon: json['icon'] as String?,
         description: json['description'] as String?,
       );
 
   /// Human-readable name of the sponsorship policy.
-  final String name;
+  final String? name;
 
   /// Author or organization that created the policy.
-  final String author;
+  final String? author;
 
   /// Optional icon URL for the policy.
   final String? icon;
@@ -331,7 +332,7 @@ class PimlicoSponsorshipPolicy {
 
   /// Creates a [PimlicoSponsorshipPolicy] from a JSON response.
   ///
-  /// Parses a single policy from `pimlico_validateSponsorshipPolicies`.
+  /// Parses a single policy from `pm_validateSponsorshipPolicies`.
   factory PimlicoSponsorshipPolicy.fromJson(Map<String, dynamic> json) =>
       PimlicoSponsorshipPolicy(
         sponsorshipPolicyId: json['sponsorshipPolicyId'] as String,
@@ -350,10 +351,13 @@ class PimlicoSponsorshipPolicy {
   String toString() => 'PimlicoSponsorshipPolicy($sponsorshipPolicyId)';
 }
 
-/// ERC-20 paymaster cost estimate from Pimlico.
+/// ERC-20 paymaster cost estimate (local computation from token quotes).
 ///
 /// Contains the estimated cost to pay for gas using a specific
 /// ERC-20 token. Both token amount and USD equivalent are provided.
+///
+/// Computed from [PimlicoClient.getTokenQuotes] + [getRequiredPrefund],
+/// matching permissionless.js `estimateErc20PaymasterCost`.
 ///
 /// Example:
 /// ```dart
@@ -361,20 +365,16 @@ class PimlicoSponsorshipPolicy {
 ///   userOperation: userOp,
 ///   token: usdcAddress,
 /// );
-/// print('Cost: ${cost.costInToken} tokens (~\$${cost.costInUsd / 1e8})');
+/// print('Cost: ${cost.costInToken} tokens (~\$${cost.costInUsd / 1e6})');
 /// ```
 class PimlicoErc20PaymasterCost {
   /// Creates an ERC-20 paymaster cost estimate.
-  ///
-  /// Use [PimlicoErc20PaymasterCost.fromJson] for parsing API responses.
   const PimlicoErc20PaymasterCost({
     required this.costInToken,
     required this.costInUsd,
   });
 
-  /// Creates a [PimlicoErc20PaymasterCost] from a JSON response.
-  ///
-  /// Parses the cost estimate from `pimlico_estimateErc20PaymasterCost`.
+  /// Creates a [PimlicoErc20PaymasterCost] from a JSON map.
   factory PimlicoErc20PaymasterCost.fromJson(Map<String, dynamic> json) =>
       PimlicoErc20PaymasterCost(
         costInToken: parseBigInt(json['costInToken']),
@@ -387,10 +387,10 @@ class PimlicoErc20PaymasterCost {
   /// For DAI (18 decimals): 1000000000000000000 = 1 DAI
   final BigInt costInToken;
 
-  /// Cost in USD with 8 decimals precision.
+  /// Cost in USD with 6 decimals precision (10^6).
   ///
-  /// Divide by 10^8 to get human-readable USD amount.
-  /// Example: 150000000 = $1.50
+  /// Matches permissionless.js: divide by 10^6 for a human-readable USD amount.
+  /// Example: 1500000 = $1.50
   final BigInt costInUsd;
 
   @override

--- a/packages/permissionless/lib/src/utils/erc7579.dart
+++ b/packages/permissionless/lib/src/utils/erc7579.dart
@@ -77,20 +77,20 @@ class Erc7579Selectors {
   static const String installModule = '0x9517e29f';
 
   /// uninstallModule(uint256 moduleTypeId, address module, bytes deInitData)
-  /// `keccak256("uninstallModule(uint256,address,bytes)")[0:4]` = 0xa4d6f1d2
-  static const String uninstallModule = '0xa4d6f1d2';
+  /// `keccak256("uninstallModule(uint256,address,bytes)")[0:4]` = 0xa71763a8
+  static const String uninstallModule = '0xa71763a8';
 
   /// isModuleInstalled(uint256 moduleTypeId, address module, bytes additionalContext)
-  /// `keccak256("isModuleInstalled(uint256,address,bytes)")[0:4]` = 0x6d61fe70
-  static const String isModuleInstalled = '0x6d61fe70';
+  /// `keccak256("isModuleInstalled(uint256,address,bytes)")[0:4]` = 0x112d3a7d
+  static const String isModuleInstalled = '0x112d3a7d';
 
   /// supportsModule(uint256 moduleTypeId)
-  /// `keccak256("supportsModule(uint256)")[0:4]` = 0x12d79da3
-  static const String supportsModule = '0x12d79da3';
+  /// `keccak256("supportsModule(uint256)")[0:4]` = 0xf2dc691d
+  static const String supportsModule = '0xf2dc691d';
 
   /// accountId()
-  /// `keccak256("accountId()")[0:4]` = 0x7b60424a
-  static const String accountId = '0x7b60424a';
+  /// `keccak256("accountId()")[0:4]` = 0x9cfd7cff
+  static const String accountId = '0x9cfd7cff';
 
   /// supportsExecutionMode(bytes32 mode)
   /// `keccak256("supportsExecutionMode(bytes32)")[0:4]` = 0xd03c7914

--- a/packages/permissionless/test/accounts/kernel/kernel_account_test.dart
+++ b/packages/permissionless/test/accounts/kernel/kernel_account_test.dart
@@ -479,7 +479,20 @@ void main() {
     });
 
     group('call encoding', () {
-      test('encodes single call with v0.2 execute', () {
+      // Fixtures generated from permissionless.js KernelExecuteAbi via viem
+      // encodeFunctionData (accounts/kernel/abi/KernelAccountAbi.ts).
+      // execute(address,uint256,bytes,uint8) = 0x51945447
+      // executeBatch((address,uint256,bytes)[]) = 0x34fcd5be
+      const jsSingleEmpty =
+          '0x5194544700000000000000000000000012345678901234567890123456789012345678900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000';
+      const jsSingleWithData =
+          '0x51945447000000000000000000000000abcdefabcdefabcdefabcdefabcdefabcdefabcd00000000000000000000000000000000000000000000000000000000000003e8000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004deadbeef00000000000000000000000000000000000000000000000000000000';
+      const jsBatch =
+          '0x34fcd5be00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000c000000000000000000000000011111111111111111111111111111111111111110000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002222222222222222222222222222222222222222000000000000000000000000000000000000000000000000000000000000006400000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000002abcd000000000000000000000000000000000000000000000000000000000000';
+      const jsBatchThree =
+          '0x34fcd5be00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000180000000000000000000000000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000010100000000000000000000000000000000000000000000000000000000000000000000000000000000000000bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000000000000000000000000000000cccccccccccccccccccccccccccccccccccccccc00000000000000000000000000000000000000000000000000000000000003e700000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000004abcdef0100000000000000000000000000000000000000000000000000000000';
+
+      test('encodes single call with Kernel v2 execute selector', () {
         final call = Call(
           to: EthereumAddress.fromHex(
             '0x1234567890123456789012345678901234567890',
@@ -491,14 +504,45 @@ void main() {
         final encoded = account.encodeCall(call);
 
         expect(encoded, startsWith('0x'));
-        // Should use v0.2 execute selector
+        expect(
+          encoded.substring(2, 10).toLowerCase(),
+          equals('51945447'),
+        );
         expect(
           encoded.substring(2, 10).toLowerCase(),
           equals(KernelSelectors.executeV2.substring(2).toLowerCase()),
         );
       });
 
-      test('encodes batch calls with v0.2 executeBatch', () {
+      test('single empty call byte-matches permissionless.js', () {
+        final encoded = account.encodeCall(
+          Call(
+            to: EthereumAddress.fromHex(
+              '0x1234567890123456789012345678901234567890',
+            ),
+            value: BigInt.zero,
+            data: '0x',
+          ),
+        );
+
+        expect(encoded.toLowerCase(), equals(jsSingleEmpty.toLowerCase()));
+      });
+
+      test('single call with value/data byte-matches permissionless.js', () {
+        final encoded = account.encodeCall(
+          Call(
+            to: EthereumAddress.fromHex(
+              '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
+            ),
+            value: BigInt.from(1000),
+            data: '0xdeadbeef',
+          ),
+        );
+
+        expect(encoded.toLowerCase(), equals(jsSingleWithData.toLowerCase()));
+      });
+
+      test('encodes batch calls with Kernel v2 executeBatch selector', () {
         final calls = [
           Call(
             to: EthereumAddress.fromHex(
@@ -521,8 +565,73 @@ void main() {
         expect(encoded, startsWith('0x'));
         expect(
           encoded.substring(2, 10).toLowerCase(),
+          equals('34fcd5be'),
+        );
+        expect(
+          encoded.substring(2, 10).toLowerCase(),
           equals(KernelSelectors.executeBatchV2.substring(2).toLowerCase()),
         );
+      });
+
+      test('batch calls byte-match permissionless.js', () {
+        final encoded = account.encodeCalls([
+          Call(
+            to: EthereumAddress.fromHex(
+              '0x1111111111111111111111111111111111111111',
+            ),
+            value: BigInt.zero,
+            data: '0x',
+          ),
+          Call(
+            to: EthereumAddress.fromHex(
+              '0x2222222222222222222222222222222222222222',
+            ),
+            value: BigInt.from(100),
+            data: '0xabcd',
+          ),
+        ]);
+
+        expect(encoded.toLowerCase(), equals(jsBatch.toLowerCase()));
+      });
+
+      test('three-call batch byte-matches permissionless.js', () {
+        final encoded = account.encodeCalls([
+          Call(
+            to: EthereumAddress.fromHex(
+              '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            ),
+            value: BigInt.one,
+            data: '0x01',
+          ),
+          Call(
+            to: EthereumAddress.fromHex(
+              '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+            ),
+            value: BigInt.zero,
+            data: '0x',
+          ),
+          Call(
+            to: EthereumAddress.fromHex(
+              '0xcccccccccccccccccccccccccccccccccccccccc',
+            ),
+            value: BigInt.from(999),
+            data: '0xabcdef01',
+          ),
+        ]);
+
+        expect(encoded.toLowerCase(), equals(jsBatchThree.toLowerCase()));
+      });
+
+      test('single call via encodeCalls matches encodeCall', () {
+        final call = Call(
+          to: EthereumAddress.fromHex(
+            '0x1234567890123456789012345678901234567890',
+          ),
+          value: BigInt.zero,
+          data: '0x',
+        );
+
+        expect(account.encodeCalls([call]), equals(account.encodeCall(call)));
       });
     });
 
@@ -730,12 +839,17 @@ void main() {
   });
 
   group('KernelSelectors', () {
-    test('executeV2 selector is correct', () {
-      expect(KernelSelectors.executeV2, equals('0xb61d27f6'));
+    test('executeV2 is Kernel execute(address,uint256,bytes,uint8)', () {
+      // cast sig "execute(address,uint256,bytes,uint8)"
+      // Not SimpleAccount's execute(address,uint256,bytes) = 0xb61d27f6
+      expect(KernelSelectors.executeV2, equals('0x51945447'));
     });
 
-    test('executeBatchV2 selector is correct', () {
-      expect(KernelSelectors.executeBatchV2, equals('0x47e1da2a'));
+    test('executeBatchV2 is Kernel executeBatch((address,uint256,bytes)[])',
+        () {
+      // cast sig "executeBatch((address,uint256,bytes)[])"
+      // Not SimpleAccount's executeBatch(address[],uint256[],bytes[]) = 0x47e1da2a
+      expect(KernelSelectors.executeBatchV2, equals('0x34fcd5be'));
     });
 
     test('executeV3 selector matches ERC-7579', () {

--- a/packages/permissionless/test/accounts/nexus/nexus_account_test.dart
+++ b/packages/permissionless/test/accounts/nexus/nexus_account_test.dart
@@ -1,0 +1,150 @@
+import 'package:permissionless/permissionless.dart';
+import 'package:test/test.dart';
+
+void main() {
+  // Hardhat account 0 — do not use in production
+  const testPrivateKey =
+      '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
+
+  final mockAddress =
+      EthereumAddress.fromHex('0x1234567890123456789012345678901234567890');
+
+  // Fixed UserOperation fields matching permissionless.js / viem fixture
+  // (chainId=1, sender=mockAddress, no factory/paymaster).
+  //
+  // JS fixture (viem getUserOperationHash + localOwner.signMessage raw hash):
+  // userOpHash: 0x152aa3402c1452b6e84bd92cdf80a83d4a93c90fa5bf441053bb90075df2191d
+  // signature:  0x00538c3d1fb4197de5a15394fcaf23ca1a570c63576424c0615656be0e112f5964840719f944a8d5b0e21ad3a262725d1004ac6a9926ac6299b3f48d1c0c0d8d1b
+  const jsFixtureUserOpSignature =
+      '0x00538c3d1fb4197de5a15394fcaf23ca1a570c63576424c0615656be0e112f59'
+      '64840719f944a8d5b0e21ad3a262725d1004ac6a9926ac6299b3f48d1c0c0d8d1b';
+
+  UserOperationV07 fixtureUserOp(EthereumAddress sender) => UserOperationV07(
+        sender: sender,
+        nonce: BigInt.zero,
+        callData: '0x',
+        callGasLimit: BigInt.from(100000),
+        verificationGasLimit: BigInt.from(100000),
+        preVerificationGas: BigInt.from(21000),
+        maxFeePerGas: BigInt.from(1000000000),
+        maxPriorityFeePerGas: BigInt.from(1000000000),
+      );
+
+  group('NexusAddresses', () {
+    test('k1ValidatorFactory address matches permissionless.js', () {
+      expect(
+        NexusAddresses.k1ValidatorFactory.hex.toLowerCase(),
+        equals('0x00000bb19a3579f4d779215def97afbd0e30db55'),
+      );
+    });
+
+    test('k1Validator address matches permissionless.js', () {
+      expect(
+        NexusAddresses.k1Validator.hex.toLowerCase(),
+        equals('0x00000004171351c442b202678c48d8ab5b321e8f'),
+      );
+    });
+  });
+
+  group('NexusSelectors', () {
+    test('createAccount selector is correct', () {
+      // keccak256("createAccount(address,uint256,address[],uint8)")[0:4]
+      expect(NexusSelectors.createAccount, equals('0x0d51f0b7'));
+    });
+
+    test('computeAccountAddress selector is correct', () {
+      // keccak256("computeAccountAddress(address,uint256,address[],uint8)")[0:4]
+      expect(NexusSelectors.computeAccountAddress, equals('0x322cc8ca'));
+    });
+  });
+
+  group('NexusSmartAccount', () {
+    late PrivateKeyOwner owner;
+    late NexusSmartAccount account;
+
+    setUp(() {
+      owner = PrivateKeyOwner(testPrivateKey);
+      account = createNexusSmartAccount(
+        owner: owner,
+        chainId: BigInt.one,
+        address: mockAddress,
+      );
+    });
+
+    group('creation', () {
+      test('creates account with defaults for EntryPoint v0.7', () {
+        expect(account.owner, equals(owner));
+        expect(account.chainId, equals(BigInt.one));
+        expect(account.entryPointVersion, equals(EntryPointVersion.v07));
+        expect(account.index, equals(BigInt.zero));
+      });
+
+      test('getAddress returns configured address', () async {
+        final address = await account.getAddress();
+        expect(address.hex.toLowerCase(), equals(mockAddress.hex.toLowerCase()));
+      });
+    });
+
+    group('signUserOperation', () {
+      test('returns bare 65-byte ECDSA signature (no validator prefix)',
+          () async {
+        final signature =
+            await account.signUserOperation(fixtureUserOp(mockAddress));
+
+        expect(signature, startsWith('0x'));
+        // 65 bytes = 130 hex chars + 0x prefix
+        expect(signature.length, equals(132));
+        expect((signature.length - 2) ~/ 2, equals(65));
+      });
+
+      test('does not prepend K1 validator address', () async {
+        final signature =
+            await account.signUserOperation(fixtureUserOp(mockAddress));
+
+        final validatorHex =
+            Hex.strip0x(NexusAddresses.k1Validator.hex).toLowerCase();
+        final sigBody = Hex.strip0x(signature).toLowerCase();
+
+        // Bug was packing validator (20B) + sig (65B) = 85B starting with validator
+        expect(sigBody.startsWith(validatorHex), isFalse);
+        expect(signature.length, isNot(equals(172))); // 85 bytes + 0x
+      });
+
+      test('byte-matches permissionless.js for same key and userOp', () async {
+        final signature =
+            await account.signUserOperation(fixtureUserOp(mockAddress));
+
+        expect(
+          signature.toLowerCase(),
+          equals(jsFixtureUserOpSignature.toLowerCase()),
+        );
+      });
+    });
+
+    group('signMessage (ERC-1271)', () {
+      test('still packs validator address + 65-byte signature', () async {
+        final signature = await account.signMessage('hello nexus');
+
+        expect(signature, startsWith('0x'));
+        // 20-byte validator + 65-byte ECDSA = 85 bytes = 170 hex + 0x
+        expect(signature.length, equals(172));
+        expect((signature.length - 2) ~/ 2, equals(85));
+
+        final validatorHex =
+            Hex.strip0x(NexusAddresses.k1Validator.hex).toLowerCase();
+        final sigBody = Hex.strip0x(signature).toLowerCase();
+        expect(sigBody.startsWith(validatorHex), isTrue);
+      });
+    });
+
+    group('getStubSignature', () {
+      test('includes validator address for gas estimation', () {
+        final stub = account.getStubSignature();
+        expect(stub, startsWith('0x'));
+        final validatorHex =
+            Hex.strip0x(NexusAddresses.k1Validator.hex).toLowerCase();
+        expect(Hex.strip0x(stub).toLowerCase().contains(validatorHex), isTrue);
+      });
+    });
+  });
+}

--- a/packages/permissionless/test/accounts/nexus/nexus_account_test.dart
+++ b/packages/permissionless/test/accounts/nexus/nexus_account_test.dart
@@ -81,7 +81,8 @@ void main() {
 
       test('getAddress returns configured address', () async {
         final address = await account.getAddress();
-        expect(address.hex.toLowerCase(), equals(mockAddress.hex.toLowerCase()));
+        expect(
+            address.hex.toLowerCase(), equals(mockAddress.hex.toLowerCase()));
       });
     });
 

--- a/packages/permissionless/test/accounts/safe/safe_account_test.dart
+++ b/packages/permissionless/test/accounts/safe/safe_account_test.dart
@@ -713,15 +713,12 @@ void main() {
       expect(addresses, isNotNull);
       expectMatchesJsTable(
         addresses!,
-        safeModuleSetupAddress:
-            '0x8EcD4ec46D4D2a6B64fE960B3D64e8B94B2234eb',
+        safeModuleSetupAddress: '0x8EcD4ec46D4D2a6B64fE960B3D64e8B94B2234eb',
         safe4337ModuleAddress: '0xa581c4A4DB7175302464fF3C06380BC3270b4037',
-        safeProxyFactoryAddress:
-            '0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67',
+        safeProxyFactoryAddress: '0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67',
         safeSingletonAddress: '0x41675C099F32341bf84BFc5382aF534df5C7461a',
         multiSendAddress: '0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526',
-        multiSendCallOnlyAddress:
-            '0x9641d764fc13c8B624c04430C7356C1C7C8102e2',
+        multiSendCallOnlyAddress: '0x9641d764fc13c8B624c04430C7356C1C7C8102e2',
       );
     });
 
@@ -734,19 +731,15 @@ void main() {
       expect(addresses, isNotNull);
       expectMatchesJsTable(
         addresses!,
-        safeModuleSetupAddress:
-            '0x2dd68b007B46fBe91B9A7c3EDa5A7a1063cB5b47',
+        safeModuleSetupAddress: '0x2dd68b007B46fBe91B9A7c3EDa5A7a1063cB5b47',
         safe4337ModuleAddress: '0x75cf11467937ce3F2f357CE24ffc3DBF8fD5c226',
-        safeProxyFactoryAddress:
-            '0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67',
+        safeProxyFactoryAddress: '0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67',
         safeSingletonAddress: '0x41675C099F32341bf84BFc5382aF534df5C7461a',
         multiSendAddress: '0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526',
-        multiSendCallOnlyAddress:
-            '0x9641d764fc13c8B624c04430C7356C1C7C8102e2',
+        multiSendCallOnlyAddress: '0x9641d764fc13c8B624c04430C7356C1C7C8102e2',
         webAuthnSharedSignerAddress:
             '0x94a4F6affBd8975951142c3999aEAB7ecee555c2',
-        safeP256VerifierAddress:
-            '0xA86e0054C51E4894D88762a017ECc5E5235f5DBA',
+        safeP256VerifierAddress: '0xA86e0054C51E4894D88762a017ECc5E5235f5DBA',
       );
     });
 
@@ -760,19 +753,15 @@ void main() {
       // JS: MULTI_SEND_CALL_ONLY_ADDRESS 0xA83c…1836 (Etherscan: MultiSendCallOnly, verified)
       expectMatchesJsTable(
         addresses!,
-        safeModuleSetupAddress:
-            '0x2dd68b007B46fBe91B9A7c3EDa5A7a1063cB5b47',
+        safeModuleSetupAddress: '0x2dd68b007B46fBe91B9A7c3EDa5A7a1063cB5b47',
         safe4337ModuleAddress: '0x75cf11467937ce3F2f357CE24ffc3DBF8fD5c226',
-        safeProxyFactoryAddress:
-            '0x14F2982D601c9458F93bd70B218933A6f8165e7b',
+        safeProxyFactoryAddress: '0x14F2982D601c9458F93bd70B218933A6f8165e7b',
         safeSingletonAddress: '0xFf51A5898e281Db6DfC7855790607438dF2ca44b',
         multiSendAddress: '0x218543288004CD07832472D464648173c77D7eB7',
-        multiSendCallOnlyAddress:
-            '0xA83c336B20401Af773B6219BA5027174338D1836',
+        multiSendCallOnlyAddress: '0xA83c336B20401Af773B6219BA5027174338D1836',
         webAuthnSharedSignerAddress:
             '0x94a4F6affBd8975951142c3999aEAB7ecee555c2',
-        safeP256VerifierAddress:
-            '0xA86e0054C51E4894D88762a017ECc5E5235f5DBA',
+        safeP256VerifierAddress: '0xA86e0054C51E4894D88762a017ECc5E5235f5DBA',
       );
     });
 

--- a/packages/permissionless/test/accounts/safe/safe_account_test.dart
+++ b/packages/permissionless/test/accounts/safe/safe_account_test.dart
@@ -649,6 +649,61 @@ void main() {
   });
 
   group('SafeVersionAddresses', () {
+    // Fixtures from permissionless.js `toSafeSmartAccount.ts` SAFE_VERSION_TO_ADDRESSES_MAP.
+    // Independent source of truth for parity — do not derive from Dart constants.
+    void expectMatchesJsTable(
+      SafeAddresses actual, {
+      required String safeModuleSetupAddress,
+      required String safe4337ModuleAddress,
+      required String safeProxyFactoryAddress,
+      required String safeSingletonAddress,
+      required String multiSendAddress,
+      required String multiSendCallOnlyAddress,
+      String? webAuthnSharedSignerAddress,
+      String? safeP256VerifierAddress,
+    }) {
+      expect(
+        actual.safeModuleSetupAddress,
+        equals(EthereumAddress.fromHex(safeModuleSetupAddress)),
+      );
+      expect(
+        actual.safe4337ModuleAddress,
+        equals(EthereumAddress.fromHex(safe4337ModuleAddress)),
+      );
+      expect(
+        actual.safeProxyFactoryAddress,
+        equals(EthereumAddress.fromHex(safeProxyFactoryAddress)),
+      );
+      expect(
+        actual.safeSingletonAddress,
+        equals(EthereumAddress.fromHex(safeSingletonAddress)),
+      );
+      expect(
+        actual.multiSendAddress,
+        equals(EthereumAddress.fromHex(multiSendAddress)),
+      );
+      expect(
+        actual.multiSendCallOnlyAddress,
+        equals(EthereumAddress.fromHex(multiSendCallOnlyAddress)),
+      );
+      if (webAuthnSharedSignerAddress == null) {
+        expect(actual.webAuthnSharedSignerAddress, isNull);
+      } else {
+        expect(
+          actual.webAuthnSharedSignerAddress,
+          equals(EthereumAddress.fromHex(webAuthnSharedSignerAddress)),
+        );
+      }
+      if (safeP256VerifierAddress == null) {
+        expect(actual.safeP256VerifierAddress, isNull);
+      } else {
+        expect(
+          actual.safeP256VerifierAddress,
+          equals(EthereumAddress.fromHex(safeP256VerifierAddress)),
+        );
+      }
+    }
+
     test('returns addresses for v1.4.1 + EP v0.6', () {
       final addresses = SafeVersionAddresses.getAddresses(
         SafeVersion.v1_4_1,
@@ -656,7 +711,18 @@ void main() {
       );
 
       expect(addresses, isNotNull);
-      expect(addresses!.safe4337ModuleAddress.hex.isNotEmpty, isTrue);
+      expectMatchesJsTable(
+        addresses!,
+        safeModuleSetupAddress:
+            '0x8EcD4ec46D4D2a6B64fE960B3D64e8B94B2234eb',
+        safe4337ModuleAddress: '0xa581c4A4DB7175302464fF3C06380BC3270b4037',
+        safeProxyFactoryAddress:
+            '0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67',
+        safeSingletonAddress: '0x41675C099F32341bf84BFc5382aF534df5C7461a',
+        multiSendAddress: '0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526',
+        multiSendCallOnlyAddress:
+            '0x9641d764fc13c8B624c04430C7356C1C7C8102e2',
+      );
     });
 
     test('returns addresses for v1.4.1 + EP v0.7', () {
@@ -666,7 +732,22 @@ void main() {
       );
 
       expect(addresses, isNotNull);
-      expect(addresses!.webAuthnSharedSignerAddress, isNotNull);
+      expectMatchesJsTable(
+        addresses!,
+        safeModuleSetupAddress:
+            '0x2dd68b007B46fBe91B9A7c3EDa5A7a1063cB5b47',
+        safe4337ModuleAddress: '0x75cf11467937ce3F2f357CE24ffc3DBF8fD5c226',
+        safeProxyFactoryAddress:
+            '0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67',
+        safeSingletonAddress: '0x41675C099F32341bf84BFc5382aF534df5C7461a',
+        multiSendAddress: '0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526',
+        multiSendCallOnlyAddress:
+            '0x9641d764fc13c8B624c04430C7356C1C7C8102e2',
+        webAuthnSharedSignerAddress:
+            '0x94a4F6affBd8975951142c3999aEAB7ecee555c2',
+        safeP256VerifierAddress:
+            '0xA86e0054C51E4894D88762a017ECc5E5235f5DBA',
+      );
     });
 
     test('returns addresses for v1.5.0 + EP v0.7', () {
@@ -676,6 +757,23 @@ void main() {
       );
 
       expect(addresses, isNotNull);
+      // JS: MULTI_SEND_CALL_ONLY_ADDRESS 0xA83c…1836 (Etherscan: MultiSendCallOnly, verified)
+      expectMatchesJsTable(
+        addresses!,
+        safeModuleSetupAddress:
+            '0x2dd68b007B46fBe91B9A7c3EDa5A7a1063cB5b47',
+        safe4337ModuleAddress: '0x75cf11467937ce3F2f357CE24ffc3DBF8fD5c226',
+        safeProxyFactoryAddress:
+            '0x14F2982D601c9458F93bd70B218933A6f8165e7b',
+        safeSingletonAddress: '0xFf51A5898e281Db6DfC7855790607438dF2ca44b',
+        multiSendAddress: '0x218543288004CD07832472D464648173c77D7eB7',
+        multiSendCallOnlyAddress:
+            '0xA83c336B20401Af773B6219BA5027174338D1836',
+        webAuthnSharedSignerAddress:
+            '0x94a4F6affBd8975951142c3999aEAB7ecee555c2',
+        safeP256VerifierAddress:
+            '0xA86e0054C51E4894D88762a017ECc5E5235f5DBA',
+      );
     });
 
     test('returns null for v1.5.0 + EP v0.6', () {

--- a/packages/permissionless/test/accounts/thirdweb/thirdweb_account_test.dart
+++ b/packages/permissionless/test/accounts/thirdweb/thirdweb_account_test.dart
@@ -1,0 +1,123 @@
+import 'package:permissionless/permissionless.dart';
+import 'package:test/test.dart';
+
+void main() {
+  // Hardhat account 0 — do not use in production
+  const testPrivateKey =
+      '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
+
+  // Same owner address as privateKeyToAccount(testPrivateKey) in viem
+  const ownerAddress = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266';
+
+  final mockAddress =
+      EthereumAddress.fromHex('0x1234567890123456789012345678901234567890');
+
+  // Fixtures from permissionless.js / viem:
+  //   salt omitted → "0x" empty bytes
+  //   salt "test-salt" → toHex("test-salt") = 0x746573742d73616c74
+  // encodeFunctionData(createAccount(admin, saltBytes))
+  const jsFactoryDataDefaultSalt =
+      '0xd8fd8f44000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb92266'
+      '0000000000000000000000000000000000000000000000000000000000000040'
+      '0000000000000000000000000000000000000000000000000000000000000000';
+
+  const jsFactoryDataTestSalt =
+      '0xd8fd8f44000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb92266'
+      '0000000000000000000000000000000000000000000000000000000000000040'
+      '0000000000000000000000000000000000000000000000000000000000000009'
+      '746573742d73616c740000000000000000000000000000000000000000000000';
+
+  group('ThirdwebSmartAccount salt encoding', () {
+    late PrivateKeyOwner owner;
+
+    setUp(() {
+      owner = PrivateKeyOwner(testPrivateKey);
+      expect(owner.address.hex.toLowerCase(), equals(ownerAddress.toLowerCase()));
+    });
+
+    test('default (empty) salt factoryData matches permissionless.js', () async {
+      final account = createThirdwebSmartAccount(
+        owner: owner,
+        chainId: BigInt.one,
+        address: mockAddress,
+      );
+
+      final factoryData = await account.getFactoryData();
+      expect(factoryData, isNotNull);
+      expect(
+        factoryData!.factoryData.toLowerCase(),
+        equals(jsFactoryDataDefaultSalt.toLowerCase()),
+      );
+      expect(
+        factoryData.factory.hex.toLowerCase(),
+        equals(ThirdwebAddresses.factoryV07.hex.toLowerCase()),
+      );
+    });
+
+    test(
+      'custom salt "test-salt" factoryData UTF-8-encodes like JS toHex',
+      () async {
+        final account = createThirdwebSmartAccount(
+          owner: owner,
+          chainId: BigInt.one,
+          salt: 'test-salt',
+          address: mockAddress,
+        );
+
+        final factoryData = await account.getFactoryData();
+        expect(factoryData, isNotNull);
+        expect(
+          factoryData!.factoryData.toLowerCase(),
+          equals(jsFactoryDataTestSalt.toLowerCase()),
+        );
+      },
+    );
+
+    test('initCode embeds the same factoryData for custom salt', () async {
+      final account = createThirdwebSmartAccount(
+        owner: owner,
+        chainId: BigInt.one,
+        salt: 'test-salt',
+        address: mockAddress,
+      );
+
+      final factoryData = await account.getFactoryData();
+      final initCode = await account.getInitCode();
+
+      expect(
+        initCode.toLowerCase(),
+        equals(
+          '${factoryData!.factory.hex}${factoryData.factoryData.substring(2)}'
+              .toLowerCase(),
+        ),
+      );
+      expect(
+        initCode.toLowerCase(),
+        endsWith(jsFactoryDataTestSalt.substring(2).toLowerCase()),
+      );
+    });
+
+    test('custom salt must not be hex-decoded (regression)', () async {
+      // If salt were hex-decoded, "test-salt" would throw or produce garbage.
+      // JS toHex UTF-8-encodes → salt bytes include ASCII 't','e','s','t',...
+      final account = createThirdwebSmartAccount(
+        owner: owner,
+        chainId: BigInt.one,
+        salt: 'test-salt',
+        address: mockAddress,
+      );
+
+      final factoryData = await account.getFactoryData();
+      // UTF-8 of "test-salt" appears after the length word (0x09)
+      expect(
+        factoryData!.factoryData.toLowerCase(),
+        contains('746573742d73616c74'),
+      );
+      // Must not contain a short hex-decode of the string as hex digits
+      expect(
+        factoryData.factoryData.toLowerCase(),
+        isNot(equals(jsFactoryDataDefaultSalt.toLowerCase())),
+      );
+    });
+  });
+}

--- a/packages/permissionless/test/accounts/thirdweb/thirdweb_account_test.dart
+++ b/packages/permissionless/test/accounts/thirdweb/thirdweb_account_test.dart
@@ -32,10 +32,12 @@ void main() {
 
     setUp(() {
       owner = PrivateKeyOwner(testPrivateKey);
-      expect(owner.address.hex.toLowerCase(), equals(ownerAddress.toLowerCase()));
+      expect(
+          owner.address.hex.toLowerCase(), equals(ownerAddress.toLowerCase()));
     });
 
-    test('default (empty) salt factoryData matches permissionless.js', () async {
+    test('default (empty) salt factoryData matches permissionless.js',
+        () async {
       final account = createThirdwebSmartAccount(
         owner: owner,
         chainId: BigInt.one,

--- a/packages/permissionless/test/clients/pimlico/pimlico_client_test.dart
+++ b/packages/permissionless/test/clients/pimlico/pimlico_client_test.dart
@@ -488,8 +488,8 @@ void main() {
           final tokensObj = params[0] as Map<String, dynamic>;
           final tokens = tokensObj['tokens'] as List<dynamic>;
           final token = tokens.first as String;
-          result = quotesForToken?.call(token) ??
-              tokenQuotesResult(token: token);
+          result =
+              quotesForToken?.call(token) ?? tokenQuotesResult(token: token);
         } else {
           throw StateError('Unexpected RPC method: $method');
         }
@@ -552,8 +552,7 @@ void main() {
       // exchangeRateNativeToUsd 15e6 => costInUsd = 425e12 * 15e6 / 1e18
       final expectedPrefund = getRequiredPrefund(userOp);
       final postOpGas = BigInt.from(75000);
-      final maxCostInWei =
-          expectedPrefund + postOpGas * userOp.maxFeePerGas;
+      final maxCostInWei = expectedPrefund + postOpGas * userOp.maxFeePerGas;
       final expectedToken =
           (maxCostInWei * BigInt.from(10).pow(18)) ~/ BigInt.from(10).pow(18);
       final expectedUsd =

--- a/packages/permissionless/test/clients/pimlico/pimlico_client_test.dart
+++ b/packages/permissionless/test/clients/pimlico/pimlico_client_test.dart
@@ -220,7 +220,7 @@ void main() {
     });
 
     group('sendCompressedUserOperation', () {
-      test('sends compressed UserOp with inflator', () async {
+      test('sends 3 params matching Pimlico/JS schema', () async {
         final mockClient = createMockClient(
           (_) => '0xcompresseduserophash1234567890abcdef',
         );
@@ -230,29 +230,15 @@ void main() {
           httpClient: mockClient,
         );
 
-        final userOp = UserOperationV07(
-          sender: EthereumAddress.fromHex(
-            '0x1234567890123456789012345678901234567890',
-          ),
-          nonce: BigInt.one,
-          callData: '0xabcdef',
-          callGasLimit: BigInt.from(100000),
-          verificationGasLimit: BigInt.from(200000),
-          preVerificationGas: BigInt.from(50000),
-          maxFeePerGas: BigInt.from(1000000000),
-          maxPriorityFeePerGas: BigInt.from(100000000),
-          signature: '0xsignature',
-        );
-
         final inflator = EthereumAddress.fromHex(
           '0xabcdef1234567890abcdef1234567890abcdef12',
         );
-        const compressedCalldata = '0xcompresseddata123';
+        const compressedUserOperation = '0xcompresseddata123';
 
+        // ignore: deprecated_member_use_from_same_package
         final hash = await client.sendCompressedUserOperation(
-          userOp,
+          compressedUserOperation,
           inflator,
-          compressedCalldata,
         );
 
         expect(hash, equals('0xcompresseduserophash1234567890abcdef'));
@@ -261,59 +247,33 @@ void main() {
           equals('pimlico_sendCompressedUserOperation'),
         );
 
+        // JS/Pimlico: [compressedUserOperation, inflatorAddress, entryPoint]
         final params = capturedRequests[0]['params'] as List<dynamic>;
-        expect(params[1], equals(EntryPointAddresses.v07.hex));
-        expect(params[2], equals(compressedCalldata));
-        expect(params[3], equals(inflator.hex));
+        expect(params.length, equals(3));
+        expect(params[0], equals(compressedUserOperation));
+        expect(params[1], equals(inflator.hex));
+        expect(params[2], equals(EntryPointAddresses.v07.hex));
       });
 
-      test('includes factory and paymaster data when present', () async {
+      test('uses client entryPoint for param 3', () async {
         final mockClient = createMockClient(
           (_) => '0xhash1234567890abcdef1234567890abcdef',
         );
         client = createPimlicoClient(
           url: 'http://localhost:8545',
-          entryPoint: EntryPointAddresses.v07,
+          entryPoint: EntryPointAddresses.v06,
           httpClient: mockClient,
         );
 
-        final userOp = UserOperationV07(
-          sender: EthereumAddress.fromHex(
-            '0x1234567890123456789012345678901234567890',
-          ),
-          nonce: BigInt.one,
-          callData: '0xabcdef',
-          callGasLimit: BigInt.from(100000),
-          verificationGasLimit: BigInt.from(200000),
-          preVerificationGas: BigInt.from(50000),
-          maxFeePerGas: BigInt.from(1000000000),
-          maxPriorityFeePerGas: BigInt.from(100000000),
-          signature: '0xsignature',
-          factory: EthereumAddress.fromHex(
-            '0xaaaa567890123456789012345678901234567890',
-          ),
-          factoryData: '0xfactorydata',
-          paymaster: EthereumAddress.fromHex(
-            '0xbbbb567890123456789012345678901234567890',
-          ),
-          paymasterData: '0xpaymasterdata',
-          paymasterVerificationGasLimit: BigInt.from(50000),
-          paymasterPostOpGasLimit: BigInt.from(25000),
-        );
-
+        // ignore: deprecated_member_use_from_same_package
         await client.sendCompressedUserOperation(
-          userOp,
-          EthereumAddress.fromHex('0xabcdef1234567890abcdef1234567890abcdef12'),
           '0xcompressed',
+          EthereumAddress.fromHex('0xabcdef1234567890abcdef1234567890abcdef12'),
         );
 
         final params = capturedRequests[0]['params'] as List<dynamic>;
-        final packedUserOp = params[0] as Map<String, dynamic>;
-
-        expect(packedUserOp['factory'], equals(userOp.factory!.hex));
-        expect(packedUserOp['factoryData'], equals('0xfactorydata'));
-        expect(packedUserOp['paymaster'], equals(userOp.paymaster!.hex));
-        expect(packedUserOp['paymasterData'], equals('0xpaymasterdata'));
+        expect(params[0], equals('0xcompressed'));
+        expect(params[2], equals(EntryPointAddresses.v06.hex));
       });
     });
 
@@ -493,40 +453,156 @@ void main() {
     late PimlicoClient client;
     late List<Map<String, dynamic>> capturedRequests;
 
-    MockClient createMockClient(
-      dynamic Function(Map<String, dynamic> request) responseFactory,
-    ) {
+    /// Token quote fixture matching pimlico_getTokenQuotes response shape.
+    Map<String, dynamic> tokenQuotesResult({
+      required String token,
+      String postOpGas = '0x124f8', // 75000
+      String exchangeRate = '0xde0b6b3a7640000', // 1e18 (1:1)
+      String exchangeRateNativeToUsd = '0xe4e1c0', // 15_000_000 ($15.00, 6 dec)
+    }) =>
+        {
+          'quotes': [
+            {
+              'token': token,
+              'paymaster': '0x0000000000000039cd5e8aE05257CE51C473ddd1',
+              'postOpGas': postOpGas,
+              'exchangeRate': exchangeRate,
+              'exchangeRateNativeToUsd': exchangeRateNativeToUsd,
+            },
+          ],
+        };
+
+    MockClient createMockClient({
+      Map<String, dynamic> Function(String token)? quotesForToken,
+    }) {
       capturedRequests = [];
       return MockClient((request) async {
         final body = jsonDecode(request.body) as Map<String, dynamic>;
         capturedRequests.add(body);
-        final response = responseFactory(body);
+        final method = body['method'] as String;
+        final dynamic result;
+        if (method == 'eth_chainId') {
+          result = '0xaa36a7'; // sepolia
+        } else if (method == 'pimlico_getTokenQuotes') {
+          final params = body['params'] as List<dynamic>;
+          final tokensObj = params[0] as Map<String, dynamic>;
+          final tokens = tokensObj['tokens'] as List<dynamic>;
+          final token = tokens.first as String;
+          result = quotesForToken?.call(token) ??
+              tokenQuotesResult(token: token);
+        } else {
+          throw StateError('Unexpected RPC method: $method');
+        }
         return http.Response(
           jsonEncode({
             'jsonrpc': '2.0',
             'id': body['id'],
-            'result': response,
+            'result': result,
           }),
           200,
         );
       });
     }
 
-    test('returns cost estimate for ERC-20 token', () async {
-      final mockClient = createMockClient(
-        (_) => {
-          'costInToken':
-              '0x5f5e100', // 100,000,000 (1 USDC with 6 decimals = $100)
-          'costInUsd': '0x5f5e100', // 100,000,000 (1.00 USD with 8 decimals)
-        },
+    UserOperationV07 sampleV07() => UserOperationV07(
+          sender: EthereumAddress.fromHex(
+            '0x1234567890123456789012345678901234567890',
+          ),
+          nonce: BigInt.one,
+          callData: '0xabcdef',
+          callGasLimit: BigInt.from(100000),
+          verificationGasLimit: BigInt.from(200000),
+          preVerificationGas: BigInt.from(50000),
+          maxFeePerGas: BigInt.from(1000000000), // 1 gwei
+          maxPriorityFeePerGas: BigInt.from(100000000),
+          signature: '0xsignature',
+        );
+
+    test('computes cost locally via getTokenQuotes (no fictitious RPC)',
+        () async {
+      final token = EthereumAddress.fromHex(
+        '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
       );
       client = createPimlicoClient(
         url: 'http://localhost:8545',
         entryPoint: EntryPointAddresses.v07,
-        httpClient: mockClient,
+        httpClient: createMockClient(),
       );
 
-      final userOp = UserOperationV07(
+      final userOp = sampleV07();
+      final cost = await client.estimateErc20PaymasterCost(
+        userOperation: userOp,
+        token: token,
+      );
+
+      // Never call the nonexistent pimlico_estimateErc20PaymasterCost
+      expect(
+        capturedRequests.map((r) => r['method']),
+        isNot(contains('pimlico_estimateErc20PaymasterCost')),
+      );
+      expect(
+        capturedRequests.map((r) => r['method']),
+        containsAll(['eth_chainId', 'pimlico_getTokenQuotes']),
+      );
+
+      // prefund gas = 50k + 100k + 200k = 350k; * 1 gwei = 350e12 wei
+      // + postOpGas 75k * 1 gwei = 75e12
+      // maxCostInWei = 425e12
+      // exchangeRate 1e18 => costInToken = 425e12
+      // exchangeRateNativeToUsd 15e6 => costInUsd = 425e12 * 15e6 / 1e18
+      final expectedPrefund = getRequiredPrefund(userOp);
+      final postOpGas = BigInt.from(75000);
+      final maxCostInWei =
+          expectedPrefund + postOpGas * userOp.maxFeePerGas;
+      final expectedToken =
+          (maxCostInWei * BigInt.from(10).pow(18)) ~/ BigInt.from(10).pow(18);
+      final expectedUsd =
+          (maxCostInWei * BigInt.from(15000000)) ~/ BigInt.from(10).pow(18);
+
+      expect(cost.costInToken, equals(expectedToken));
+      expect(cost.costInUsd, equals(expectedUsd));
+    });
+
+    test('getTokenQuotes request params match JS fixture shape', () async {
+      final token = EthereumAddress.fromHex(
+        '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+      );
+      client = createPimlicoClient(
+        url: 'http://localhost:8545',
+        entryPoint: EntryPointAddresses.v07,
+        httpClient: createMockClient(),
+      );
+
+      await client.estimateErc20PaymasterCost(
+        userOperation: sampleV07(),
+        token: token,
+      );
+
+      final quotesReq = capturedRequests
+          .firstWhere((r) => r['method'] == 'pimlico_getTokenQuotes');
+      final params = quotesReq['params'] as List<dynamic>;
+
+      // JS: [{ tokens }, entryPointAddress, numberToHex(chainId)]
+      expect(params.length, equals(3));
+      expect(
+        (params[0] as Map<String, dynamic>)['tokens'],
+        equals([token.hex]),
+      );
+      expect(params[1], equals(EntryPointAddresses.v07.hex));
+      expect(params[2], equals('0xaa36a7'));
+    });
+
+    test('supports UserOperationV06 prefund formula', () async {
+      final token = EthereumAddress.fromHex(
+        '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+      );
+      client = createPimlicoClient(
+        url: 'http://localhost:8545',
+        entryPoint: EntryPointAddresses.v06,
+        httpClient: createMockClient(),
+      );
+
+      final userOp = UserOperationV06(
         sender: EthereumAddress.fromHex(
           '0x1234567890123456789012345678901234567890',
         ),
@@ -542,58 +618,40 @@ void main() {
 
       final cost = await client.estimateErc20PaymasterCost(
         userOperation: userOp,
-        token: EthereumAddress.fromHex(
-          '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
-        ), // USDC
+        token: token,
       );
 
-      expect(cost.costInToken, equals(BigInt.from(100000000)));
-      expect(cost.costInUsd, equals(BigInt.from(100000000)));
-      expect(
-        capturedRequests[0]['method'],
-        equals('pimlico_estimateErc20PaymasterCost'),
-      );
+      final expectedPrefund = getRequiredPrefundV06(userOp);
+      final maxCostInWei =
+          expectedPrefund + BigInt.from(75000) * userOp.maxFeePerGas;
+      final expectedToken =
+          (maxCostInWei * BigInt.from(10).pow(18)) ~/ BigInt.from(10).pow(18);
+      final expectedUsd =
+          (maxCostInWei * BigInt.from(15000000)) ~/ BigInt.from(10).pow(18);
+
+      expect(cost.costInToken, equals(expectedToken));
+      expect(cost.costInUsd, equals(expectedUsd));
     });
 
-    test('includes correct parameters in request', () async {
-      final mockClient = createMockClient(
-        (_) => {'costInToken': '0x1', 'costInUsd': '0x1'},
+    test('throws when token has no quotes', () async {
+      final token = EthereumAddress.fromHex(
+        '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
       );
       client = createPimlicoClient(
         url: 'http://localhost:8545',
         entryPoint: EntryPointAddresses.v07,
-        httpClient: mockClient,
-      );
-
-      final userOp = UserOperationV07(
-        sender: EthereumAddress.fromHex(
-          '0x1234567890123456789012345678901234567890',
+        httpClient: createMockClient(
+          quotesForToken: (_) => {'quotes': <dynamic>[]},
         ),
-        nonce: BigInt.from(5),
-        callData: '0xabcdef123456',
-        callGasLimit: BigInt.from(100000),
-        verificationGasLimit: BigInt.from(200000),
-        preVerificationGas: BigInt.from(50000),
-        maxFeePerGas: BigInt.from(1000000000),
-        maxPriorityFeePerGas: BigInt.from(100000000),
-        signature: '0xsig',
       );
 
-      final tokenAddress = EthereumAddress.fromHex(
-        '0xdAC17F958D2ee523a2206206994597C13D831ec7',
-      ); // USDT
-
-      await client.estimateErc20PaymasterCost(
-        userOperation: userOp,
-        token: tokenAddress,
+      expect(
+        () => client.estimateErc20PaymasterCost(
+          userOperation: sampleV07(),
+          token: token,
+        ),
+        throwsA(isA<ArgumentError>()),
       );
-
-      final params = capturedRequests[0]['params'] as List<dynamic>;
-      final packedUserOp = params[0] as Map<String, dynamic>;
-
-      expect(packedUserOp['sender'], equals(userOp.sender.hex));
-      expect(params[1], equals(EntryPointAddresses.v07.hex));
-      expect(params[2], equals(tokenAddress.hex));
     });
   });
 
@@ -620,6 +678,20 @@ void main() {
       });
     }
 
+    UserOperationV07 sampleV07({BigInt? nonce}) => UserOperationV07(
+          sender: EthereumAddress.fromHex(
+            '0x1234567890123456789012345678901234567890',
+          ),
+          nonce: nonce ?? BigInt.one,
+          callData: '0xabcdef',
+          callGasLimit: BigInt.from(100000),
+          verificationGasLimit: BigInt.from(200000),
+          preVerificationGas: BigInt.from(50000),
+          maxFeePerGas: BigInt.from(1000000000),
+          maxPriorityFeePerGas: BigInt.from(100000000),
+          signature: '0xsignature',
+        );
+
     test('returns valid sponsorship policies', () async {
       final mockClient = createMockClient(
         (_) => [
@@ -640,22 +712,8 @@ void main() {
         httpClient: mockClient,
       );
 
-      final userOp = UserOperationV07(
-        sender: EthereumAddress.fromHex(
-          '0x1234567890123456789012345678901234567890',
-        ),
-        nonce: BigInt.one,
-        callData: '0xabcdef',
-        callGasLimit: BigInt.from(100000),
-        verificationGasLimit: BigInt.from(200000),
-        preVerificationGas: BigInt.from(50000),
-        maxFeePerGas: BigInt.from(1000000000),
-        maxPriorityFeePerGas: BigInt.from(100000000),
-        signature: '0xsignature',
-      );
-
       final policies = await client.validateSponsorshipPolicies(
-        userOperation: userOp,
+        userOperation: sampleV07(),
         sponsorshipPolicyIds: ['sp_my_policy_123'],
       );
 
@@ -667,7 +725,7 @@ void main() {
       expect(policies[0].data.description, equals('A test sponsorship policy'));
       expect(
         capturedRequests[0]['method'],
-        equals('pimlico_validateSponsorshipPolicies'),
+        equals('pm_validateSponsorshipPolicies'),
       );
     });
 
@@ -690,22 +748,8 @@ void main() {
         httpClient: mockClient,
       );
 
-      final userOp = UserOperationV07(
-        sender: EthereumAddress.fromHex(
-          '0x1234567890123456789012345678901234567890',
-        ),
-        nonce: BigInt.one,
-        callData: '0xabcdef',
-        callGasLimit: BigInt.from(100000),
-        verificationGasLimit: BigInt.from(200000),
-        preVerificationGas: BigInt.from(50000),
-        maxFeePerGas: BigInt.from(1000000000),
-        maxPriorityFeePerGas: BigInt.from(100000000),
-        signature: '0xsig',
-      );
-
       final policies = await client.validateSponsorshipPolicies(
-        userOperation: userOp,
+        userOperation: sampleV07(),
         sponsorshipPolicyIds: ['sp_policy_1', 'sp_policy_2'],
       );
 
@@ -722,7 +766,54 @@ void main() {
         httpClient: mockClient,
       );
 
-      final userOp = UserOperationV07(
+      final policies = await client.validateSponsorshipPolicies(
+        userOperation: sampleV07(),
+        sponsorshipPolicyIds: [],
+      );
+
+      expect(policies, isEmpty);
+      // Should not make an RPC call if no policy IDs provided
+      expect(capturedRequests, isEmpty);
+    });
+
+    test('request params match JS fixture: method + deepHexlify userOp',
+        () async {
+      final mockClient = createMockClient((_) => <dynamic>[]);
+      client = createPimlicoClient(
+        url: 'http://localhost:8545',
+        entryPoint: EntryPointAddresses.v07,
+        httpClient: mockClient,
+      );
+
+      final userOp = sampleV07(nonce: BigInt.from(42));
+
+      await client.validateSponsorshipPolicies(
+        userOperation: userOp,
+        sponsorshipPolicyIds: ['sp_test_1', 'sp_test_2'],
+      );
+
+      expect(
+        capturedRequests[0]['method'],
+        equals('pm_validateSponsorshipPolicies'),
+      );
+
+      // JS: [deepHexlify(userOperation), entryPointAddress, sponsorshipPolicyIds]
+      final params = capturedRequests[0]['params'] as List<dynamic>;
+      expect(params.length, equals(3));
+      expect(params[0], equals(userOp.toJson()));
+      expect(params[1], equals(EntryPointAddresses.v07.hex));
+      expect(params[2], equals(['sp_test_1', 'sp_test_2']));
+    });
+
+    test('supports UserOperationV06 payload shape', () async {
+      final mockClient = createMockClient((_) => <dynamic>[]);
+      client = createPimlicoClient(
+        url: 'http://localhost:8545',
+        entryPoint: EntryPointAddresses.v06,
+        httpClient: mockClient,
+      );
+
+      final userOp = UserOperationV06(
         sender: EthereumAddress.fromHex(
           '0x1234567890123456789012345678901234567890',
         ),
@@ -734,48 +825,53 @@ void main() {
         maxFeePerGas: BigInt.from(1000000000),
         maxPriorityFeePerGas: BigInt.from(100000000),
         signature: '0xsig',
+        initCode: '0x',
+        paymasterAndData: '0x',
       );
 
-      final policies = await client.validateSponsorshipPolicies(
+      await client.validateSponsorshipPolicies(
         userOperation: userOp,
-        sponsorshipPolicyIds: [],
+        sponsorshipPolicyIds: ['sp_v06'],
       );
 
-      expect(policies, isEmpty);
-      // Should not make an RPC call if no policy IDs provided
-      expect(capturedRequests, isEmpty);
+      final params = capturedRequests[0]['params'] as List<dynamic>;
+      final sent = params[0] as Map<String, dynamic>;
+      expect(sent['initCode'], equals('0x'));
+      expect(sent['paymasterAndData'], equals('0x'));
+      expect(sent.containsKey('factory'), isFalse);
+      expect(params[1], equals(EntryPointAddresses.v06.hex));
     });
 
-    test('includes correct parameters in request', () async {
-      final mockClient = createMockClient((_) => <dynamic>[]);
+    test('handles null name/author in policy data', () async {
+      final mockClient = createMockClient(
+        (_) => [
+          {
+            'sponsorshipPolicyId': 'sp_null_fields',
+            'data': {
+              'name': null,
+              'author': null,
+              'icon': null,
+              'description': null,
+            },
+          },
+        ],
+      );
       client = createPimlicoClient(
         url: 'http://localhost:8545',
         entryPoint: EntryPointAddresses.v07,
         httpClient: mockClient,
       );
 
-      final userOp = UserOperationV07(
-        sender: EthereumAddress.fromHex(
-          '0x1234567890123456789012345678901234567890',
-        ),
-        nonce: BigInt.from(42),
-        callData: '0xabcdef',
-        callGasLimit: BigInt.from(100000),
-        verificationGasLimit: BigInt.from(200000),
-        preVerificationGas: BigInt.from(50000),
-        maxFeePerGas: BigInt.from(1000000000),
-        maxPriorityFeePerGas: BigInt.from(100000000),
-        signature: '0xsig',
+      final policies = await client.validateSponsorshipPolicies(
+        userOperation: sampleV07(),
+        sponsorshipPolicyIds: ['sp_null_fields'],
       );
 
-      await client.validateSponsorshipPolicies(
-        userOperation: userOp,
-        sponsorshipPolicyIds: ['sp_test_1', 'sp_test_2'],
-      );
-
-      final params = capturedRequests[0]['params'] as List<dynamic>;
-      expect(params[1], equals(EntryPointAddresses.v07.hex));
-      expect(params[2], equals(['sp_test_1', 'sp_test_2']));
+      expect(policies.length, equals(1));
+      expect(policies[0].data.name, isNull);
+      expect(policies[0].data.author, isNull);
+      expect(policies[0].data.icon, isNull);
+      expect(policies[0].data.description, isNull);
     });
   });
 
@@ -802,6 +898,20 @@ void main() {
 
       expect(data.name, equals('Minimal'));
       expect(data.author, equals('Author'));
+      expect(data.icon, isNull);
+      expect(data.description, isNull);
+    });
+
+    test('PimlicoSponsorshipPolicyData fromJson with null name/author', () {
+      final data = PimlicoSponsorshipPolicyData.fromJson({
+        'name': null,
+        'author': null,
+        'icon': null,
+        'description': null,
+      });
+
+      expect(data.name, isNull);
+      expect(data.author, isNull);
       expect(data.icon, isNull);
       expect(data.description, isNull);
     });

--- a/packages/permissionless/test/utils/erc7579_test.dart
+++ b/packages/permissionless/test/utils/erc7579_test.dart
@@ -311,36 +311,61 @@ void main() {
     });
 
     group('Erc7579Selectors', () {
-      test('execute selector is correct', () {
-        // execute(bytes32,bytes) should have selector 0x61461954
-        // (this is the standard ERC-7579 selector)
-        expect(Erc7579Selectors.execute, startsWith('0x'));
-        expect(Erc7579Selectors.execute.length, equals(10));
+      // Expected selectors are derived from the canonical ERC-7579 signatures
+      // (first 4 bytes of keccak256) so wrong hard-coded values fail the suite.
+      // Verified against `cast sig` / ERC-7579 interface.
+      String expectedSelector(String signature) =>
+          AbiEncoder.functionSelector(signature);
+
+      test('execute selector matches keccak of signature', () {
+        expect(
+          Erc7579Selectors.execute,
+          equals(expectedSelector('execute(bytes32,bytes)')),
+        );
       });
 
-      test('installModule selector is correct', () {
-        // keccak256("installModule(uint256,address,bytes)")[0:4] = 0x9517e29f
-        expect(Erc7579Selectors.installModule, equals('0x9517e29f'));
+      test('installModule selector matches keccak of signature', () {
+        expect(
+          Erc7579Selectors.installModule,
+          equals(expectedSelector('installModule(uint256,address,bytes)')),
+        );
       });
 
-      test('uninstallModule selector is correct', () {
-        // keccak256("uninstallModule(uint256,address,bytes)")[0:4] = 0xa4d6f1d2
-        expect(Erc7579Selectors.uninstallModule, equals('0xa4d6f1d2'));
+      test('uninstallModule selector matches keccak of signature', () {
+        expect(
+          Erc7579Selectors.uninstallModule,
+          equals(expectedSelector('uninstallModule(uint256,address,bytes)')),
+        );
       });
 
-      test('isModuleInstalled selector is correct', () {
-        // keccak256("isModuleInstalled(uint256,address,bytes)")[0:4] = 0x6d61fe70
-        expect(Erc7579Selectors.isModuleInstalled, equals('0x6d61fe70'));
+      test('isModuleInstalled selector matches keccak of signature', () {
+        expect(
+          Erc7579Selectors.isModuleInstalled,
+          equals(
+            expectedSelector('isModuleInstalled(uint256,address,bytes)'),
+          ),
+        );
       });
 
-      test('supportsModule selector is correct', () {
-        // keccak256("supportsModule(uint256)")[0:4] = 0x12d79da3
-        expect(Erc7579Selectors.supportsModule, equals('0x12d79da3'));
+      test('supportsModule selector matches keccak of signature', () {
+        expect(
+          Erc7579Selectors.supportsModule,
+          equals(expectedSelector('supportsModule(uint256)')),
+        );
       });
 
-      test('accountId selector is correct', () {
-        // keccak256("accountId()")[0:4] = 0x7b60424a
-        expect(Erc7579Selectors.accountId, equals('0x7b60424a'));
+      test('accountId selector matches keccak of signature', () {
+        expect(
+          Erc7579Selectors.accountId,
+          equals(expectedSelector('accountId()')),
+        );
+      });
+
+      test('supportsExecutionMode selector matches keccak of signature', () {
+        expect(
+          Erc7579Selectors.supportsExecutionMode,
+          equals(expectedSelector('supportsExecutionMode(bytes32)')),
+        );
       });
     });
 
@@ -539,6 +564,68 @@ void main() {
       test('returns accountId selector', () {
         final encoded = encode7579AccountId();
         expect(encoded, equals(Erc7579Selectors.accountId));
+      });
+    });
+
+    group('7579 query encode + recorded eth_call fixtures', () {
+      // Recorded ABI-encoded eth_call results as returned by a modular
+      // ERC-7579 account (bool true / string account id). Combined with
+      // correct query selectors this exercises the full read path without
+      // a live network.
+      const recordedBoolTrue =
+          '0x0000000000000000000000000000000000000000000000000000000000000001';
+      const recordedBoolFalse =
+          '0x0000000000000000000000000000000000000000000000000000000000000000';
+      // ABI-encoded string "rhinestone.nexus.1.0.0" (22 bytes, length 0x16)
+      const recordedAccountId = '0x'
+          '0000000000000000000000000000000000000000000000000000000000000020'
+          '0000000000000000000000000000000000000000000000000000000000000016'
+          '7268696e6573746f6e652e6e657875732e312e302e3000000000000000000000';
+
+      test('isModuleInstalled query uses derived selector and decodes true',
+          () {
+        final module = EthereumAddress.fromHex(
+          '0x1234567890123456789012345678901234567890',
+        );
+        final callData = encode7579IsModuleInstalled(
+          moduleType: Erc7579ModuleType.validator,
+          module: module,
+        );
+
+        expect(
+          callData.substring(0, 10),
+          equals(
+            AbiEncoder.functionSelector(
+              'isModuleInstalled(uint256,address,bytes)',
+            ),
+          ),
+        );
+        expect(decode7579BoolResult(recordedBoolTrue), isTrue);
+        expect(decode7579BoolResult(recordedBoolFalse), isFalse);
+      });
+
+      test('supportsModule query uses derived selector and decodes true', () {
+        final callData = encode7579SupportsModule(Erc7579ModuleType.validator);
+
+        expect(
+          callData.substring(0, 10),
+          equals(AbiEncoder.functionSelector('supportsModule(uint256)')),
+        );
+        expect(decode7579BoolResult(recordedBoolTrue), isTrue);
+      });
+
+      test('accountId query uses derived selector and decodes fixture string',
+          () {
+        final callData = encode7579AccountId();
+
+        expect(
+          callData,
+          equals(AbiEncoder.functionSelector('accountId()')),
+        );
+        expect(
+          decode7579StringResult(recordedAccountId),
+          equals('rhinestone.nexus.1.0.0'),
+        );
       });
     });
 


### PR DESCRIPTION
Chunk 1 of 6 splitting the parity-audit backlog into reviewable PRs.

Fixes the verified P0 bugs from the Dart-vs-JS parity audit:

- **erc7579**: correct four wrong hard-coded function selectors
- **kernel**: use Kernel v2 execute/executeBatch selectors for v0.2.4
- **nexus**: return bare 65-byte signature from signUserOperation
- **thirdweb**: UTF-8-encode salt like permissionless.js toHex
- **pimlico**: align three client actions with permissionless.js
- **safe**: correct v1.5.0 MultiSendCallOnly address

🤖 Generated with [Claude Code](https://claude.com/claude-code)