### PR TITLE
fix(accounts): align signing paths with permissionless.js across EntryPoint versions

### DIFF
--- a/packages/permissionless/lib/src/accounts/biconomy/biconomy_account.dart
+++ b/packages/permissionless/lib/src/accounts/biconomy/biconomy_account.dart
@@ -352,8 +352,10 @@ class BiconomySmartAccount implements SmartAccountV06 {
   /// Signs a personal message (EIP-191).
   @override
   Future<String> signMessage(String message) async {
+    // hashMessage already applies the EIP-191 prefix; sign that digest raw
+    // (matches viem localOwner.signMessage — one prefix only).
     final messageHash = hashMessage(message);
-    final signature = await _config.owner.signPersonalMessage(messageHash);
+    final signature = await _config.owner.signRawHash(messageHash);
     return _encodeModuleSignature(signature);
   }
 

--- a/packages/permissionless/lib/src/accounts/etherspot/etherspot_account.dart
+++ b/packages/permissionless/lib/src/accounts/etherspot/etherspot_account.dart
@@ -422,8 +422,10 @@ class EtherspotSmartAccount implements SmartAccount {
   /// Returns signature with validator prefix.
   @override
   Future<String> signMessage(String message) async {
+    // hashMessage already applies the EIP-191 prefix; sign that digest raw
+    // (matches viem localOwner.signMessage — one prefix only).
     final messageHash = hashMessage(message);
-    final signature = await owner.signPersonalMessage(messageHash);
+    final signature = await owner.signRawHash(messageHash);
 
     // Prepend validator address
     final validatorHex = Hex.strip0x(ecdsaValidator.hex).toLowerCase();
@@ -436,8 +438,8 @@ class EtherspotSmartAccount implements SmartAccount {
   /// Returns signature with validator prefix.
   @override
   Future<String> signTypedData(TypedData typedData) async {
-    final hash = hashTypedData(typedData);
-    final signature = await owner.signPersonalMessage(hash);
+    // Sign the EIP-712 digest raw (no personal-message prefix).
+    final signature = await owner.signTypedData(typedData);
 
     // Prepend validator address
     final validatorHex = Hex.strip0x(ecdsaValidator.hex).toLowerCase();

--- a/packages/permissionless/lib/src/accounts/kernel/kernel_account.dart
+++ b/packages/permissionless/lib/src/accounts/kernel/kernel_account.dart
@@ -750,7 +750,8 @@ class KernelSmartAccount implements SmartAccount {
 
   /// Root validator identifier for Kernel v0.3.x: `0x01 ‖ validatorAddress`.
   String _getEcdsaRootIdentifier() => Hex.concat([
-        Hex.fromBigInt(BigInt.from(KernelValidatorType.validator), byteLength: 1),
+        Hex.fromBigInt(BigInt.from(KernelValidatorType.validator),
+            byteLength: 1),
         _validatorAddress.hex,
       ]);
 

--- a/packages/permissionless/lib/src/accounts/kernel/kernel_account.dart
+++ b/packages/permissionless/lib/src/accounts/kernel/kernel_account.dart
@@ -582,8 +582,9 @@ class KernelSmartAccount implements SmartAccount {
       );
     }
 
-    // ECDSA signing
-    final signature = await _config.owner.signRawHash(userOpHash);
+    // ECDSA: EIP-191 personal_sign over the raw userOpHash (matches
+    // permissionless.js owner.signMessage({ message: { raw: hash } })).
+    final signature = await _config.owner.signPersonalMessage(userOpHash);
 
     if (_config.version == KernelVersion.v0_2_4) {
       // v0.2.x: ROOT_MODE (4 bytes) + signature
@@ -603,7 +604,8 @@ class KernelSmartAccount implements SmartAccount {
   /// and returns the signature with ROOT_MODE prefix.
   Future<String> signUserOperationV06(UserOperationV06 userOp) async {
     final userOpHash = _computeUserOpHashV06(userOp);
-    final signature = await _config.owner.signRawHash(userOpHash);
+    // EIP-191 personal_sign over the raw userOpHash (matches JS).
+    final signature = await _config.owner.signPersonalMessage(userOpHash);
 
     // v0.2.x: ROOT_MODE (4 bytes) + signature
     return Hex.concat([
@@ -646,48 +648,111 @@ class KernelSmartAccount implements SmartAccount {
     ]);
   }
 
-  /// Signs a personal message (EIP-191).
+  /// Signs a personal message (EIP-191) with Kernel EIP-712 wrapping.
   ///
   /// Returns the signature in the appropriate format for the owner type:
-  /// - ECDSA: raw 65-byte signature
-  /// - WebAuthn: ABI-encoded P256 signature with metadata
+  /// - ECDSA: Kernel-wrapped personal signature, with `0x01‖validator` prefix on v0.3.x
+  /// - WebAuthn: ABI-encoded P256 signature over the wrapped digest (same prefix rules)
   @override
   Future<String> signMessage(String message) async {
     final messageHash = hashMessage(message);
-
-    if (_isWebAuthn) {
-      final usePrecompiled = await _shouldUsePrecompile();
-      final webAuthnOwner = _config.owner as WebAuthnAccountOwner;
-      final sigData = await webAuthnOwner.signP256(messageHash);
-      return encodeKernelWebAuthnSignature(
-        sigData,
-        usePrecompiled: usePrecompiled,
-      );
-    }
-
-    return _config.owner.signRawHash(messageHash);
+    return _signWithKernelWrapper(messageHash);
   }
 
-  /// Signs EIP-712 typed data.
+  /// Signs EIP-712 typed data with Kernel EIP-712 wrapping.
   ///
   /// Returns the signature in the appropriate format for the owner type:
-  /// - ECDSA: raw 65-byte signature
-  /// - WebAuthn: ABI-encoded P256 signature with metadata
+  /// - ECDSA: Kernel-wrapped personal signature, with `0x01‖validator` prefix on v0.3.x
+  /// - WebAuthn: ABI-encoded P256 signature over the wrapped digest (same prefix rules)
   @override
   Future<String> signTypedData(TypedData typedData) async {
+    final hash = hashTypedData(typedData);
+    return _signWithKernelWrapper(hash);
+  }
+
+  /// Wraps [messageHash] with the Kernel EIP-712 domain and signs it.
+  ///
+  /// Mirrors permissionless.js `wrapMessageHash` + `owner.signMessage({ raw })`,
+  /// then for v0.3.x prefixes `0x01 ‖ validatorAddress`.
+  Future<String> _signWithKernelWrapper(String messageHash) async {
+    final wrappedDigest = await _wrapMessageHash(messageHash);
+
+    String signature;
     if (_isWebAuthn) {
       final usePrecompiled = await _shouldUsePrecompile();
       final webAuthnOwner = _config.owner as WebAuthnAccountOwner;
-      final hash = hashTypedData(typedData);
-      final sigData = await webAuthnOwner.signP256(hash);
-      return encodeKernelWebAuthnSignature(
+      final sigData = await webAuthnOwner.signP256(wrappedDigest);
+      signature = encodeKernelWebAuthnSignature(
         sigData,
         usePrecompiled: usePrecompiled,
       );
+    } else {
+      // EIP-191 personal_sign over the 32-byte Kernel digest.
+      signature = await _config.owner.signPersonalMessage(wrappedDigest);
     }
 
-    return _config.owner.signTypedData(typedData);
+    if (_config.version == KernelVersion.v0_2_4) {
+      return signature;
+    }
+
+    // v0.3.x: prepend root validator identifier `0x01 ‖ validatorAddress`
+    final validatorId = _getEcdsaRootIdentifier();
+    return Hex.concat([validatorId, Hex.strip0x(signature)]);
   }
+
+  /// Kernel EIP-712 wrap of a message/typed-data hash.
+  ///
+  /// v0.2.x: digest = keccak256(0x1901 ‖ domainSeparator ‖ messageHash)
+  /// v0.3.x: digest = keccak256(0x1901 ‖ domainSeparator ‖
+  ///   keccak256(keccak256("Kernel(bytes32 hash)") ‖ messageHash))
+  Future<String> _wrapMessageHash(String messageHash) async {
+    final accountAddress = await getAddress();
+
+    final domain = TypedDataDomain(
+      name: 'Kernel',
+      version: _config.version.value,
+      chainId: _config.chainId,
+      verifyingContract: accountAddress,
+    );
+    final domainSep = computeDomainSeparator(domain);
+
+    final String structHash;
+    if (_config.version == KernelVersion.v0_2_4) {
+      structHash = messageHash;
+    } else {
+      final typeHash = keccak256(
+        Uint8List.fromList('Kernel(bytes32 hash)'.codeUnits),
+      );
+      structHash = Hex.fromBytes(
+        keccak256(
+          Hex.decode(
+            Hex.concat([
+              Hex.fromBytes(typeHash),
+              messageHash,
+            ]),
+          ),
+        ),
+      );
+    }
+
+    return Hex.fromBytes(
+      keccak256(
+        Hex.decode(
+          Hex.concat([
+            '0x1901',
+            Hex.strip0x(domainSep),
+            Hex.strip0x(structHash),
+          ]),
+        ),
+      ),
+    );
+  }
+
+  /// Root validator identifier for Kernel v0.3.x: `0x01 ‖ validatorAddress`.
+  String _getEcdsaRootIdentifier() => Hex.concat([
+        Hex.fromBigInt(BigInt.from(KernelValidatorType.validator), byteLength: 1),
+        _validatorAddress.hex,
+      ]);
 
   Future<String> _computeUserOpHash(UserOperationV07 userOp) async {
     // Pack the UserOperation according to ERC-4337

--- a/packages/permissionless/lib/src/accounts/light/light_account.dart
+++ b/packages/permissionless/lib/src/accounts/light/light_account.dart
@@ -389,8 +389,9 @@ class LightSmartAccount implements SmartAccount {
       message: {'message': hashedMessage},
     );
 
-    final hash = hashTypedData(typedData);
-    return _config.owner.signPersonalMessage(hash);
+    // Sign the EIP-712 digest raw (no EIP-191 prefix). LightAccount's
+    // on-chain isValidSignature recovers against this digest.
+    return _config.owner.signTypedData(typedData);
   }
 
   String _computeUserOpHash(UserOperationV07 userOp) {

--- a/packages/permissionless/lib/src/accounts/light/light_account.dart
+++ b/packages/permissionless/lib/src/accounts/light/light_account.dart
@@ -86,7 +86,7 @@ class LightSmartAccountConfig {
 /// final address = await account.getAddress();
 /// print('Light account: $address');
 /// ```
-class LightSmartAccount implements SmartAccount {
+class LightSmartAccount implements SmartAccount, SmartAccountV06 {
   /// Creates a Light smart account from the given configuration.
   ///
   /// Prefer using [createLightSmartAccount] factory function instead
@@ -299,9 +299,19 @@ class LightSmartAccount implements SmartAccount {
     return signature;
   }
 
+  /// Signs a UserOperation for EntryPoint v0.7.
+  ///
+  /// For v0.6 accounts, use [signUserOperationV06] instead.
   @override
   Future<String> signUserOperation(UserOperationV07 userOp) async {
-    final userOpHash = _computeUserOpHash(userOp);
+    if (_config.entryPointVersion == EntryPointVersion.v06) {
+      throw UnsupportedError(
+        'Light account configured for EntryPoint v0.6. '
+        'Use signUserOperationV06 instead.',
+      );
+    }
+
+    final userOpHash = _computeUserOpHashV07(userOp);
     final signature = await _config.owner.signPersonalMessage(userOpHash);
 
     // v2.0.0 prepends signature type
@@ -316,6 +326,24 @@ class LightSmartAccount implements SmartAccount {
     }
 
     return signature;
+  }
+
+  /// Signs a UserOperation for EntryPoint v0.6.
+  ///
+  /// Uses the v0.6 userOpHash layout (unpacked gas fields) and EIP-191
+  /// personal-sign, matching permissionless.js / viem.
+  @override
+  Future<String> signUserOperationV06(UserOperationV06 userOp) async {
+    if (_config.entryPointVersion != EntryPointVersion.v06) {
+      throw UnsupportedError(
+        'signUserOperationV06 requires EntryPoint v0.6. '
+        'This account is configured for ${_config.entryPointVersion.name}.',
+      );
+    }
+
+    final userOpHash = _computeUserOpHashV06(userOp);
+    // v1.1.0 (EP v0.6) has no signature-type prefix.
+    return _config.owner.signPersonalMessage(userOpHash);
   }
 
   @override
@@ -394,8 +422,8 @@ class LightSmartAccount implements SmartAccount {
     return _config.owner.signTypedData(typedData);
   }
 
-  String _computeUserOpHash(UserOperationV07 userOp) {
-    final packed = _packUserOpForHash(userOp);
+  String _computeUserOpHashV07(UserOperationV07 userOp) {
+    final packed = _packUserOpForHashV07(userOp);
     final packedHash = keccak256(Hex.decode(packed));
 
     final hashInput = Hex.concat([
@@ -407,7 +435,7 @@ class LightSmartAccount implements SmartAccount {
     return Hex.fromBytes(keccak256(Hex.decode(hashInput)));
   }
 
-  String _packUserOpForHash(UserOperationV07 userOp) {
+  String _packUserOpForHashV07(UserOperationV07 userOp) {
     var initCode = '0x';
     if (userOp.factory != null) {
       initCode = Hex.concat([
@@ -453,6 +481,40 @@ class LightSmartAccount implements SmartAccount {
       Hex.strip0x(accountGasLimits),
       AbiEncoder.encodeUint256(userOp.preVerificationGas),
       Hex.strip0x(gasFees),
+      Hex.fromBytes(paymasterAndDataHash),
+    ]);
+  }
+
+  /// Computes the userOpHash for EntryPoint v0.6 signing.
+  String _computeUserOpHashV06(UserOperationV06 userOp) {
+    final packed = _packUserOpForHashV06(userOp);
+    final packedHash = keccak256(Hex.decode(packed));
+
+    final hashInput = Hex.concat([
+      Hex.fromBytes(packedHash),
+      AbiEncoder.encodeAddress(entryPoint),
+      AbiEncoder.encodeUint256(_config.chainId),
+    ]);
+
+    return Hex.fromBytes(keccak256(Hex.decode(hashInput)));
+  }
+
+  /// Packs a UserOperation for EntryPoint v0.6 hashing.
+  String _packUserOpForHashV06(UserOperationV06 userOp) {
+    final initCodeHash = keccak256(Hex.decode(userOp.initCode));
+    final callDataHash = keccak256(Hex.decode(userOp.callData));
+    final paymasterAndDataHash = keccak256(Hex.decode(userOp.paymasterAndData));
+
+    return Hex.concat([
+      AbiEncoder.encodeAddress(userOp.sender),
+      AbiEncoder.encodeUint256(userOp.nonce),
+      Hex.fromBytes(initCodeHash),
+      Hex.fromBytes(callDataHash),
+      AbiEncoder.encodeUint256(userOp.callGasLimit),
+      AbiEncoder.encodeUint256(userOp.verificationGasLimit),
+      AbiEncoder.encodeUint256(userOp.preVerificationGas),
+      AbiEncoder.encodeUint256(userOp.maxFeePerGas),
+      AbiEncoder.encodeUint256(userOp.maxPriorityFeePerGas),
       Hex.fromBytes(paymasterAndDataHash),
     ]);
   }

--- a/packages/permissionless/lib/src/accounts/safe/safe_account.dart
+++ b/packages/permissionless/lib/src/accounts/safe/safe_account.dart
@@ -857,30 +857,89 @@ class SafeSmartAccount implements SmartAccount {
     return Hex.concat([validAfter, validUntil, concatenatedSigs]);
   }
 
-  /// Signs a personal message (EIP-191).
+  /// Signs a personal message (EIP-191) via SafeMessage EIP-712 wrapper.
   ///
-  /// The message is hashed and signed by all owners (sorted by address).
-  /// Returns a combined signature suitable for EIP-1271 verification.
+  /// Matches permissionless.js: wrap as `SafeMessage(bytes)`, each ECDSA
+  /// owner eth_signs the digest (v adjusted +4 → 31/32), then concatenate.
+  /// In ERC-7579 mode the result is prefixed with 20 zero bytes.
   @override
   Future<String> signMessage(String message) async {
-    final messageHash = hashMessage(message);
-    return _signHash(messageHash);
+    _assertCanSignMessage();
+    final accountAddress = await getAddress();
+    final safeMessage =
+        _buildSafeMessageTypedData(hashMessage(message), accountAddress);
+    final safeMessageHash = hashTypedData(safeMessage);
+    return _signSafeMessage(
+      safeMessageHash: safeMessageHash,
+      safeMessageTypedData: safeMessage,
+      ethSign: true,
+    );
   }
 
-  /// Signs EIP-712 typed data.
+  /// Signs EIP-712 typed data via SafeMessage EIP-712 wrapper.
   ///
-  /// The typed data is hashed and signed by all owners (sorted by address).
-  /// Returns a combined signature suitable for EIP-1271 verification.
+  /// Matches permissionless.js: wrap as `SafeMessage(bytes)` over the
+  /// typed-data hash; ECDSA owners sign the SafeMessage typed data
+  /// (v stays 27/28). In ERC-7579 mode the result is prefixed with 20 zero bytes.
   @override
   Future<String> signTypedData(TypedData typedData) async {
-    final hash = hashTypedData(typedData);
-    return _signHash(hash);
+    _assertCanSignMessage();
+    final accountAddress = await getAddress();
+    final safeMessage =
+        _buildSafeMessageTypedData(hashTypedData(typedData), accountAddress);
+    final safeMessageHash = hashTypedData(safeMessage);
+    return _signSafeMessage(
+      safeMessageHash: safeMessageHash,
+      safeMessageTypedData: safeMessage,
+      ethSign: false,
+    );
   }
 
-  /// Signs a hash with all owners and returns the combined signature.
-  Future<String> _signHash(String hash) async {
-    // Sign with each owner (sorted by "address" for consistency)
-    // For WebAuthn owners, use the shared signer address for sorting
+  /// Guards matching permissionless.js Safe signMessage/signTypedData.
+  void _assertCanSignMessage() {
+    if (_config.owners.length < _config.threshold.toInt()) {
+      throw StateError(
+        'Owners length mismatch, currently not supported',
+      );
+    }
+    if (isErc7579Enabled && _config.version == SafeVersion.v1_5_0) {
+      throw StateError('Safe 7579 & version 1.5.0 are not compatible');
+    }
+  }
+
+  /// Builds the SafeMessage EIP-712 typed data for [innerHash].
+  ///
+  /// [accountAddress] is the Safe account (not the 4337 module).
+  TypedData _buildSafeMessageTypedData(
+    String innerHash,
+    EthereumAddress accountAddress,
+  ) =>
+      TypedData(
+        domain: TypedDataDomain(
+          chainId: _config.chainId,
+          verifyingContract: accountAddress,
+        ),
+        types: {
+          'SafeMessage': [
+            const TypedDataField(name: 'message', type: 'bytes'),
+          ],
+        },
+        primaryType: 'SafeMessage',
+        message: {'message': innerHash},
+      );
+
+  /// Signs a SafeMessage hash with all owners and concatenates signatures.
+  ///
+  /// When [ethSign] is true (signMessage path), ECDSA owners use personal_sign
+  /// and V is adjusted +4. When false (signTypedData path), they sign the
+  /// SafeMessage typed data directly and V stays 27/28.
+  Future<String> _signSafeMessage({
+    required String safeMessageHash,
+    required TypedData safeMessageTypedData,
+    required bool ethSign,
+  }) async {
+    final signatureEntries = <_SignatureEntry>[];
+
     final sortedOwners = List<AccountOwner>.from(_config.owners)
       ..sort((a, b) {
         final aAddr = isWebAuthnAccount(a)
@@ -892,22 +951,72 @@ class SafeSmartAccount implements SmartAccount {
         return aAddr.compareTo(bAddr);
       });
 
-    final signatures = <String>[];
     for (final owner in sortedOwners) {
       if (isWebAuthnAccount(owner)) {
-        // WebAuthn P256 signing with Safe encoding
         final webAuthnOwner = owner as WebAuthnAccountOwner;
-        final sigData = await webAuthnOwner.signP256(hash);
+        final sigData = await webAuthnOwner.signP256(safeMessageHash);
         final encoded = encodeSafeWebAuthnSignature(sigData);
-        signatures.add(Hex.strip0x(encoded));
+        signatureEntries.add(
+          _SignatureEntry(
+            signer: _addresses.webAuthnSharedSignerAddress!,
+            data: encoded,
+            isDynamic: true,
+          ),
+        );
       } else {
-        // ECDSA signing - Safe signs the raw hash directly
-        final sig = await owner.signRawHash(hash);
-        signatures.add(Hex.strip0x(sig));
+        final String sig;
+        if (ethSign) {
+          // eth_sign: personal_sign of the 32-byte SafeMessage hash, then V+4
+          final raw = await owner.signPersonalMessage(safeMessageHash);
+          sig = _adjustVInSignature(raw, ethSign: true);
+        } else {
+          // eth_signTypedData: sign SafeMessage typed data raw, normalize V
+          final raw = await owner.signTypedData(safeMessageTypedData);
+          sig = _adjustVInSignature(raw, ethSign: false);
+        }
+        signatureEntries.add(
+          _SignatureEntry(
+            signer: owner.address,
+            data: sig,
+            isDynamic: false,
+          ),
+        );
       }
     }
 
-    return Hex.concat(signatures);
+    final signatureBytes = _concatSignatures(signatureEntries);
+
+    // ERC-7579 mode prefixes with zero address (permissionless.js)
+    if (isErc7579Enabled) {
+      return Hex.concat([
+        Hex.fromBytes(Uint8List(20)),
+        Hex.strip0x(signatureBytes),
+      ]);
+    }
+
+    return signatureBytes;
+  }
+
+  /// Adjusts the V byte of a 65-byte ECDSA signature for Safe.
+  ///
+  /// - eth_sign: normalize to 27/28 then add 4 → 31/32
+  /// - eth_signTypedData: normalize to 27/28 only
+  String _adjustVInSignature(String signature, {required bool ethSign}) {
+    final hex = Hex.strip0x(signature);
+    if (hex.length != 130) {
+      throw ArgumentError('Expected 65-byte ECDSA signature, got ${hex.length ~/ 2} bytes');
+    }
+    var v = int.parse(hex.substring(128, 130), radix: 16);
+    if (v != 0 && v != 1 && v != 27 && v != 28) {
+      throw ArgumentError('Invalid signature V value: $v');
+    }
+    if (v < 27) {
+      v += 27;
+    }
+    if (ethSign) {
+      v += 4;
+    }
+    return '0x${hex.substring(0, 128)}${v.toRadixString(16).padLeft(2, '0')}';
   }
 
   /// Computes the SafeOp hash for EIP-712 signing.

--- a/packages/permissionless/lib/src/accounts/safe/safe_account.dart
+++ b/packages/permissionless/lib/src/accounts/safe/safe_account.dart
@@ -1030,7 +1030,8 @@ class SafeSmartAccount implements SmartAccount, SmartAccountV06 {
   String _adjustVInSignature(String signature, {required bool ethSign}) {
     final hex = Hex.strip0x(signature);
     if (hex.length != 130) {
-      throw ArgumentError('Expected 65-byte ECDSA signature, got ${hex.length ~/ 2} bytes');
+      throw ArgumentError(
+          'Expected 65-byte ECDSA signature, got ${hex.length ~/ 2} bytes');
     }
     var v = int.parse(hex.substring(128, 130), radix: 16);
     if (v != 0 && v != 1 && v != 27 && v != 28) {

--- a/packages/permissionless/lib/src/accounts/safe/safe_account.dart
+++ b/packages/permissionless/lib/src/accounts/safe/safe_account.dart
@@ -161,7 +161,7 @@ class SafeSmartAccountConfig {
 }
 
 /// A Safe smart account implementation for ERC-4337.
-class SafeSmartAccount implements SmartAccount {
+class SafeSmartAccount implements SmartAccount, SmartAccountV06 {
   /// Creates a Safe smart account from the given configuration.
   ///
   /// Prefer using [createSafeSmartAccount] factory function instead
@@ -794,19 +794,45 @@ class SafeSmartAccount implements SmartAccount {
     return Hex.concat([validAfter, validUntil, concatenatedSigs]);
   }
 
-  /// Signs a UserOperation.
+  /// Signs a UserOperation for EntryPoint v0.7.
   ///
-  /// For EntryPoint v0.7, creates an EIP-712 signature over the SafeOp.
+  /// Creates an EIP-712 signature over the v0.7 SafeOp typehash.
+  /// For v0.6 accounts, use [signUserOperationV06] instead.
   @override
   Future<String> signUserOperation(UserOperationV07 userOp) async {
+    if (_config.entryPointVersion == EntryPointVersion.v06) {
+      throw UnsupportedError(
+        'Safe account configured for EntryPoint v0.6. '
+        'Use signUserOperationV06 instead.',
+      );
+    }
+
     // Use the sender from the UserOp rather than computing locally
     // This ensures the signature matches the actual account address
-    final accountAddress = userOp.sender;
+    final safeOpHash = _computeSafeOpHashV07(userOp, userOp.sender);
+    return _signSafeOpHash(safeOpHash);
+  }
 
-    // Compute SafeOp hash for EIP-712 signing
-    final safeOpHash = _computeSafeOpHash(userOp, accountAddress);
+  /// Signs a UserOperation for EntryPoint v0.6.
+  ///
+  /// Creates an EIP-712 signature over the v0.6 SafeOp typehash
+  /// (uint256 gas fields, callGasLimit before verificationGasLimit),
+  /// matching permissionless.js `EIP712_SAFE_OPERATION_TYPE_V06`.
+  @override
+  Future<String> signUserOperationV06(UserOperationV06 userOp) async {
+    if (_config.entryPointVersion != EntryPointVersion.v06) {
+      throw UnsupportedError(
+        'signUserOperationV06 requires EntryPoint v0.6. '
+        'This account is configured for ${_config.entryPointVersion.name}.',
+      );
+    }
 
-    // Build signature entries for each owner
+    final safeOpHash = _computeSafeOpHashV06(userOp, userOp.sender);
+    return _signSafeOpHash(safeOpHash);
+  }
+
+  /// Signs a SafeOp hash with all owners and packs validAfter/validUntil.
+  Future<String> _signSafeOpHash(String safeOpHash) async {
     final signatureEntries = <_SignatureEntry>[];
 
     // Sort owners by their "effective" address (shared signer for WebAuthn)
@@ -1019,26 +1045,35 @@ class SafeSmartAccount implements SmartAccount {
     return '0x${hex.substring(0, 128)}${v.toRadixString(16).padLeft(2, '0')}';
   }
 
-  /// Computes the SafeOp hash for EIP-712 signing.
-  String _computeSafeOpHash(
+  /// Computes the SafeOp EIP-712 hash for EntryPoint v0.7.
+  String _computeSafeOpHashV07(
     UserOperationV07 userOp,
     EthereumAddress accountAddress,
   ) {
-    // IMPORTANT: Domain separator uses the Safe4337Module address as verifyingContract
-    // (not the Safe account address!) because Safe's fallback uses 'call' not 'delegatecall',
-    // so 'this' in the module's domainSeparator() refers to the module's address.
     final domainSeparator = _computeDomainSeparator();
+    final safeOpStructHash =
+        _computeSafeOpStructHashV07(userOp, accountAddress);
+    return _eip712Hash(domainSeparator, safeOpStructHash);
+  }
 
-    // SafeOp struct hash
-    final safeOpStructHash = _computeSafeOpStructHash(userOp, accountAddress);
+  /// Computes the SafeOp EIP-712 hash for EntryPoint v0.6.
+  String _computeSafeOpHashV06(
+    UserOperationV06 userOp,
+    EthereumAddress accountAddress,
+  ) {
+    final domainSeparator = _computeDomainSeparator();
+    final safeOpStructHash =
+        _computeSafeOpStructHashV06(userOp, accountAddress);
+    return _eip712Hash(domainSeparator, safeOpStructHash);
+  }
 
-    // EIP-712 hash: keccak256("\x19\x01" ++ domainSeparator ++ structHash)
+  /// EIP-712 hash: keccak256("\x19\x01" ‖ domainSeparator ‖ structHash).
+  String _eip712Hash(String domainSeparator, String structHash) {
     final preImage = Hex.concat([
       '0x1901',
       Hex.strip0x(domainSeparator),
-      Hex.strip0x(safeOpStructHash),
+      Hex.strip0x(structHash),
     ]);
-
     return Hex.fromBytes(keccak256(Hex.decode(preImage)));
   }
 
@@ -1067,12 +1102,12 @@ class SafeSmartAccount implements SmartAccount {
     return Hex.fromBytes(keccak256(Hex.decode(encoded)));
   }
 
-  /// Computes the SafeOp struct hash for EIP-712.
-  String _computeSafeOpStructHash(
+  /// Computes the SafeOp struct hash for EntryPoint v0.7 EIP-712.
+  String _computeSafeOpStructHashV07(
     UserOperationV07 userOp,
     EthereumAddress accountAddress,
   ) {
-    // SafeOp type hash for v0.7
+    // SafeOp type hash for v0.7 (uint128 gas fields; verification before call)
     const safeOpTypeString =
         'SafeOp(address safe,uint256 nonce,bytes initCode,bytes callData,uint128 verificationGasLimit,uint128 callGasLimit,uint256 preVerificationGas,uint128 maxPriorityFeePerGas,uint128 maxFeePerGas,bytes paymasterAndData,uint48 validAfter,uint48 validUntil,address entryPoint)';
 
@@ -1122,7 +1157,46 @@ class SafeSmartAccount implements SmartAccount {
       Hex.fromBytes(paymasterAndDataHash),
       AbiEncoder.encodeUint48(0), // validAfter
       AbiEncoder.encodeUint48(0), // validUntil
-      AbiEncoder.encodeAddress(EntryPointAddresses.v07),
+      AbiEncoder.encodeAddress(entryPoint),
+    ]);
+
+    return Hex.fromBytes(keccak256(Hex.decode(encoded)));
+  }
+
+  /// Computes the SafeOp struct hash for EntryPoint v0.6 EIP-712.
+  ///
+  /// Matches permissionless.js `EIP712_SAFE_OPERATION_TYPE_V06`: uint256 gas
+  /// fields with callGasLimit before verificationGasLimit, and maxFeePerGas
+  /// before maxPriorityFeePerGas.
+  String _computeSafeOpStructHashV06(
+    UserOperationV06 userOp,
+    EthereumAddress accountAddress,
+  ) {
+    const safeOpTypeString =
+        'SafeOp(address safe,uint256 nonce,bytes initCode,bytes callData,uint256 callGasLimit,uint256 verificationGasLimit,uint256 preVerificationGas,uint256 maxFeePerGas,uint256 maxPriorityFeePerGas,bytes paymasterAndData,uint48 validAfter,uint48 validUntil,address entryPoint)';
+
+    final safeOpTypeHash =
+        keccak256(Uint8List.fromList(safeOpTypeString.codeUnits));
+
+    final initCodeHash = keccak256(Hex.decode(userOp.initCode));
+    final callDataHash = keccak256(Hex.decode(userOp.callData));
+    final paymasterAndDataHash = keccak256(Hex.decode(userOp.paymasterAndData));
+
+    final encoded = Hex.concat([
+      Hex.fromBytes(safeOpTypeHash),
+      AbiEncoder.encodeAddress(accountAddress),
+      AbiEncoder.encodeUint256(userOp.nonce),
+      Hex.fromBytes(initCodeHash),
+      Hex.fromBytes(callDataHash),
+      AbiEncoder.encodeUint256(userOp.callGasLimit),
+      AbiEncoder.encodeUint256(userOp.verificationGasLimit),
+      AbiEncoder.encodeUint256(userOp.preVerificationGas),
+      AbiEncoder.encodeUint256(userOp.maxFeePerGas),
+      AbiEncoder.encodeUint256(userOp.maxPriorityFeePerGas),
+      Hex.fromBytes(paymasterAndDataHash),
+      AbiEncoder.encodeUint48(0), // validAfter
+      AbiEncoder.encodeUint48(0), // validUntil
+      AbiEncoder.encodeAddress(entryPoint),
     ]);
 
     return Hex.fromBytes(keccak256(Hex.decode(encoded)));

--- a/packages/permissionless/lib/src/accounts/simple/constants.dart
+++ b/packages/permissionless/lib/src/accounts/simple/constants.dart
@@ -50,12 +50,16 @@ class SimpleAccountSelectors {
   /// Used by all versions for single call execution.
   static const String execute = '0xb61d27f6';
 
+  /// executeBatch(address[] calldata dest, bytes[] calldata func)
+  /// Used by EntryPoint v0.6 SimpleAccount (no values array).
+  static const String executeBatchV06 = '0x18dfb3c7';
+
   /// executeBatch(address[] calldata dest, uint256[] calldata values, bytes[] calldata func)
-  /// Used by v0.6 and v0.7 for batch execution.
+  /// Used by EntryPoint v0.7 SimpleAccount for batch execution.
   static const String executeBatch = '0x47e1da2a';
 
   /// executeBatch(Call[] calldata calls) where Call = (address target, uint256 value, bytes data)
-  /// Used by v0.8 for batch execution with tuple array.
+  /// Used by EntryPoint v0.8 SimpleAccount for batch execution with tuple array.
   static const String executeBatchV08 = '0x34fcd5be';
 
   /// createAccount(address owner, uint256 salt)

--- a/packages/permissionless/lib/src/accounts/simple/simple_account.dart
+++ b/packages/permissionless/lib/src/accounts/simple/simple_account.dart
@@ -76,7 +76,7 @@ class SimpleSmartAccountConfig {
 /// final address = await account.getAddress();
 /// print('Simple account: $address');
 /// ```
-class SimpleSmartAccount implements SmartAccount {
+class SimpleSmartAccount implements SmartAccount, SmartAccountV06 {
   /// Creates a Simple smart account from the given configuration.
   ///
   /// Prefer using [createSimpleSmartAccount] factory function instead
@@ -220,7 +220,11 @@ class SimpleSmartAccount implements SmartAccount {
   String encodeCall(Call call) =>
       _encodeExecute(call.to, call.value, call.data);
 
-  /// Encodes multiple calls using executeBatch.
+  /// Encodes multiple calls using the version-specific executeBatch ABI.
+  ///
+  /// - v0.6: `executeBatch(address[],bytes[])` (`0x18dfb3c7`)
+  /// - v0.7: `executeBatch(address[],uint256[],bytes[])` (`0x47e1da2a`)
+  /// - v0.8: `executeBatch((address,uint256,bytes)[])` (`0x34fcd5be`)
   @override
   String encodeCalls(List<Call> calls) {
     if (calls.isEmpty) {
@@ -231,8 +235,11 @@ class SimpleSmartAccount implements SmartAccount {
       return encodeCall(calls.first);
     }
 
-    // executeBatch(address[], uint256[], bytes[])
-    return _encodeExecuteBatch(calls);
+    return switch (_config.entryPointVersion) {
+      EntryPointVersion.v06 => _encodeExecuteBatchV06(calls),
+      EntryPointVersion.v07 => _encodeExecuteBatchV07(calls),
+      EntryPointVersion.v08 => _encodeExecuteBatchV08(calls),
+    };
   }
 
   /// Encodes a single execute call.
@@ -251,11 +258,30 @@ class SimpleSmartAccount implements SmartAccount {
     ]);
   }
 
-  /// Encodes a batch execute call.
-  String _encodeExecuteBatch(List<Call> calls) {
-    // executeBatch(address[] calldata dest, uint256[] calldata values, bytes[] calldata func)
-    // This is a complex ABI encoding with 3 dynamic arrays
+  /// Encodes a v0.6 batch execute call: executeBatch(address[], bytes[]).
+  ///
+  /// v0.6 SimpleAccount has no values array; ETH transfers are not batched.
+  String _encodeExecuteBatchV06(List<Call> calls) {
+    final destArray = calls.map((c) => c.to).toList();
+    final dataArray = calls.map((c) => c.data).toList();
 
+    // Two dynamic arrays → offsets at 0x40 and 0x40 + len(dest encoding)
+    const destOffset = 2 * 32;
+    final destEncoded = _encodeAddressArray(destArray);
+    final dataArrayOffset = destOffset + Hex.byteLength(destEncoded);
+    final dataArrayEncoded = _encodeBytesArray(dataArray);
+
+    return Hex.concat([
+      SimpleAccountSelectors.executeBatchV06,
+      AbiEncoder.encodeUint256(BigInt.from(destOffset)),
+      AbiEncoder.encodeUint256(BigInt.from(dataArrayOffset)),
+      Hex.strip0x(destEncoded),
+      Hex.strip0x(dataArrayEncoded),
+    ]);
+  }
+
+  /// Encodes a v0.7 batch execute call: executeBatch(address[], uint256[], bytes[]).
+  String _encodeExecuteBatchV07(List<Call> calls) {
     final destArray = calls.map((c) => c.to).toList();
     final valuesArray = calls.map((c) => c.value).toList();
     final dataArray = calls.map((c) => c.data).toList();
@@ -277,6 +303,54 @@ class SimpleSmartAccount implements SmartAccount {
       Hex.strip0x(valuesEncoded),
       Hex.strip0x(dataArrayEncoded),
     ]);
+  }
+
+  /// Encodes a v0.8 batch execute call: executeBatch(Call[]).
+  ///
+  /// Call is the tuple `(address target, uint256 value, bytes data)`.
+  String _encodeExecuteBatchV08(List<Call> calls) {
+    const arrayOffset = 32;
+    final parts = <String>[
+      Hex.strip0x(AbiEncoder.encodeUint256(BigInt.from(arrayOffset))),
+      Hex.strip0x(AbiEncoder.encodeUint256(BigInt.from(calls.length))),
+    ];
+
+    var currentOffset = calls.length * 32;
+    final tupleOffsets = <String>[];
+    final tupleData = <String>[];
+
+    for (final call in calls) {
+      tupleOffsets.add(
+        Hex.strip0x(AbiEncoder.encodeUint256(BigInt.from(currentOffset))),
+      );
+      final encodedTuple = _encodeTupleCall(call);
+      tupleData.add(encodedTuple);
+      currentOffset += Hex.byteLength('0x$encodedTuple');
+    }
+
+    parts
+      ..addAll(tupleOffsets)
+      ..addAll(tupleData);
+
+    return Hex.concat([
+      SimpleAccountSelectors.executeBatchV08,
+      ...parts.map((p) => p.startsWith('0x') ? p : '0x$p'),
+    ]);
+  }
+
+  /// Encodes a single Call tuple for v0.8 executeBatch.
+  String _encodeTupleCall(Call call) {
+    const bytesOffset = 3 * 32;
+    final bytesEncoded = AbiEncoder.encodeBytes(call.data);
+
+    return Hex.strip0x(
+      Hex.concat([
+        AbiEncoder.encodeAddress(call.to),
+        AbiEncoder.encodeUint256(call.value),
+        AbiEncoder.encodeUint256(BigInt.from(bytesOffset)),
+        bytesEncoded,
+      ]),
+    );
   }
 
   /// Encodes an array of addresses.
@@ -324,12 +398,41 @@ class SimpleSmartAccount implements SmartAccount {
       // This format passes simulation without requiring actual signature verification
       '0xfffffffffffffffffffffffffffffff0000000000000000000000000000000007aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1c';
 
-  /// Signs a UserOperation.
+  /// Signs a UserOperation for EntryPoint v0.7 or v0.8.
   ///
-  /// For Simple accounts, this signs the userOpHash with personal message prefix.
+  /// - v0.7: EIP-191 personal-sign of the packed userOpHash
+  /// - v0.8: EIP-712 typed data over PackedUserOperation (same as 7702 path)
+  /// - v0.6: throws — use [signUserOperationV06] instead
   @override
   Future<String> signUserOperation(UserOperationV07 userOp) async {
-    final userOpHash = _computeUserOpHash(userOp);
+    switch (_config.entryPointVersion) {
+      case EntryPointVersion.v06:
+        throw UnsupportedError(
+          'Simple account configured for EntryPoint v0.6. '
+          'Use signUserOperationV06 instead.',
+        );
+      case EntryPointVersion.v07:
+        final userOpHash = _computeUserOpHashV07(userOp);
+        return _config.owner.signPersonalMessage(userOpHash);
+      case EntryPointVersion.v08:
+        final typedData = _getUserOperationTypedData(userOp);
+        return _config.owner.signTypedData(typedData);
+    }
+  }
+
+  /// Signs a UserOperation for EntryPoint v0.6.
+  ///
+  /// Uses the v0.6 userOpHash layout (unpacked gas fields) and EIP-191
+  /// personal-sign, matching permissionless.js / viem.
+  @override
+  Future<String> signUserOperationV06(UserOperationV06 userOp) async {
+    if (_config.entryPointVersion != EntryPointVersion.v06) {
+      throw UnsupportedError(
+        'signUserOperationV06 requires EntryPoint v0.6. '
+        'This account is configured for ${_config.entryPointVersion.name}.',
+      );
+    }
+    final userOpHash = _computeUserOpHashV06(userOp);
     return _config.owner.signPersonalMessage(userOpHash);
   }
 
@@ -349,14 +452,11 @@ class SimpleSmartAccount implements SmartAccount {
   Future<String> signTypedData(TypedData typedData) async =>
       _config.owner.signTypedData(typedData);
 
-  /// Computes the userOpHash for signing.
-  ///
-  /// hash = keccak256(packUserOp(userOp), entryPoint, chainId)
-  String _computeUserOpHash(UserOperationV07 userOp) {
-    final packed = _packUserOpForHash(userOp);
+  /// Computes the userOpHash for EntryPoint v0.7 signing.
+  String _computeUserOpHashV07(UserOperationV07 userOp) {
+    final packed = _packUserOpForHashV07(userOp);
     final packedHash = keccak256(Hex.decode(packed));
 
-    // Final hash includes entryPoint and chainId
     final hashInput = Hex.concat([
       Hex.fromBytes(packedHash),
       AbiEncoder.encodeAddress(entryPoint),
@@ -366,9 +466,8 @@ class SimpleSmartAccount implements SmartAccount {
     return Hex.fromBytes(keccak256(Hex.decode(hashInput)));
   }
 
-  /// Packs a UserOperation for hashing.
-  String _packUserOpForHash(UserOperationV07 userOp) {
-    // Pack initCode
+  /// Packs a UserOperation for EntryPoint v0.7 hashing.
+  String _packUserOpForHashV07(UserOperationV07 userOp) {
     var initCode = '0x';
     if (userOp.factory != null) {
       initCode = Hex.concat([
@@ -378,22 +477,18 @@ class SimpleSmartAccount implements SmartAccount {
     }
     final initCodeHash = keccak256(Hex.decode(initCode));
 
-    // Pack callData
     final callDataHash = keccak256(Hex.decode(userOp.callData));
 
-    // Pack accountGasLimits (verificationGasLimit || callGasLimit)
     final accountGasLimits = Hex.concat([
       Hex.fromBigInt(userOp.verificationGasLimit, byteLength: 16),
       Hex.fromBigInt(userOp.callGasLimit, byteLength: 16),
     ]);
 
-    // Pack gasFees (maxPriorityFeePerGas || maxFeePerGas)
     final gasFees = Hex.concat([
       Hex.fromBigInt(userOp.maxPriorityFeePerGas, byteLength: 16),
       Hex.fromBigInt(userOp.maxFeePerGas, byteLength: 16),
     ]);
 
-    // Pack paymasterAndData
     var paymasterAndData = '0x';
     if (userOp.paymaster != null) {
       paymasterAndData = Hex.concat([
@@ -411,7 +506,6 @@ class SimpleSmartAccount implements SmartAccount {
     }
     final paymasterAndDataHash = keccak256(Hex.decode(paymasterAndData));
 
-    // Pack all together
     return Hex.concat([
       AbiEncoder.encodeAddress(userOp.sender),
       AbiEncoder.encodeUint256(userOp.nonce),
@@ -422,6 +516,119 @@ class SimpleSmartAccount implements SmartAccount {
       Hex.strip0x(gasFees),
       Hex.fromBytes(paymasterAndDataHash),
     ]);
+  }
+
+  /// Computes the userOpHash for EntryPoint v0.6 signing.
+  String _computeUserOpHashV06(UserOperationV06 userOp) {
+    final packed = _packUserOpForHashV06(userOp);
+    final packedHash = keccak256(Hex.decode(packed));
+
+    final hashInput = Hex.concat([
+      Hex.fromBytes(packedHash),
+      AbiEncoder.encodeAddress(entryPoint),
+      AbiEncoder.encodeUint256(_config.chainId),
+    ]);
+
+    return Hex.fromBytes(keccak256(Hex.decode(hashInput)));
+  }
+
+  /// Packs a UserOperation for EntryPoint v0.6 hashing.
+  String _packUserOpForHashV06(UserOperationV06 userOp) {
+    final initCodeHash = keccak256(Hex.decode(userOp.initCode));
+    final callDataHash = keccak256(Hex.decode(userOp.callData));
+    final paymasterAndDataHash = keccak256(Hex.decode(userOp.paymasterAndData));
+
+    return Hex.concat([
+      AbiEncoder.encodeAddress(userOp.sender),
+      AbiEncoder.encodeUint256(userOp.nonce),
+      Hex.fromBytes(initCodeHash),
+      Hex.fromBytes(callDataHash),
+      AbiEncoder.encodeUint256(userOp.callGasLimit),
+      AbiEncoder.encodeUint256(userOp.verificationGasLimit),
+      AbiEncoder.encodeUint256(userOp.preVerificationGas),
+      AbiEncoder.encodeUint256(userOp.maxFeePerGas),
+      AbiEncoder.encodeUint256(userOp.maxPriorityFeePerGas),
+      Hex.fromBytes(paymasterAndDataHash),
+    ]);
+  }
+
+  /// Creates the EIP-712 typed data for a v0.8 UserOperation.
+  ///
+  /// Matches viem's `getUserOperationTypedData` and the 7702 Simple path.
+  TypedData _getUserOperationTypedData(UserOperationV07 userOp) {
+    final accountGasLimits = Hex.concat([
+      Hex.fromBigInt(userOp.verificationGasLimit, byteLength: 16),
+      Hex.fromBigInt(userOp.callGasLimit, byteLength: 16),
+    ]);
+
+    final gasFees = Hex.concat([
+      Hex.fromBigInt(userOp.maxPriorityFeePerGas, byteLength: 16),
+      Hex.fromBigInt(userOp.maxFeePerGas, byteLength: 16),
+    ]);
+
+    var paymasterAndData = '0x';
+    if (userOp.paymaster != null) {
+      paymasterAndData = Hex.concat([
+        userOp.paymaster!.hex,
+        Hex.fromBigInt(
+          userOp.paymasterVerificationGasLimit ?? BigInt.zero,
+          byteLength: 16,
+        ),
+        Hex.fromBigInt(
+          userOp.paymasterPostOpGasLimit ?? BigInt.zero,
+          byteLength: 16,
+        ),
+        Hex.strip0x(userOp.paymasterData ?? '0x'),
+      ]);
+    }
+
+    String initCode;
+    if (userOp.factory != null) {
+      initCode = Hex.concat([
+        userOp.factory!.hex,
+        Hex.strip0x(userOp.factoryData ?? '0x'),
+      ]);
+    } else {
+      initCode = '0x';
+    }
+
+    return TypedData(
+      domain: TypedDataDomain(
+        name: 'ERC4337',
+        version: '1',
+        chainId: _config.chainId,
+        verifyingContract: entryPoint,
+      ),
+      types: {
+        'EIP712Domain': [
+          const TypedDataField(name: 'name', type: 'string'),
+          const TypedDataField(name: 'version', type: 'string'),
+          const TypedDataField(name: 'chainId', type: 'uint256'),
+          const TypedDataField(name: 'verifyingContract', type: 'address'),
+        ],
+        'PackedUserOperation': [
+          const TypedDataField(name: 'sender', type: 'address'),
+          const TypedDataField(name: 'nonce', type: 'uint256'),
+          const TypedDataField(name: 'initCode', type: 'bytes'),
+          const TypedDataField(name: 'callData', type: 'bytes'),
+          const TypedDataField(name: 'accountGasLimits', type: 'bytes32'),
+          const TypedDataField(name: 'preVerificationGas', type: 'uint256'),
+          const TypedDataField(name: 'gasFees', type: 'bytes32'),
+          const TypedDataField(name: 'paymasterAndData', type: 'bytes'),
+        ],
+      },
+      primaryType: 'PackedUserOperation',
+      message: {
+        'sender': userOp.sender.hex,
+        'nonce': userOp.nonce.toString(),
+        'initCode': initCode,
+        'callData': userOp.callData,
+        'accountGasLimits': accountGasLimits,
+        'preVerificationGas': userOp.preVerificationGas.toString(),
+        'gasFees': gasFees,
+        'paymasterAndData': paymasterAndData,
+      },
+    );
   }
 }
 

--- a/packages/permissionless/lib/src/accounts/thirdweb/thirdweb_account.dart
+++ b/packages/permissionless/lib/src/accounts/thirdweb/thirdweb_account.dart
@@ -348,9 +348,8 @@ class ThirdwebSmartAccount implements SmartAccount {
       message: {'message': messageHash},
     );
 
-    // Thirdweb signs typed data with personal message prefix
-    final wrappedHash = hashTypedData(wrappedTypedData);
-    return _config.owner.signPersonalMessage(wrappedHash);
+    // Sign the AccountMessage EIP-712 digest raw (no EIP-191 prefix).
+    return _config.owner.signTypedData(wrappedTypedData);
   }
 
   /// Signs EIP-712 typed data with Thirdweb wrapper.
@@ -361,8 +360,7 @@ class ThirdwebSmartAccount implements SmartAccount {
     // Check if self-verifying contract
     if (typedData.domain.verifyingContract?.hex.toLowerCase() ==
         accountAddress.hex.toLowerCase()) {
-      final hash = hashTypedData(typedData);
-      return _config.owner.signPersonalMessage(hash);
+      return _config.owner.signTypedData(typedData);
     }
 
     // Wrap the typed data hash
@@ -387,9 +385,8 @@ class ThirdwebSmartAccount implements SmartAccount {
       message: {'message': wrappedHash},
     );
 
-    // Thirdweb signs typed data with personal message prefix
-    final finalHash = hashTypedData(wrappedTypedData);
-    return _config.owner.signPersonalMessage(finalHash);
+    // Sign the AccountMessage EIP-712 digest raw (no EIP-191 prefix).
+    return _config.owner.signTypedData(wrappedTypedData);
   }
 
   /// Computes the userOpHash for signing.

--- a/packages/permissionless/lib/src/accounts/thirdweb/thirdweb_account.dart
+++ b/packages/permissionless/lib/src/accounts/thirdweb/thirdweb_account.dart
@@ -82,7 +82,7 @@ class ThirdwebSmartAccountConfig {
 /// final address = await account.getAddress();
 /// print('Thirdweb account: $address');
 /// ```
-class ThirdwebSmartAccount implements SmartAccount {
+class ThirdwebSmartAccount implements SmartAccount, SmartAccountV06 {
   /// Creates a Thirdweb smart account from the given configuration.
   ///
   /// Prefer using [createThirdwebSmartAccount] factory function instead
@@ -318,10 +318,36 @@ class ThirdwebSmartAccount implements SmartAccount {
   String getStubSignature() =>
       '0xfffffffffffffffffffffffffffffff0000000000000000000000000000000007aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1c';
 
-  /// Signs a UserOperation.
+  /// Signs a UserOperation for EntryPoint v0.7.
+  ///
+  /// For v0.6 accounts, use [signUserOperationV06] instead.
   @override
   Future<String> signUserOperation(UserOperationV07 userOp) async {
-    final userOpHash = _computeUserOpHash(userOp);
+    if (_config.entryPointVersion == EntryPointVersion.v06) {
+      throw UnsupportedError(
+        'Thirdweb account configured for EntryPoint v0.6. '
+        'Use signUserOperationV06 instead.',
+      );
+    }
+
+    final userOpHash = _computeUserOpHashV07(userOp);
+    return _config.owner.signPersonalMessage(userOpHash);
+  }
+
+  /// Signs a UserOperation for EntryPoint v0.6.
+  ///
+  /// Uses the v0.6 userOpHash layout (unpacked gas fields) and EIP-191
+  /// personal-sign, matching permissionless.js / viem.
+  @override
+  Future<String> signUserOperationV06(UserOperationV06 userOp) async {
+    if (_config.entryPointVersion != EntryPointVersion.v06) {
+      throw UnsupportedError(
+        'signUserOperationV06 requires EntryPoint v0.6. '
+        'This account is configured for ${_config.entryPointVersion.name}.',
+      );
+    }
+
+    final userOpHash = _computeUserOpHashV06(userOp);
     return _config.owner.signPersonalMessage(userOpHash);
   }
 
@@ -389,9 +415,9 @@ class ThirdwebSmartAccount implements SmartAccount {
     return _config.owner.signTypedData(wrappedTypedData);
   }
 
-  /// Computes the userOpHash for signing.
-  String _computeUserOpHash(UserOperationV07 userOp) {
-    final packed = _packUserOpForHash(userOp);
+  /// Computes the userOpHash for EntryPoint v0.7 signing.
+  String _computeUserOpHashV07(UserOperationV07 userOp) {
+    final packed = _packUserOpForHashV07(userOp);
     final packedHash = keccak256(Hex.decode(packed));
 
     final hashInput = Hex.concat([
@@ -403,8 +429,8 @@ class ThirdwebSmartAccount implements SmartAccount {
     return Hex.fromBytes(keccak256(Hex.decode(hashInput)));
   }
 
-  /// Packs a UserOperation for hashing.
-  String _packUserOpForHash(UserOperationV07 userOp) {
+  /// Packs a UserOperation for EntryPoint v0.7 hashing.
+  String _packUserOpForHashV07(UserOperationV07 userOp) {
     var initCode = '0x';
     if (userOp.factory != null) {
       initCode = Hex.concat([
@@ -450,6 +476,40 @@ class ThirdwebSmartAccount implements SmartAccount {
       Hex.strip0x(accountGasLimits),
       AbiEncoder.encodeUint256(userOp.preVerificationGas),
       Hex.strip0x(gasFees),
+      Hex.fromBytes(paymasterAndDataHash),
+    ]);
+  }
+
+  /// Computes the userOpHash for EntryPoint v0.6 signing.
+  String _computeUserOpHashV06(UserOperationV06 userOp) {
+    final packed = _packUserOpForHashV06(userOp);
+    final packedHash = keccak256(Hex.decode(packed));
+
+    final hashInput = Hex.concat([
+      Hex.fromBytes(packedHash),
+      AbiEncoder.encodeAddress(entryPoint),
+      AbiEncoder.encodeUint256(_config.chainId),
+    ]);
+
+    return Hex.fromBytes(keccak256(Hex.decode(hashInput)));
+  }
+
+  /// Packs a UserOperation for EntryPoint v0.6 hashing.
+  String _packUserOpForHashV06(UserOperationV06 userOp) {
+    final initCodeHash = keccak256(Hex.decode(userOp.initCode));
+    final callDataHash = keccak256(Hex.decode(userOp.callData));
+    final paymasterAndDataHash = keccak256(Hex.decode(userOp.paymasterAndData));
+
+    return Hex.concat([
+      AbiEncoder.encodeAddress(userOp.sender),
+      AbiEncoder.encodeUint256(userOp.nonce),
+      Hex.fromBytes(initCodeHash),
+      Hex.fromBytes(callDataHash),
+      AbiEncoder.encodeUint256(userOp.callGasLimit),
+      AbiEncoder.encodeUint256(userOp.verificationGasLimit),
+      AbiEncoder.encodeUint256(userOp.preVerificationGas),
+      AbiEncoder.encodeUint256(userOp.maxFeePerGas),
+      AbiEncoder.encodeUint256(userOp.maxPriorityFeePerGas),
       Hex.fromBytes(paymasterAndDataHash),
     ]);
   }

--- a/packages/permissionless/lib/src/accounts/trust/trust_account.dart
+++ b/packages/permissionless/lib/src/accounts/trust/trust_account.dart
@@ -350,9 +350,9 @@ class TrustSmartAccount implements SmartAccountV06 {
       message: {'message': hashedMessage},
     );
 
-    // Trust signs typed data with personal message prefix
-    final hash = hashTypedData(wrappedTypedData);
-    return _config.owner.signPersonalMessage(hash);
+    // Sign the Barz EIP-712 digest raw (no EIP-191 prefix). Matches
+    // permissionless.js which uses signer.signTypedData on the wrapper.
+    return _config.owner.signTypedData(wrappedTypedData);
   }
 
   /// Computes the userOpHash for v0.6.

--- a/packages/permissionless/test/accounts/erc1271_signing_parity_test.dart
+++ b/packages/permissionless/test/accounts/erc1271_signing_parity_test.dart
@@ -1,0 +1,233 @@
+import 'package:permissionless/permissionless.dart';
+import 'package:test/test.dart';
+
+/// Byte-for-byte ERC-1271 `signMessage` / `signTypedData` parity fixtures
+/// generated with viem (permissionless.js reference) for fixed inputs:
+///
+/// - privateKey: `0x59c6…690d` → owner `0x70997970C51812dc3A010C7d01b50e0d17dc79C8`
+/// - message: `"hello"`
+/// - account: `0x4444…4444`
+/// - chainId: `11155111` (Sepolia)
+///
+/// See docs/parity-audit ticket 008 and per-account reports.
+void main() {
+  const privateKey =
+      '0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d';
+  const ownerAddress = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8';
+  const message = 'hello';
+  final accountAddress = EthereumAddress.fromHex(
+    '0x4444444444444444444444444444444444444444',
+  );
+  final chainId = BigInt.from(11155111);
+
+  late PrivateKeyOwner owner;
+
+  setUp(() {
+    owner = PrivateKeyOwner(privateKey);
+    expect(
+      owner.address.hex.toLowerCase(),
+      equals(ownerAddress.toLowerCase()),
+    );
+  });
+
+  final sampleTypedData = TypedData(
+    domain: TypedDataDomain(
+      name: 'Mail',
+      version: '1',
+      chainId: chainId,
+      verifyingContract: accountAddress,
+    ),
+    types: {
+      'Mail': [const TypedDataField(name: 'contents', type: 'string')],
+    },
+    primaryType: 'Mail',
+    message: {'contents': 'Hello'},
+  );
+
+  group('Trust (Barz) EIP-712 wrapper', () {
+    // JS: signer.signTypedData(BarzMessage) — no EIP-191 over the digest
+    const jsSignMessage =
+        '0x461b0fe38f4c33023993a07c4f39f9957295250657ad5d9332c8cab134e276344d5c0308b8971abf79cb4ea4980c581ad1b44f4a862ff2be9854a57ac3db7f841c';
+
+    test('signMessage matches permissionless.js', () async {
+      final account = createTrustSmartAccount(
+        owner: owner,
+        chainId: chainId,
+        address: accountAddress,
+      );
+      final sig = await account.signMessage(message);
+      expect(sig.toLowerCase(), equals(jsSignMessage.toLowerCase()));
+    });
+  });
+
+  group('LightAccountMessage EIP-712 wrapper', () {
+    const jsSignMessage =
+        '0x4bc537d2ee07a5e334d4a85c51f76deb1f47b36172364ab347c4d89f06d471756bc1bfd451ec046414f3a01b2db8b390a9b6a2fb1992bb8d5ba002ff80558e1a1b';
+    const jsSignMessageV2 =
+        '0x004bc537d2ee07a5e334d4a85c51f76deb1f47b36172364ab347c4d89f06d471756bc1bfd451ec046414f3a01b2db8b390a9b6a2fb1992bb8d5ba002ff80558e1a1b';
+
+    test('signMessage (v1.1.0) matches permissionless.js', () async {
+      final account = createLightSmartAccount(
+        owner: owner,
+        chainId: chainId,
+        address: accountAddress,
+        version: LightAccountVersion.v110,
+        entryPointVersion: EntryPointVersion.v06,
+      );
+      final sig = await account.signMessage(message);
+      expect(sig.toLowerCase(), equals(jsSignMessage.toLowerCase()));
+    });
+
+    test('signMessage (v2.0.0) prepends 0x00 type byte', () async {
+      final account = createLightSmartAccount(
+        owner: owner,
+        chainId: chainId,
+        address: accountAddress,
+        version: LightAccountVersion.v200,
+        entryPointVersion: EntryPointVersion.v07,
+      );
+      final sig = await account.signMessage(message);
+      expect(sig.toLowerCase(), equals(jsSignMessageV2.toLowerCase()));
+    });
+  });
+
+  group('Thirdweb AccountMessage EIP-712 wrapper', () {
+    const jsSignMessage =
+        '0x3f788acda7d9ff8066f7a1074f94cbf739095a3989086cfeb507e00078e41c69297b4298d9fe66047064bab7955264eb2881e566b4c07e0d7c468c7254d452081b';
+
+    test('signMessage matches permissionless.js', () async {
+      final account = createThirdwebSmartAccount(
+        owner: owner,
+        chainId: chainId,
+        address: accountAddress,
+      );
+      final sig = await account.signMessage(message);
+      expect(sig.toLowerCase(), equals(jsSignMessage.toLowerCase()));
+    });
+  });
+
+  group('Etherspot (single EIP-191 + validator prefix)', () {
+    // encodePacked(address, bytes) = validator ‖ signature
+    const jsSignMessage =
+        '0x0740Ed7c11b9da33d9C80Bd76b826e4E90CC190676930d64d2e5eb4b3f4572ce806eda50e1e2329d51d9ca5a713a9befcb9d20883e3d4885c3c5eaf775fc8c9fcf4882a28b582b427bc0270565f3294d935549221b';
+    const jsSignTypedData =
+        '0x0740Ed7c11b9da33d9C80Bd76b826e4E90CC190681eab6b0e9d1ead7dd997bc09eee29631dbbe6cc3a2de04944cae34a4fcba39e66264aced59ae68dbc0c19b9629d10adcb64f89f0af2f4fade7f38ebba79126c1c';
+
+    test('signMessage matches permissionless.js (no double prefix)', () async {
+      final account = createEtherspotSmartAccount(
+        owner: owner,
+        chainId: chainId,
+        address: accountAddress,
+      );
+      final sig = await account.signMessage(message);
+      expect(sig.toLowerCase(), equals(jsSignMessage.toLowerCase()));
+    });
+
+    test('signTypedData matches permissionless.js', () async {
+      final account = createEtherspotSmartAccount(
+        owner: owner,
+        chainId: chainId,
+        address: accountAddress,
+      );
+      final sig = await account.signTypedData(sampleTypedData);
+      expect(sig.toLowerCase(), equals(jsSignTypedData.toLowerCase()));
+    });
+  });
+
+  group('Biconomy (single EIP-191 + module encode)', () {
+    // ABI encode (bytes signature, address module) with body from
+    // localOwner.signMessage({ message: "hello" })
+    const jsEncoded =
+        '0x00000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000001c5b32f37f5bea87bdd5374eb2ac54ea8e000000000000000000000000000000000000000000000000000000000000004176930d64d2e5eb4b3f4572ce806eda50e1e2329d51d9ca5a713a9befcb9d20883e3d4885c3c5eaf775fc8c9fcf4882a28b582b427bc0270565f3294d935549221b00000000000000000000000000000000000000000000000000000000000000';
+
+    test('signMessage matches permissionless.js (no double prefix)', () async {
+      // ignore: deprecated_member_use_from_same_package
+      final account = createBiconomySmartAccount(
+        owner: owner,
+        chainId: chainId,
+        address: accountAddress,
+      );
+      final sig = await account.signMessage(message);
+      expect(sig.toLowerCase(), equals(jsEncoded.toLowerCase()));
+    });
+  });
+
+  group('Kernel wrapMessageHash + root-validator prefix', () {
+    // wrapMessageHash(hashMessage("hello")) then personal_sign raw digest,
+    // then 0x01 ‖ ecdsaValidator for v0.3.1
+    const jsSignMessageV031 =
+        '0x01845ADb2C711129d4f3966735eD98a9F09fC4cE57cc0db94238eec02857c6ed9b7b63da573700091511fa606a132c9e817aecb32b56d14b7db6df7cb7101411368a81c7863c54ba025e27a57ecf734722bb6dcccd1c';
+    const jsSignTypedDataV031 =
+        '0x01845ADb2C711129d4f3966735eD98a9F09fC4cE57482c8a6d24395d2fd86a593003a056d83eb0132d622c3dc5fd56aecc9f38590f0c012b369e907ba35596e428cc398224346a41304f0fc233e118c5978e0784661c';
+    // v0.2.4: wrap without Kernel(bytes32) struct step, no validator prefix
+    const jsSignMessageV024 =
+        '0xa87069aaabd6cad2f39667debf72d986198f450789762541dfd83106b91ffa2f0ae095a1ef7a49156ccfa238cbdfb1c00a47152a7faaeeb29ab97a5afd6e19081c';
+
+    test('signMessage v0.3.1 matches permissionless.js', () async {
+      final account = createKernelSmartAccount(
+        owner: owner,
+        chainId: chainId,
+        address: accountAddress,
+        version: KernelVersion.v0_3_1,
+      );
+      final sig = await account.signMessage(message);
+      expect(sig.toLowerCase(), equals(jsSignMessageV031.toLowerCase()));
+    });
+
+    test('signTypedData v0.3.1 matches permissionless.js', () async {
+      final account = createKernelSmartAccount(
+        owner: owner,
+        chainId: chainId,
+        address: accountAddress,
+        version: KernelVersion.v0_3_1,
+      );
+      final sig = await account.signTypedData(sampleTypedData);
+      expect(sig.toLowerCase(), equals(jsSignTypedDataV031.toLowerCase()));
+    });
+
+    test('signMessage v0.2.4 matches permissionless.js', () async {
+      final account = createKernelSmartAccount(
+        owner: owner,
+        chainId: chainId,
+        address: accountAddress,
+        version: KernelVersion.v0_2_4,
+      );
+      final sig = await account.signMessage(message);
+      expect(sig.toLowerCase(), equals(jsSignMessageV024.toLowerCase()));
+    });
+  });
+
+  group('Safe SafeMessage wrapper + eth_sign V adjustment', () {
+    // SafeMessage domain {chainId, verifyingContract: safe}, eth_sign of
+    // digest, then adjustV(+4) → v ∈ {31, 32}
+    const jsSignMessage =
+        '0x21ba7cf79d39dddbad7a2a7344b7ded678b6de8e69d25e6579575928cd820264782f0e4a4f45c242b76d86fd54331fd4152ab4431325330425cd0c8e5d1b82e220';
+    const jsSignTypedData =
+        '0x84d641b18edbc498e1b5b1a6fd90248baf65695e6bd4329400177ba621a33ec0695a0315d03ab8d307564eabce30172903b21fc325104450ee35f4fd96b2cdb71c';
+
+    test('signMessage matches permissionless.js (eth_sign +4 V)', () async {
+      final account = createSafeSmartAccount(
+        owners: [owner],
+        chainId: chainId,
+        address: accountAddress,
+      );
+      final sig = await account.signMessage(message);
+      expect(sig.toLowerCase(), equals(jsSignMessage.toLowerCase()));
+      // V should be 0x20 (32) or 0x1f (31) after +4 eth_sign adjustment
+      final v = int.parse(sig.substring(sig.length - 2), radix: 16);
+      expect(v == 31 || v == 32, isTrue);
+    });
+
+    test('signTypedData matches permissionless.js (v 27/28)', () async {
+      final account = createSafeSmartAccount(
+        owners: [owner],
+        chainId: chainId,
+        address: accountAddress,
+      );
+      final sig = await account.signTypedData(sampleTypedData);
+      expect(sig.toLowerCase(), equals(jsSignTypedData.toLowerCase()));
+      final v = int.parse(sig.substring(sig.length - 2), radix: 16);
+      expect(v == 27 || v == 28, isTrue);
+    });
+  });
+}

--- a/packages/permissionless/test/accounts/light/light_account_test.dart
+++ b/packages/permissionless/test/accounts/light/light_account_test.dart
@@ -430,5 +430,104 @@ void main() {
         );
       });
     });
+
+    group('signUserOperation', () {
+      late PrivateKeyOwner owner;
+
+      setUp(() {
+        owner = PrivateKeyOwner(
+          '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80',
+        );
+      });
+
+      UserOperationV07 fixtureUserOpV07(EthereumAddress sender) =>
+          UserOperationV07(
+            sender: sender,
+            nonce: BigInt.one,
+            callData: '0xabcdef',
+            callGasLimit: BigInt.from(100000),
+            verificationGasLimit: BigInt.from(200000),
+            preVerificationGas: BigInt.from(50000),
+            maxFeePerGas: BigInt.from(1000000000),
+            maxPriorityFeePerGas: BigInt.from(100000000),
+            signature: '0x',
+          );
+
+      UserOperationV06 fixtureUserOpV06(EthereumAddress sender) =>
+          UserOperationV06(
+            sender: sender,
+            nonce: BigInt.one,
+            initCode: '0x',
+            callData: '0xabcdef',
+            callGasLimit: BigInt.from(100000),
+            verificationGasLimit: BigInt.from(200000),
+            preVerificationGas: BigInt.from(50000),
+            maxFeePerGas: BigInt.from(1000000000),
+            maxPriorityFeePerGas: BigInt.from(100000000),
+            paymasterAndData: '0x',
+            signature: '0x',
+          );
+
+      test('v0.6 personal-signs v0.6 userOpHash matching viem fixture',
+          () async {
+        final account = createLightSmartAccount(
+          owner: owner,
+          chainId: BigInt.one,
+          entryPointVersion: EntryPointVersion.v06,
+          address: mockAddress,
+        );
+
+        final signature =
+            await account.signUserOperationV06(fixtureUserOpV06(mockAddress));
+
+        // viem getUserOperationHash (v0.6) + signMessage({ raw: hash })
+        // Light v1.1.0 has no signature-type prefix.
+        expect(
+          signature.toLowerCase(),
+          equals(
+            '0x722cff5408f0bfb44be7b89c1352926b788b13e3aab3ca90eba3f140541ef0e84f013c007081d3f0d27f5fccbdb10d1d33c7582f930504f7b874134d1781c55d1b',
+          ),
+        );
+      });
+
+      test('v0.6 throws when signUserOperation (v0.7 API) is used', () async {
+        final account = createLightSmartAccount(
+          owner: owner,
+          chainId: BigInt.one,
+          entryPointVersion: EntryPointVersion.v06,
+          address: mockAddress,
+        );
+
+        expect(
+          () => account.signUserOperation(fixtureUserOpV07(mockAddress)),
+          throwsA(isA<UnsupportedError>()),
+        );
+      });
+
+      test('v0.7 throws when signUserOperationV06 is used', () async {
+        final account = createLightSmartAccount(
+          owner: owner,
+          chainId: BigInt.one,
+          entryPointVersion: EntryPointVersion.v07,
+          address: mockAddress,
+        );
+
+        expect(
+          () => account.signUserOperationV06(fixtureUserOpV06(mockAddress)),
+          throwsA(isA<UnsupportedError>()),
+        );
+      });
+
+      test('implements SmartAccountV06 for client v0.6 pipeline', () {
+        final account = createLightSmartAccount(
+          owner: owner,
+          chainId: BigInt.one,
+          entryPointVersion: EntryPointVersion.v06,
+          address: mockAddress,
+        );
+
+        expect(account, isA<SmartAccountV06>());
+      });
+    });
   });
 }

--- a/packages/permissionless/test/accounts/safe/safe_account_test.dart
+++ b/packages/permissionless/test/accounts/safe/safe_account_test.dart
@@ -491,6 +491,111 @@ void main() {
 
         expect(sig1, isNot(equals(sig2)));
       });
+
+      test(
+        'v0.6 EIP-712 SafeOp signature matches permissionless.js fixture',
+        () async {
+          final owner = PrivateKeyOwner(testPrivateKey);
+          final account = createSafeSmartAccount(
+            owners: [owner],
+            chainId: BigInt.one,
+            entryPointVersion: EntryPointVersion.v06,
+            address: mockAddress,
+          );
+
+          final userOp = UserOperationV06(
+            sender: mockAddress,
+            nonce: BigInt.one,
+            initCode: '0x',
+            callData: '0xabcdef',
+            callGasLimit: BigInt.from(100000),
+            verificationGasLimit: BigInt.from(200000),
+            preVerificationGas: BigInt.from(50000),
+            maxFeePerGas: BigInt.from(1000000000),
+            maxPriorityFeePerGas: BigInt.from(100000000),
+            paymasterAndData: '0x',
+            signature: '0x',
+          );
+
+          final signature = await account.signUserOperationV06(userOp);
+
+          // viem signTypedData over EIP712_SAFE_OPERATION_TYPE_V06 with
+          // Safe4337Module 0xa581c4A4…4037, validAfter=0, validUntil=0,
+          // then packed as uint48‖uint48‖sig.
+          expect(
+            signature.toLowerCase(),
+            equals(
+              '0x000000000000000000000000c43b190628af4f8c76904c710f7a0f081556482309ff0352d0351986e0c8fecc298b32f1ccb48415db61fc1ef259f328e52e611cb13a51194a31c75036abbb971b',
+            ),
+          );
+        },
+      );
+
+      test('v0.6 throws when signUserOperation (v0.7 API) is used', () async {
+        final owner = PrivateKeyOwner(testPrivateKey);
+        final account = createSafeSmartAccount(
+          owners: [owner],
+          chainId: BigInt.one,
+          entryPointVersion: EntryPointVersion.v06,
+          address: mockAddress,
+        );
+
+        final userOp = UserOperationV07(
+          sender: mockAddress,
+          nonce: BigInt.one,
+          callData: '0xabcdef',
+          callGasLimit: BigInt.from(100000),
+          verificationGasLimit: BigInt.from(200000),
+          preVerificationGas: BigInt.from(50000),
+          maxFeePerGas: BigInt.from(1000000000),
+          maxPriorityFeePerGas: BigInt.from(100000000),
+        );
+
+        expect(
+          () => account.signUserOperation(userOp),
+          throwsA(isA<UnsupportedError>()),
+        );
+      });
+
+      test('v0.7 throws when signUserOperationV06 is used', () async {
+        final owner = PrivateKeyOwner(testPrivateKey);
+        final account = createSafeSmartAccount(
+          owners: [owner],
+          chainId: BigInt.one,
+          entryPointVersion: EntryPointVersion.v07,
+          address: mockAddress,
+        );
+
+        final userOp = UserOperationV06(
+          sender: mockAddress,
+          nonce: BigInt.one,
+          initCode: '0x',
+          callData: '0xabcdef',
+          callGasLimit: BigInt.from(100000),
+          verificationGasLimit: BigInt.from(200000),
+          preVerificationGas: BigInt.from(50000),
+          maxFeePerGas: BigInt.from(1000000000),
+          maxPriorityFeePerGas: BigInt.from(100000000),
+          paymasterAndData: '0x',
+        );
+
+        expect(
+          () => account.signUserOperationV06(userOp),
+          throwsA(isA<UnsupportedError>()),
+        );
+      });
+
+      test('implements SmartAccountV06 for client v0.6 pipeline', () {
+        final owner = PrivateKeyOwner(testPrivateKey);
+        final account = createSafeSmartAccount(
+          owners: [owner],
+          chainId: BigInt.one,
+          entryPointVersion: EntryPointVersion.v06,
+          address: mockAddress,
+        );
+
+        expect(account, isA<SmartAccountV06>());
+      });
     });
 
     group('useMultiSendForSetup', () {

--- a/packages/permissionless/test/accounts/simple/simple_account_test.dart
+++ b/packages/permissionless/test/accounts/simple/simple_account_test.dart
@@ -268,8 +268,7 @@ void main() {
         expect(callData, startsWith('0xb61d27f6'));
       });
 
-      test('v0.6 uses executeBatch(address[],bytes[]) selector 0x18dfb3c7',
-          () {
+      test('v0.6 uses executeBatch(address[],bytes[]) selector 0x18dfb3c7', () {
         account = createSimpleSmartAccount(
           owner: owner,
           chainId: BigInt.from(1),

--- a/packages/permissionless/test/accounts/simple/simple_account_test.dart
+++ b/packages/permissionless/test/accounts/simple/simple_account_test.dart
@@ -231,6 +231,23 @@ void main() {
     });
 
     group('encodeCalls', () {
+      // Shared batch inputs used for viem/permissionless.js fixtures below.
+      final batchCalls = [
+        Call(
+          to: EthereumAddress.fromHex(
+            '0x1234567890123456789012345678901234567890',
+          ),
+          data: '0xabcdef',
+        ),
+        Call(
+          to: EthereumAddress.fromHex(
+            '0x2345678901234567890123456789012345678901',
+          ),
+          value: BigInt.from(1000),
+          data: '0x123456',
+        ),
+      ];
+
       test('uses execute for single call', () {
         account = createSimpleSmartAccount(
           owner: owner,
@@ -251,31 +268,66 @@ void main() {
         expect(callData, startsWith('0xb61d27f6'));
       });
 
-      test('uses executeBatch for multiple calls', () {
+      test('v0.6 uses executeBatch(address[],bytes[]) selector 0x18dfb3c7',
+          () {
         account = createSimpleSmartAccount(
           owner: owner,
           chainId: BigInt.from(1),
+          entryPointVersion: EntryPointVersion.v06,
           address: mockAddress,
         );
 
-        final callData = account.encodeCalls([
-          Call(
-            to: EthereumAddress.fromHex(
-              '0x1234567890123456789012345678901234567890',
-            ),
-            data: '0xabcdef',
-          ),
-          Call(
-            to: EthereumAddress.fromHex(
-              '0x2345678901234567890123456789012345678901',
-            ),
-            value: BigInt.from(1000),
-            data: '0x123456',
-          ),
-        ]);
+        final callData = account.encodeCalls(batchCalls);
 
-        // Multiple calls should use executeBatch
-        expect(callData, startsWith('0x47e1da2a'));
+        // viem encodeFunctionData fixture for executeBatch06Abi
+        expect(
+          callData.toLowerCase(),
+          equals(
+            '0x18dfb3c7000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000002000000000000000000000000123456789012345678901234567890123456789000000000000000000000000023456789012345678901234567890123456789010000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000003abcdef000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000031234560000000000000000000000000000000000000000000000000000000000',
+          ),
+        );
+      });
+
+      test(
+          'v0.7 uses executeBatch(address[],uint256[],bytes[]) selector 0x47e1da2a',
+          () {
+        account = createSimpleSmartAccount(
+          owner: owner,
+          chainId: BigInt.from(1),
+          entryPointVersion: EntryPointVersion.v07,
+          address: mockAddress,
+        );
+
+        final callData = account.encodeCalls(batchCalls);
+
+        // viem encodeFunctionData fixture for executeBatch07Abi
+        expect(
+          callData.toLowerCase(),
+          equals(
+            '0x47e1da2a000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000c000000000000000000000000000000000000000000000000000000000000001200000000000000000000000000000000000000000000000000000000000000002000000000000000000000000123456789012345678901234567890123456789000000000000000000000000023456789012345678901234567890123456789010000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003e80000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000003abcdef000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000031234560000000000000000000000000000000000000000000000000000000000',
+          ),
+        );
+      });
+
+      test(
+          'v0.8 uses executeBatch((address,uint256,bytes)[]) selector 0x34fcd5be',
+          () {
+        account = createSimpleSmartAccount(
+          owner: owner,
+          chainId: BigInt.from(1),
+          entryPointVersion: EntryPointVersion.v08,
+          address: mockAddress,
+        );
+
+        final callData = account.encodeCalls(batchCalls);
+
+        // viem encodeFunctionData fixture for executeBatch08Abi
+        expect(
+          callData.toLowerCase(),
+          equals(
+            '0x34fcd5be00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000e00000000000000000000000001234567890123456789012345678901234567890000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000003abcdef0000000000000000000000000000000000000000000000000000000000000000000000000000000000234567890123456789012345678901234567890100000000000000000000000000000000000000000000000000000000000003e8000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000031234560000000000000000000000000000000000000000000000000000000000',
+          ),
+        );
       });
 
       test('throws on empty calls', () {
@@ -309,30 +361,133 @@ void main() {
     });
 
     group('signUserOperation', () {
-      test('signs UserOperation and returns signature', () async {
+      /// Canonical UserOperation used for viem fixture signatures (chainId=1).
+      UserOperationV07 fixtureUserOpV07(EthereumAddress sender) =>
+          UserOperationV07(
+            sender: sender,
+            nonce: BigInt.one,
+            callData: '0xabcdef',
+            callGasLimit: BigInt.from(100000),
+            verificationGasLimit: BigInt.from(200000),
+            preVerificationGas: BigInt.from(50000),
+            maxFeePerGas: BigInt.from(1000000000),
+            maxPriorityFeePerGas: BigInt.from(100000000),
+            signature: '0x',
+          );
+
+      UserOperationV06 fixtureUserOpV06(EthereumAddress sender) =>
+          UserOperationV06(
+            sender: sender,
+            nonce: BigInt.one,
+            initCode: '0x',
+            callData: '0xabcdef',
+            callGasLimit: BigInt.from(100000),
+            verificationGasLimit: BigInt.from(200000),
+            preVerificationGas: BigInt.from(50000),
+            maxFeePerGas: BigInt.from(1000000000),
+            maxPriorityFeePerGas: BigInt.from(100000000),
+            paymasterAndData: '0x',
+            signature: '0x',
+          );
+
+      test('v0.7 personal-signs userOpHash matching viem fixture', () async {
         account = createSimpleSmartAccount(
           owner: owner,
-          chainId: BigInt.from(11155111),
+          chainId: BigInt.one,
+          entryPointVersion: EntryPointVersion.v07,
           address: mockAddress,
         );
 
-        final userOp = UserOperationV07(
-          sender: await account.getAddress(),
-          nonce: BigInt.one,
-          callData: '0xabcdef',
-          callGasLimit: BigInt.from(100000),
-          verificationGasLimit: BigInt.from(200000),
-          preVerificationGas: BigInt.from(50000),
-          maxFeePerGas: BigInt.from(1000000000),
-          maxPriorityFeePerGas: BigInt.from(100000000),
-          signature: '0x',
+        final signature =
+            await account.signUserOperation(fixtureUserOpV07(mockAddress));
+
+        // viem getUserOperationHash (v0.7) + signMessage({ raw: hash })
+        expect(
+          signature.toLowerCase(),
+          equals(
+            '0xc6a3c86d23bc0a8f53a1a6b8f0d0918a93582e804cb77736199801cbb1a6f08d6c87bf1af6de3f99e40152770b759abc36107b8c168e9a7be8651eeb4a1bfa001c',
+          ),
+        );
+      });
+
+      test('v0.6 personal-signs v0.6 userOpHash matching viem fixture',
+          () async {
+        account = createSimpleSmartAccount(
+          owner: owner,
+          chainId: BigInt.one,
+          entryPointVersion: EntryPointVersion.v06,
+          address: mockAddress,
         );
 
-        final signature = await account.signUserOperation(userOp);
+        final signature =
+            await account.signUserOperationV06(fixtureUserOpV06(mockAddress));
 
-        // Signature should be 65 bytes (r + s + v)
-        expect(signature, startsWith('0x'));
-        expect(signature.length, equals(132));
+        // viem getUserOperationHash (v0.6) + signMessage({ raw: hash })
+        expect(
+          signature.toLowerCase(),
+          equals(
+            '0x722cff5408f0bfb44be7b89c1352926b788b13e3aab3ca90eba3f140541ef0e84f013c007081d3f0d27f5fccbdb10d1d33c7582f930504f7b874134d1781c55d1b',
+          ),
+        );
+      });
+
+      test('v0.8 signs EIP-712 typed data matching viem fixture', () async {
+        account = createSimpleSmartAccount(
+          owner: owner,
+          chainId: BigInt.one,
+          entryPointVersion: EntryPointVersion.v08,
+          address: mockAddress,
+        );
+
+        final signature =
+            await account.signUserOperation(fixtureUserOpV07(mockAddress));
+
+        // viem getUserOperationTypedData + signTypedData
+        expect(
+          signature.toLowerCase(),
+          equals(
+            '0x7717cbb0620c7bf781b2175f13e7e6b809fe9042bce6937ae82deb396c4f537b2c5cfad80c2b6880a6de20e94123f3e341470e18a10443b7896a6c2167e32b501b',
+          ),
+        );
+      });
+
+      test('v0.6 throws when signUserOperation (v0.7 API) is used', () async {
+        account = createSimpleSmartAccount(
+          owner: owner,
+          chainId: BigInt.one,
+          entryPointVersion: EntryPointVersion.v06,
+          address: mockAddress,
+        );
+
+        expect(
+          () => account.signUserOperation(fixtureUserOpV07(mockAddress)),
+          throwsA(isA<UnsupportedError>()),
+        );
+      });
+
+      test('v0.7 throws when signUserOperationV06 is used', () async {
+        account = createSimpleSmartAccount(
+          owner: owner,
+          chainId: BigInt.one,
+          entryPointVersion: EntryPointVersion.v07,
+          address: mockAddress,
+        );
+
+        expect(
+          () => account.signUserOperationV06(fixtureUserOpV06(mockAddress)),
+          throwsA(isA<UnsupportedError>()),
+        );
+      });
+
+      test('implements SmartAccountV06 for client v0.6 pipeline', () {
+        account = createSimpleSmartAccount(
+          owner: owner,
+          chainId: BigInt.one,
+          entryPointVersion: EntryPointVersion.v06,
+          address: mockAddress,
+        );
+
+        expect(account, isA<SmartAccountV06>());
       });
 
       test('produces deterministic signature', () async {
@@ -549,8 +704,16 @@ void main() {
       expect(SimpleAccountSelectors.execute, equals('0xb61d27f6'));
     });
 
-    test('has correct executeBatch selector', () {
+    test('has correct executeBatch v0.6 selector', () {
+      expect(SimpleAccountSelectors.executeBatchV06, equals('0x18dfb3c7'));
+    });
+
+    test('has correct executeBatch v0.7 selector', () {
       expect(SimpleAccountSelectors.executeBatch, equals('0x47e1da2a'));
+    });
+
+    test('has correct executeBatch v0.8 selector', () {
+      expect(SimpleAccountSelectors.executeBatchV08, equals('0x34fcd5be'));
     });
 
     test('has correct createAccount selector', () {

--- a/packages/permissionless/test/accounts/thirdweb/thirdweb_account_test.dart
+++ b/packages/permissionless/test/accounts/thirdweb/thirdweb_account_test.dart
@@ -122,4 +122,100 @@ void main() {
       );
     });
   });
+
+  group('ThirdwebSmartAccount signUserOperation', () {
+    late PrivateKeyOwner owner;
+
+    setUp(() {
+      owner = PrivateKeyOwner(testPrivateKey);
+    });
+
+    UserOperationV07 fixtureUserOpV07(EthereumAddress sender) =>
+        UserOperationV07(
+          sender: sender,
+          nonce: BigInt.one,
+          callData: '0xabcdef',
+          callGasLimit: BigInt.from(100000),
+          verificationGasLimit: BigInt.from(200000),
+          preVerificationGas: BigInt.from(50000),
+          maxFeePerGas: BigInt.from(1000000000),
+          maxPriorityFeePerGas: BigInt.from(100000000),
+          signature: '0x',
+        );
+
+    UserOperationV06 fixtureUserOpV06(EthereumAddress sender) =>
+        UserOperationV06(
+          sender: sender,
+          nonce: BigInt.one,
+          initCode: '0x',
+          callData: '0xabcdef',
+          callGasLimit: BigInt.from(100000),
+          verificationGasLimit: BigInt.from(200000),
+          preVerificationGas: BigInt.from(50000),
+          maxFeePerGas: BigInt.from(1000000000),
+          maxPriorityFeePerGas: BigInt.from(100000000),
+          paymasterAndData: '0x',
+          signature: '0x',
+        );
+
+    test('v0.6 personal-signs v0.6 userOpHash matching viem fixture',
+        () async {
+      final account = createThirdwebSmartAccount(
+        owner: owner,
+        chainId: BigInt.one,
+        entryPointVersion: EntryPointVersion.v06,
+        address: mockAddress,
+      );
+
+      final signature =
+          await account.signUserOperationV06(fixtureUserOpV06(mockAddress));
+
+      // viem getUserOperationHash (v0.6) + signMessage({ raw: hash })
+      expect(
+        signature.toLowerCase(),
+        equals(
+          '0x722cff5408f0bfb44be7b89c1352926b788b13e3aab3ca90eba3f140541ef0e84f013c007081d3f0d27f5fccbdb10d1d33c7582f930504f7b874134d1781c55d1b',
+        ),
+      );
+    });
+
+    test('v0.6 throws when signUserOperation (v0.7 API) is used', () async {
+      final account = createThirdwebSmartAccount(
+        owner: owner,
+        chainId: BigInt.one,
+        entryPointVersion: EntryPointVersion.v06,
+        address: mockAddress,
+      );
+
+      expect(
+        () => account.signUserOperation(fixtureUserOpV07(mockAddress)),
+        throwsA(isA<UnsupportedError>()),
+      );
+    });
+
+    test('v0.7 throws when signUserOperationV06 is used', () async {
+      final account = createThirdwebSmartAccount(
+        owner: owner,
+        chainId: BigInt.one,
+        entryPointVersion: EntryPointVersion.v07,
+        address: mockAddress,
+      );
+
+      expect(
+        () => account.signUserOperationV06(fixtureUserOpV06(mockAddress)),
+        throwsA(isA<UnsupportedError>()),
+      );
+    });
+
+    test('implements SmartAccountV06 for client v0.6 pipeline', () {
+      final account = createThirdwebSmartAccount(
+        owner: owner,
+        chainId: BigInt.one,
+        entryPointVersion: EntryPointVersion.v06,
+        address: mockAddress,
+      );
+
+      expect(account, isA<SmartAccountV06>());
+    });
+  });
 }

--- a/packages/permissionless/test/accounts/thirdweb/thirdweb_account_test.dart
+++ b/packages/permissionless/test/accounts/thirdweb/thirdweb_account_test.dart
@@ -158,8 +158,7 @@ void main() {
           signature: '0x',
         );
 
-    test('v0.6 personal-signs v0.6 userOpHash matching viem fixture',
-        () async {
+    test('v0.6 personal-signs v0.6 userOpHash matching viem fixture', () async {
       final account = createThirdwebSmartAccount(
         owner: owner,
         chainId: BigInt.one,


### PR DESCRIPTION
Chunk 2 of 6 splitting the parity-audit backlog into reviewable PRs. Builds on #38.

- **simple**: branch encode/sign paths by EntryPoint version
- **accounts**: align ERC-1271 signMessage/signTypedData with permissionless.js
- **accounts**: implement EntryPoint v0.6 signUserOperation paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)