### PR TITLE
fix(erc7579): encoding parity for actions + unit tests for untested accounts

### DIFF
--- a/packages/permissionless/lib/src/accounts/safe/safe_account.dart
+++ b/packages/permissionless/lib/src/accounts/safe/safe_account.dart
@@ -665,8 +665,13 @@ class SafeSmartAccount implements SmartAccount, SmartAccountV06 {
       throw ArgumentError('At least one call is required');
     }
 
-    // ERC-7579 mode uses standard 7579 batch encoding
+    // ERC-7579 mode: call vs batchcall by length (permissionless.js parity).
+    // encode7579ExecuteBatch always emits batch mode — do not pass a single
+    // call through it when call mode is intended.
     if (isErc7579Enabled) {
+      if (calls.length == 1) {
+        return encode7579Execute(calls.first);
+      }
       return encode7579ExecuteBatch(calls);
     }
 
@@ -707,8 +712,10 @@ class SafeSmartAccount implements SmartAccount, SmartAccountV06 {
       throw ArgumentError('At least one call is required');
     }
 
-    // Encode the user's calls using ERC-7579 format
-    final userCallData = encode7579ExecuteBatch(calls);
+    // Encode the user's calls using ERC-7579 format (call vs batch by length)
+    final userCallData = calls.length == 1
+        ? encode7579Execute(calls.first)
+        : encode7579ExecuteBatch(calls);
 
     // Build the full InitData for setupSafe
     return _encodeSetupSafe(userCallData);

--- a/packages/permissionless/lib/src/actions/erc7579/erc7579_actions.dart
+++ b/packages/permissionless/lib/src/actions/erc7579/erc7579_actions.dart
@@ -293,12 +293,12 @@ extension Erc7579Actions on SmartAccountClient {
   ///
   /// Example:
   /// ```dart
-  /// // Check if batch calls with try mode are supported
+  /// // Check if batch calls with try mode (execType 0x01) are supported
   /// final supportsBatchTry = await client.supportsExecutionMode(
   ///   publicClient: publicClient,
   ///   mode: ExecutionMode(
   ///     type: Erc7579CallKind.batchCall,
-  ///     revertOnError: false,
+  ///     revertOnError: true, // JS polarity → execType 0x01
   ///   ),
   /// );
   ///

--- a/packages/permissionless/lib/src/actions/smart_account/smart_account_actions.dart
+++ b/packages/permissionless/lib/src/actions/smart_account/smart_account_actions.dart
@@ -2,6 +2,7 @@ import '../../clients/bundler/types.dart';
 import '../../clients/smart_account/smart_account_client.dart';
 import '../../types/address.dart';
 import '../../types/calls_status.dart';
+import '../../types/hex.dart';
 import '../../types/typed_data.dart';
 import '../../types/user_operation.dart';
 import '../../utils/encoding.dart';
@@ -96,14 +97,16 @@ extension SmartAccountActions on SmartAccountClient {
 
   /// Sends a contract write call.
   ///
-  /// Encodes the function call using the provided signature and arguments,
-  /// then sends it as a transaction.
+  /// Encodes the function call using the provided signature and arguments
+  /// (via web3dart ABI encoding, matching viem `encodeFunctionData`), then
+  /// sends it as a transaction.
   ///
   /// Parameters:
   /// - [address] - The contract address
   /// - [functionSignature] - The function signature (e.g., 'transfer(address,uint256)')
   /// - [args] - The function arguments (must match signature order)
   /// - [value] - ETH value to send (defaults to 0)
+  /// - [dataSuffix] - Optional hex appended after the encoded calldata
   /// - [maxFeePerGas] - Maximum fee per gas
   /// - [maxPriorityFeePerGas] - Maximum priority fee per gas
   /// - [nonce] - Optional nonce override
@@ -124,12 +127,16 @@ extension SmartAccountActions on SmartAccountClient {
     required String functionSignature,
     List<dynamic> args = const [],
     BigInt? value,
+    String? dataSuffix,
     required BigInt maxFeePerGas,
     required BigInt maxPriorityFeePerGas,
     BigInt? nonce,
     Duration timeout = const Duration(seconds: 60),
   }) async {
-    final callData = _encodeFunction(functionSignature, args);
+    var callData = AbiEncoder.encodeFunctionData(functionSignature, args);
+    if (dataSuffix != null && dataSuffix.isNotEmpty) {
+      callData = Hex.concat([callData, dataSuffix]);
+    }
 
     return sendTransaction(
       to: address,
@@ -257,83 +264,4 @@ extension SmartAccountActions on SmartAccountClient {
         gasUsed: receipt.gasUsed,
         transactionHash: receipt.transactionHash,
       );
-
-  /// Encodes a function call with the given signature and arguments.
-  ///
-  /// This is a simplified encoder that supports basic types:
-  /// - address
-  /// - uint256, uint128, uint48, etc.
-  /// - bool
-  /// - bytes, bytes32
-  String _encodeFunction(String signature, List<dynamic> args) {
-    final selector = AbiEncoder.functionSelector(signature);
-
-    if (args.isEmpty) {
-      return selector;
-    }
-
-    // Parse argument types from signature
-    final paramsStart = signature.indexOf('(');
-    final paramsEnd = signature.lastIndexOf(')');
-    if (paramsStart == -1 || paramsEnd == -1) {
-      throw ArgumentError('Invalid function signature: $signature');
-    }
-
-    final paramsStr = signature.substring(paramsStart + 1, paramsEnd);
-    final types = paramsStr.isEmpty ? <String>[] : paramsStr.split(',');
-
-    if (types.length != args.length) {
-      throw ArgumentError(
-        'Argument count mismatch: expected ${types.length}, got ${args.length}',
-      );
-    }
-
-    // Encode each argument
-    final encodedParams = <String>[];
-    for (var i = 0; i < args.length; i++) {
-      final type = types[i].trim();
-      final value = args[i];
-      encodedParams.add(_encodeArg(type, value));
-    }
-
-    return AbiEncoder.encodeFunctionCall(selector, encodedParams);
-  }
-
-  /// Encodes a single argument based on its Solidity type.
-  String _encodeArg(String type, dynamic value) {
-    if (type == 'address') {
-      if (value is EthereumAddress) {
-        return AbiEncoder.encodeAddress(value);
-      }
-      return AbiEncoder.encodeAddress(
-        EthereumAddress.fromHex(value.toString()),
-      );
-    }
-
-    if (type.startsWith('uint')) {
-      BigInt bigValue;
-      if (value is BigInt) {
-        bigValue = value;
-      } else if (value is int) {
-        bigValue = BigInt.from(value);
-      } else {
-        bigValue = BigInt.parse(value.toString());
-      }
-      return AbiEncoder.encodeUint256(bigValue);
-    }
-
-    if (type == 'bool') {
-      return AbiEncoder.encodeBool(value: value as bool);
-    }
-
-    if (type == 'bytes32') {
-      return AbiEncoder.encodeBytes32(value.toString());
-    }
-
-    if (type == 'bytes') {
-      return AbiEncoder.encodeBytes(value.toString());
-    }
-
-    throw ArgumentError('Unsupported argument type: $type');
-  }
 }

--- a/packages/permissionless/lib/src/utils/encoding.dart
+++ b/packages/permissionless/lib/src/utils/encoding.dart
@@ -57,6 +57,49 @@ class AbiEncoder {
   ) =>
       Hex.concat([selector, ...encodedParams.map(Hex.strip0x)]);
 
+  /// Encodes function calldata from a Solidity signature and arguments.
+  ///
+  /// Uses web3dart's ABI encoder so encoding matches Solidity and viem
+  /// `encodeFunctionData` for static types, dynamic `bytes`/`string`, arrays,
+  /// and tuples (including nested).
+  ///
+  /// [functionSignature] examples:
+  /// - `transfer(address,uint256)`
+  /// - `execute(address,uint256,bytes)`
+  /// - `setPoint((uint256,uint256))`
+  ///
+  /// Accepted argument forms:
+  /// - `address`: [EthereumAddress] or hex [String]
+  /// - `uint*` / `int*`: [BigInt] or [int]
+  /// - `bool`: [bool]
+  /// - `bytes` / `bytesN`: hex [String] or [Uint8List]
+  /// - `string`: [String]
+  /// - arrays / tuples: [List], converted element-wise
+  static String encodeFunctionData(
+    String functionSignature, [
+    List<dynamic> args = const [],
+  ]) {
+    final parsed = _parseFunctionSignature(functionSignature);
+    if (parsed.types.length != args.length) {
+      throw ArgumentError(
+        'Argument count mismatch: expected ${parsed.types.length}, '
+        'got ${args.length}',
+      );
+    }
+
+    final parameters = <FunctionParameter<dynamic>>[
+      for (var i = 0; i < parsed.types.length; i++)
+        FunctionParameter<dynamic>('arg$i', parseAbiType(parsed.types[i])),
+    ];
+    final function = ContractFunction(parsed.name, parameters);
+    final converted = <dynamic>[
+      for (var i = 0; i < args.length; i++)
+        _convertAbiArg(parsed.types[i], args[i]),
+    ];
+
+    return Hex.fromBytes(function.encodeCall(converted));
+  }
+
   /// Encodes multiple values with dynamic types.
   ///
   /// `parts` - List of tuples (isStatic, encodedValue).
@@ -80,6 +123,156 @@ class AbiEncoder {
     }
 
     return Hex.concat([...staticParts, ...dynamicParts]);
+  }
+
+  static ({String name, List<String> types}) _parseFunctionSignature(
+    String signature,
+  ) {
+    final paramsStart = signature.indexOf('(');
+    final paramsEnd = signature.lastIndexOf(')');
+    if (paramsStart == -1 || paramsEnd == -1 || paramsEnd < paramsStart) {
+      throw ArgumentError('Invalid function signature: $signature');
+    }
+
+    final name = signature.substring(0, paramsStart).trim();
+    if (name.isEmpty) {
+      throw ArgumentError('Invalid function signature: $signature');
+    }
+
+    final paramsStr = signature.substring(paramsStart + 1, paramsEnd);
+    return (name: name, types: _splitAbiParameterTypes(paramsStr));
+  }
+
+  /// Splits a top-level ABI parameter list, respecting nested tuples.
+  static List<String> _splitAbiParameterTypes(String params) {
+    final trimmed = params.trim();
+    if (trimmed.isEmpty) return [];
+
+    final types = <String>[];
+    final buffer = StringBuffer();
+    var depth = 0;
+
+    for (var i = 0; i < trimmed.length; i++) {
+      final char = trimmed[i];
+      if (char == '(') {
+        depth++;
+        buffer.write(char);
+      } else if (char == ')') {
+        depth--;
+        buffer.write(char);
+      } else if (char == ',' && depth == 0) {
+        types.add(buffer.toString().trim());
+        buffer.clear();
+      } else {
+        buffer.write(char);
+      }
+    }
+
+    if (buffer.isNotEmpty) {
+      types.add(buffer.toString().trim());
+    }
+
+    if (depth != 0) {
+      throw ArgumentError(
+        'Invalid ABI type list (mismatched parentheses): $params',
+      );
+    }
+
+    return types;
+  }
+
+  /// Converts a Dart-friendly argument into the form web3dart expects.
+  static dynamic _convertAbiArg(String type, dynamic value) {
+    final arrayMatch = RegExp(r'^(.*)\[(\d*)\]$').firstMatch(type);
+    if (arrayMatch != null) {
+      final elementType = arrayMatch.group(1)!;
+      if (value is! List) {
+        throw ArgumentError(
+          'Expected List for array type $type, got ${value.runtimeType}',
+        );
+      }
+      final lengthStr = arrayMatch.group(2)!;
+      if (lengthStr.isNotEmpty) {
+        final expectedLength = int.parse(lengthStr);
+        if (value.length != expectedLength) {
+          throw ArgumentError(
+            'Array length mismatch for $type: expected $expectedLength, '
+            'got ${value.length}',
+          );
+        }
+      }
+      return [
+        for (final element in value) _convertAbiArg(elementType, element),
+      ];
+    }
+
+    if (type.startsWith('(') && type.endsWith(')')) {
+      if (value is! List) {
+        throw ArgumentError(
+          'Expected List for tuple type $type, got ${value.runtimeType}',
+        );
+      }
+      final componentTypes = _splitAbiParameterTypes(
+        type.substring(1, type.length - 1),
+      );
+      if (componentTypes.length != value.length) {
+        throw ArgumentError(
+          'Tuple length mismatch for $type: expected '
+          '${componentTypes.length}, got ${value.length}',
+        );
+      }
+      return [
+        for (var i = 0; i < componentTypes.length; i++)
+          _convertAbiArg(componentTypes[i], value[i]),
+      ];
+    }
+
+    if (type == 'address') {
+      if (value is EthereumAddress) return value;
+      return EthereumAddress.fromHex(value.toString());
+    }
+
+    if (type == 'bool') {
+      return value as bool;
+    }
+
+    if (type == 'string') {
+      return value as String;
+    }
+
+    if (type == 'bytes' || (type.startsWith('bytes') && type.length > 5)) {
+      return _toBytes(
+        value,
+        fixedLength: type == 'bytes' ? null : int.parse(type.substring(5)),
+      );
+    }
+
+    if (type.startsWith('uint') || type.startsWith('int')) {
+      if (value is BigInt) return value;
+      if (value is int) return BigInt.from(value);
+      return BigInt.parse(value.toString());
+    }
+
+    return value;
+  }
+
+  static Uint8List _toBytes(dynamic value, {int? fixedLength}) {
+    final Uint8List bytes;
+    if (value is Uint8List) {
+      bytes = value;
+    } else if (value is List<int>) {
+      bytes = Uint8List.fromList(value);
+    } else {
+      bytes = Hex.decode(value.toString());
+    }
+
+    if (fixedLength != null && bytes.length != fixedLength) {
+      throw ArgumentError(
+        'Invalid bytes$fixedLength length: expected $fixedLength, '
+        'got ${bytes.length}',
+      );
+    }
+    return bytes;
   }
 }
 

--- a/packages/permissionless/lib/src/utils/erc7579.dart
+++ b/packages/permissionless/lib/src/utils/erc7579.dart
@@ -135,20 +135,29 @@ enum Erc7579CallKind {
 /// The execution mode determines how the account executes calls and
 /// handles errors. It is encoded as a 32-byte value:
 /// - Byte 0: Call type (call=0x00, batch=0x01, delegatecall=0xff)
-/// - Byte 1: Revert behavior (0x00=revert on error, 0x01=try/continue)
+/// - Byte 1: Exec type (0x00=default/revert on failure, 0x01=try/continue)
 /// - Bytes 2-5: Reserved (padding)
 /// - Bytes 6-9: Optional function selector
 /// - Bytes 10-31: Optional context data (22 bytes)
 ///
+/// ## `revertOnError` polarity (permissionless.js parity)
+///
+/// The [revertOnError] flag matches permissionless.js `encodeExecutionMode`:
+/// `true` → execType `0x01`, `false` → execType `0x00`.
+///
+/// That is **not** English/ERC-7579 naming: ERC-7579 `0x00` is default (revert
+/// on failure) and `0x01` is try. Prefer thinking in execType bytes for on-chain
+/// semantics; use [revertOnError] only when mirroring JS callers.
+///
 /// Example:
 /// ```dart
-/// // Default single call mode (reverts on error)
+/// // Default single call mode (execType 0x00 — reverts on failure)
 /// final mode = ExecutionMode(type: Erc7579CallKind.call);
 ///
-/// // Batch call that continues on error
+/// // Batch call with execType 0x01 (try / continue on error) — JS true
 /// final batchMode = ExecutionMode(
 ///   type: Erc7579CallKind.batchCall,
-///   revertOnError: false,
+///   revertOnError: true,
 /// );
 ///
 /// // Check if account supports a mode
@@ -158,7 +167,7 @@ class ExecutionMode {
   /// Creates an execution mode configuration.
   const ExecutionMode({
     required this.type,
-    this.revertOnError = true,
+    this.revertOnError = false,
     this.selector,
     this.context,
   });
@@ -166,10 +175,14 @@ class ExecutionMode {
   /// The type of call execution.
   final Erc7579CallKind type;
 
-  /// Whether to revert the entire operation on error.
+  /// permissionless.js-compatible flag mapped onto the ERC-7579 execType byte.
   ///
-  /// When true (default), any error reverts the transaction.
-  /// When false, errors are caught and execution continues (try mode).
+  /// Wire mapping (matches JS `encodeExecutionMode`):
+  /// - `false` (default) → execType `0x00` (ERC-7579 default: revert on failure)
+  /// - `true` → execType `0x01` (ERC-7579 try: continue on failure)
+  ///
+  /// The field name follows permissionless.js, not the English meaning of
+  /// "revert on error".
   final bool revertOnError;
 
   /// Optional 4-byte function selector.
@@ -186,9 +199,9 @@ class ExecutionMode {
 
   /// Encodes this execution mode as a 32-byte hex string.
   ///
-  /// The encoding follows ERC-7579:
+  /// The encoding follows ERC-7579 layout with permissionless.js polarity:
   /// - Byte 0: call type
-  /// - Byte 1: exec type (0x00 if revertOnError, 0x01 if try)
+  /// - Byte 1: exec type (`0x01` if [revertOnError], else `0x00`)
   /// - Bytes 2-5: padding (zeros)
   /// - Bytes 6-9: selector (or zeros)
   /// - Bytes 10-31: context (or zeros)
@@ -198,8 +211,8 @@ class ExecutionMode {
     // Byte 0: Call type
     mode[0] = type.value;
 
-    // Byte 1: Exec type (0x00 = revert on error, 0x01 = try/continue)
-    mode[1] = revertOnError ? 0x00 : 0x01;
+    // Byte 1: Exec type — permissionless.js: revertOnError ? 0x01 : 0x00
+    mode[1] = revertOnError ? 0x01 : 0x00;
 
     // Bytes 2-5: Reserved (already zeros)
 
@@ -350,21 +363,42 @@ String encode7579Execute(Call call) {
 
 /// Encodes a complete ERC-7579 execute call (batch calls).
 ///
-/// Generates: execute(mode, executionCalldata) with batch call encoding.
+/// Generates: execute(mode, executionCalldata) with batch call encoding
+/// (`callType = 0x01`, `abi.encode(Execution[])`).
+///
+/// A single-element [calls] list still uses batch mode — it is **not**
+/// silently downgraded to [encode7579Execute]. Callers that want call mode for
+/// one item should use [encode7579Execute] (or branch on `calls.length` like
+/// permissionless.js accounts do).
 String encode7579ExecuteBatch(List<Call> calls) {
   if (calls.isEmpty) {
     throw ArgumentError('At least one call is required');
-  }
-
-  // Single call optimization
-  if (calls.length == 1) {
-    return encode7579Execute(calls.first);
   }
 
   final mode = encode7579ExecuteMode(callType: Erc7579CallType.batchCall);
   final executionData = encode7579BatchCallData(calls);
 
   // Encode the execute function call
+  const executionDataOffset = 2 * 32;
+  final executionDataEncoded = AbiEncoder.encodeBytes(executionData);
+
+  return Hex.concat([
+    Erc7579Selectors.execute,
+    Hex.strip0x(mode),
+    AbiEncoder.encodeUint256(BigInt.from(executionDataOffset)),
+    Hex.strip0x(executionDataEncoded),
+  ]);
+}
+
+/// Encodes a complete ERC-7579 execute call as a delegatecall.
+///
+/// Generates: execute(mode, executionCalldata) with `callType = 0xff` and
+/// packed single-call execution data (`to || value || data`), matching
+/// permissionless.js `encode7579Calls` when `mode.type === "delegatecall"`.
+String encode7579ExecuteDelegateCall(Call call) {
+  final mode = encode7579ExecuteMode(callType: Erc7579CallType.delegateCall);
+  final executionData = encode7579SingleCallData(call);
+
   const executionDataOffset = 2 * 32;
   final executionDataEncoded = AbiEncoder.encodeBytes(executionData);
 
@@ -514,7 +548,7 @@ String encode7579SupportsModule(Erc7579ModuleType moduleType) => Hex.concat([
 /// ```dart
 /// final mode = ExecutionMode(
 ///   type: Erc7579CallKind.batchCall,
-///   revertOnError: false,
+///   revertOnError: true, // JS polarity → execType 0x01 (try)
 /// );
 /// final callData = encode7579SupportsExecutionMode(mode);
 /// final result = await publicClient.call(Call(to: account, data: callData));
@@ -741,7 +775,24 @@ class Decoded7579Calls {
 
 /// Decodes ERC-7579 execute call data back into mode and calls.
 ///
-/// Reverses the encoding done by [encode7579Execute] or [encode7579ExecuteBatch].
+/// Reverses the encoding done by [encode7579Execute], [encode7579ExecuteBatch],
+/// or [encode7579ExecuteDelegateCall].
+///
+/// ## Mode layout (deliberate decode-offset stance)
+///
+/// Mode is decoded with the ERC-7579 layout used by both this library's encoder
+/// and permissionless.js `encodeExecutionMode`:
+/// `callType(1) | execType(1) | unused(4) | modeSelector(4 @ bytes 6-9) |
+/// modePayload(22 @ bytes 10-31)`.
+///
+/// permissionless.js `decode7579Calls` currently slices selector/context at
+/// bytes 3-6 / 7-31 (lossy vs its own encoder). Dart **keeps** the
+/// spec-aligned offsets so encode→decode round-trips of non-zero selector /
+/// context succeed. Cross-port comparisons of decoded `selector`/`context`
+/// against JS decode output will differ for non-zero fields.
+///
+/// [ExecutionMode.revertOnError] uses permissionless.js polarity:
+/// execType `0x01` → `true`, `0x00` → `false`.
 ///
 /// Example:
 /// ```dart
@@ -775,9 +826,10 @@ Decoded7579Calls decode7579Calls(String callData) {
 
   // Decode mode components
   final callType = Erc7579CallKind.fromValue(modeBytes[0]);
-  final revertOnError = modeBytes[1] == 0x00;
+  // permissionless.js: revertOnError === (execType == 0x01)
+  final revertOnError = modeBytes[1] == 0x01;
 
-  // Bytes 6-9: selector (4 bytes)
+  // Bytes 6-9: selector (4 bytes) — ERC-7579 / JS encoder layout (not JS decode)
   String? modeSelector;
   if (modeBytes[6] != 0 ||
       modeBytes[7] != 0 ||

--- a/packages/permissionless/test/accounts/biconomy/biconomy_account_test.dart
+++ b/packages/permissionless/test/accounts/biconomy/biconomy_account_test.dart
@@ -1,0 +1,289 @@
+import 'package:permissionless/permissionless.dart';
+import 'package:test/test.dart';
+
+/// Unit tests for Biconomy (legacy EP v0.6) smart account.
+///
+/// Fixtures generated from permissionless.js v0.3.5 / viem with:
+/// - privateKey: Hardhat #0
+/// - chainId: 1
+/// - sender: 0x1234...7890
+/// - message: "hello"
+void main() {
+
+  // Hardhat account #0 — do not use in production
+  const testPrivateKey =
+      '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
+  const ownerAddress = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266';
+
+  // Pre-set address for unit tests (avoids RPC). Same sender used in JS fixtures.
+  final mockAddress =
+      EthereumAddress.fromHex('0x1234567890123456789012345678901234567890');
+
+  final singleCall = Call(
+    to: EthereumAddress.fromHex('0x2222222222222222222222222222222222222222'),
+    value: BigInt.one,
+    data: '0xdeadbeef',
+  );
+  final batchCalls = [
+    singleCall,
+    Call(
+      to: EthereumAddress.fromHex('0x3333333333333333333333333333333333333333'),
+      value: BigInt.zero,
+      data: '0x',
+    ),
+  ];
+
+  final sampleTypedData = TypedData(
+    domain: TypedDataDomain(
+      name: 'Mail',
+      version: '1',
+      chainId: BigInt.one,
+      verifyingContract: mockAddress,
+    ),
+    types: {
+      'Mail': [const TypedDataField(name: 'contents', type: 'string')],
+    },
+    primaryType: 'Mail',
+    message: {'contents': 'Hello'},
+  );
+
+  UserOperationV06 fixtureUserOpV06(EthereumAddress sender) =>
+      UserOperationV06(
+        sender: sender,
+        nonce: BigInt.zero,
+        initCode: '0x',
+        callData: '0x',
+        callGasLimit: BigInt.from(100000),
+        verificationGasLimit: BigInt.from(100000),
+        preVerificationGas: BigInt.from(21000),
+        maxFeePerGas: BigInt.from(1000000000),
+        maxPriorityFeePerGas: BigInt.from(1000000000),
+        paymasterAndData: '0x',
+      );
+
+  // ---- permissionless.js fixtures ----
+  const jsFactoryData =
+      '0xdf20ffbc0000000000000000000000000000001c5b32f37f5bea87bdd5374eb2'
+      'ac54ea8e00000000000000000000000000000000000000000000000000000000'
+      '0000006000000000000000000000000000000000000000000000000000000000'
+      '0000000000000000000000000000000000000000000000000000000000000000'
+      '000000242ede3bc0000000000000000000000000f39fd6e51aad88f6f4ce6ab8'
+      '827279cfffb92266000000000000000000000000000000000000000000000000'
+      '00000000';
+
+  const jsInitCode =
+      '0x000000a56aaca3e9a4c479ea6b6cd0dbcb6634f5df20ffbc0000000000000000'
+      '000000000000001c5b32f37f5bea87bdd5374eb2ac54ea8e0000000000000000'
+      '0000000000000000000000000000000000000000000000600000000000000000'
+      '0000000000000000000000000000000000000000000000000000000000000000'
+      '0000000000000000000000000000000000000000000000242ede3bc000000000'
+      '0000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb9226600000000'
+      '000000000000000000000000000000000000000000000000';
+
+  const jsStubSignature =
+      '0x0000000000000000000000000000000000000000000000000000000000000040'
+      '0000000000000000000000000000001c5b32f37f5bea87bdd5374eb2ac54ea8e'
+      '0000000000000000000000000000000000000000000000000000000000000041'
+      '81d4b4981670cb18f99f0b4a66446df1bf5b204d24cfcb659bf38ba27a4359b5'
+      '711649ec2423c5e1247245eba2964679b6a1dbb85c992ae40b9b00c6935b02ff'
+      '1b00000000000000000000000000000000000000000000000000000000000000';
+
+  const jsEncodeCallsSingle =
+      '0x0000189a00000000000000000000000022222222222222222222222222222222'
+      '2222222200000000000000000000000000000000000000000000000000000000'
+      '0000000100000000000000000000000000000000000000000000000000000000'
+      '0000006000000000000000000000000000000000000000000000000000000000'
+      '00000004deadbeef000000000000000000000000000000000000000000000000'
+      '00000000';
+
+  const jsEncodeCallsBatch =
+      '0x0000468000000000000000000000000000000000000000000000000000000000'
+      '0000006000000000000000000000000000000000000000000000000000000000'
+      '000000c000000000000000000000000000000000000000000000000000000000'
+      '0000012000000000000000000000000000000000000000000000000000000000'
+      '0000000200000000000000000000000022222222222222222222222222222222'
+      '2222222200000000000000000000000033333333333333333333333333333333'
+      '3333333300000000000000000000000000000000000000000000000000000000'
+      '0000000200000000000000000000000000000000000000000000000000000000'
+      '0000000100000000000000000000000000000000000000000000000000000000'
+      '0000000000000000000000000000000000000000000000000000000000000000'
+      '0000000200000000000000000000000000000000000000000000000000000000'
+      '0000004000000000000000000000000000000000000000000000000000000000'
+      '0000008000000000000000000000000000000000000000000000000000000000'
+      '00000004deadbeef000000000000000000000000000000000000000000000000'
+      '0000000000000000000000000000000000000000000000000000000000000000'
+      '00000000';
+
+  const jsSignUserOperation =
+      '0x0000000000000000000000000000000000000000000000000000000000000040'
+      '0000000000000000000000000000001c5b32f37f5bea87bdd5374eb2ac54ea8e'
+      '0000000000000000000000000000000000000000000000000000000000000041'
+      'c6a17ddf898b2b92ca9ad4ca38b8d3eb73d538e199b939b416ebbe746debeac2'
+      '57952180f7c4e4f5433bf20caf4b1bc5330104661b71f16f8cafeecba1aba762'
+      '1b00000000000000000000000000000000000000000000000000000000000000';
+
+  const jsSignMessage =
+      '0x0000000000000000000000000000000000000000000000000000000000000040'
+      '0000000000000000000000000000001c5b32f37f5bea87bdd5374eb2ac54ea8e'
+      '0000000000000000000000000000000000000000000000000000000000000041'
+      'f16ea9a3478698f695fd1401bfe27e9e4a7e8e3da94aa72b021125e31fa899cc'
+      '573c48ea3fe1d4ab61a9db10c19032026e3ed2dbccba5a178235ac27f9450431'
+      '1c00000000000000000000000000000000000000000000000000000000000000';
+
+  const jsSignTypedData =
+      '0x0000000000000000000000000000000000000000000000000000000000000040'
+      '0000000000000000000000000000001c5b32f37f5bea87bdd5374eb2ac54ea8e'
+      '0000000000000000000000000000000000000000000000000000000000000041'
+      'd8fd05ea6e49e0922a405ed6321ffbd3eedd417fcc8bc44873fa2c78c52bd051'
+      '4a1fb653acc8e3752a3901b320950712aecfec9ca122dd7676c9fb9c888e6911'
+      '1b00000000000000000000000000000000000000000000000000000000000000';
+
+  const jsCounterfactualAddress =
+      '0x0788816536defa6a14779711c0b08b7f0edfe68b';
+
+
+  group('BiconomyAddresses', () {
+    test('factory matches permissionless.js', () {
+      // ignore: deprecated_member_use_from_same_package
+      expect(
+        BiconomyAddresses.factory.hex.toLowerCase(),
+        equals('0x000000a56aaca3e9a4c479ea6b6cd0dbcb6634f5'),
+      );
+    });
+
+    test('ecdsa ownership module matches permissionless.js', () {
+      // ignore: deprecated_member_use_from_same_package
+      expect(
+        BiconomyAddresses.ecdsaOwnershipModule.hex.toLowerCase(),
+        equals('0x0000001c5b32f37f5bea87bdd5374eb2ac54ea8e'),
+      );
+    });
+  });
+
+  group('BiconomySmartAccount', () {
+    late PrivateKeyOwner owner;
+    // ignore: deprecated_member_use_from_same_package
+    late BiconomySmartAccount account;
+
+    setUp(() {
+      owner = PrivateKeyOwner(testPrivateKey);
+      expect(owner.address.hex.toLowerCase(), equals(ownerAddress.toLowerCase()));
+      // ignore: deprecated_member_use_from_same_package
+      account = createBiconomySmartAccount(
+        owner: owner,
+        chainId: BigInt.one,
+        address: mockAddress,
+      );
+    });
+
+    group('creation', () {
+      test('defaults to EntryPoint v0.6', () {
+        expect(account.entryPoint, equals(EntryPointAddresses.v06));
+        expect(account.chainId, equals(BigInt.one));
+        expect(account.index, equals(BigInt.zero));
+      });
+    });
+
+    group('counterfactual address', () {
+      test('CREATE2 address matches permissionless.js', () async {
+        // No pre-set address — pure local CREATE2
+        // ignore: deprecated_member_use_from_same_package
+        final create2Account = createBiconomySmartAccount(
+          owner: owner,
+          chainId: BigInt.one,
+        );
+        final address = await create2Account.getAddress();
+        expect(
+          address.hex.toLowerCase(),
+          equals(jsCounterfactualAddress),
+        );
+      });
+
+      test('returns pre-set address when provided', () async {
+        final address = await account.getAddress();
+        expect(address.hex.toLowerCase(), equals(mockAddress.hex.toLowerCase()));
+      });
+    });
+
+    group('factoryData / initCode', () {
+      test('factoryData matches permissionless.js', () async {
+        final factoryData = await account.getFactoryData();
+        expect(factoryData, isNotNull);
+        expect(
+          factoryData!.factory.hex.toLowerCase(),
+          equals('0x000000a56aaca3e9a4c479ea6b6cd0dbcb6634f5'),
+        );
+        expect(factoryData.factoryData.toLowerCase(), equals(jsFactoryData));
+      });
+
+      test('initCode is factory ++ factoryData', () async {
+        final initCode = await account.getInitCode();
+        expect(initCode.toLowerCase(), equals(jsInitCode));
+      });
+    });
+
+    group('stub signature', () {
+      test('matches permissionless.js module-wrapped dummy', () {
+        expect(account.getStubSignature().toLowerCase(), equals(jsStubSignature));
+      });
+    });
+
+    group('encodeCalls', () {
+      test('single call matches permissionless.js execute_ncC', () {
+        expect(
+          account.encodeCalls([singleCall]).toLowerCase(),
+          equals(jsEncodeCallsSingle),
+        );
+      });
+
+      test('batch matches permissionless.js executeBatch_y6U', () {
+        expect(
+          account.encodeCalls(batchCalls).toLowerCase(),
+          equals(jsEncodeCallsBatch),
+        );
+      });
+
+      test('throws on empty calls', () {
+        expect(() => account.encodeCalls([]), throwsA(isA<ArgumentError>()));
+      });
+    });
+
+    group('signUserOperation', () {
+      test('matches permissionless.js module-wrapped signature', () async {
+        final signature =
+            await account.signUserOperationV06(fixtureUserOpV06(mockAddress));
+        expect(signature.toLowerCase(), equals(jsSignUserOperation));
+      });
+
+      test('v0.7 API throws UnsupportedError', () async {
+        expect(
+          () => account.signUserOperation(
+            UserOperationV07(
+              sender: mockAddress,
+              nonce: BigInt.zero,
+              callData: '0x',
+              callGasLimit: BigInt.from(100000),
+              verificationGasLimit: BigInt.from(100000),
+              preVerificationGas: BigInt.from(21000),
+              maxFeePerGas: BigInt.from(1000000000),
+              maxPriorityFeePerGas: BigInt.from(1000000000),
+            ),
+          ),
+          throwsA(isA<UnsupportedError>()),
+        );
+      });
+    });
+
+    group('ERC-1271 signing', () {
+      test('signMessage matches permissionless.js', () async {
+        final signature = await account.signMessage('hello');
+        expect(signature.toLowerCase(), equals(jsSignMessage));
+      });
+
+      test('signTypedData matches permissionless.js', () async {
+        final signature = await account.signTypedData(sampleTypedData);
+        expect(signature.toLowerCase(), equals(jsSignTypedData));
+      });
+    });
+  });
+}

--- a/packages/permissionless/test/accounts/biconomy/biconomy_account_test.dart
+++ b/packages/permissionless/test/accounts/biconomy/biconomy_account_test.dart
@@ -9,7 +9,6 @@ import 'package:test/test.dart';
 /// - sender: 0x1234...7890
 /// - message: "hello"
 void main() {
-
   // Hardhat account #0 — do not use in production
   const testPrivateKey =
       '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
@@ -47,8 +46,7 @@ void main() {
     message: {'contents': 'Hello'},
   );
 
-  UserOperationV06 fixtureUserOpV06(EthereumAddress sender) =>
-      UserOperationV06(
+  UserOperationV06 fixtureUserOpV06(EthereumAddress sender) => UserOperationV06(
         sender: sender,
         nonce: BigInt.zero,
         initCode: '0x',
@@ -138,9 +136,7 @@ void main() {
       '4a1fb653acc8e3752a3901b320950712aecfec9ca122dd7676c9fb9c888e6911'
       '1b00000000000000000000000000000000000000000000000000000000000000';
 
-  const jsCounterfactualAddress =
-      '0x0788816536defa6a14779711c0b08b7f0edfe68b';
-
+  const jsCounterfactualAddress = '0x0788816536defa6a14779711c0b08b7f0edfe68b';
 
   group('BiconomyAddresses', () {
     test('factory matches permissionless.js', () {
@@ -167,7 +163,8 @@ void main() {
 
     setUp(() {
       owner = PrivateKeyOwner(testPrivateKey);
-      expect(owner.address.hex.toLowerCase(), equals(ownerAddress.toLowerCase()));
+      expect(
+          owner.address.hex.toLowerCase(), equals(ownerAddress.toLowerCase()));
       // ignore: deprecated_member_use_from_same_package
       account = createBiconomySmartAccount(
         owner: owner,
@@ -201,7 +198,8 @@ void main() {
 
       test('returns pre-set address when provided', () async {
         final address = await account.getAddress();
-        expect(address.hex.toLowerCase(), equals(mockAddress.hex.toLowerCase()));
+        expect(
+            address.hex.toLowerCase(), equals(mockAddress.hex.toLowerCase()));
       });
     });
 
@@ -224,7 +222,8 @@ void main() {
 
     group('stub signature', () {
       test('matches permissionless.js module-wrapped dummy', () {
-        expect(account.getStubSignature().toLowerCase(), equals(jsStubSignature));
+        expect(
+            account.getStubSignature().toLowerCase(), equals(jsStubSignature));
       });
     });
 

--- a/packages/permissionless/test/accounts/nexus/nexus_account_test.dart
+++ b/packages/permissionless/test/accounts/nexus/nexus_account_test.dart
@@ -1,25 +1,54 @@
 import 'package:permissionless/permissionless.dart';
 import 'package:test/test.dart';
 
+/// Unit tests for Nexus (Biconomy ERC-7579) smart account.
+///
+/// Fixtures generated from permissionless.js v0.3.5 / viem with:
+/// - privateKey: Hardhat #0
+/// - chainId: 1
+/// - sender: 0x1234...7890
+/// - message: "hello"
 void main() {
-  // Hardhat account 0 — do not use in production
+
+  // Hardhat account #0 — do not use in production
   const testPrivateKey =
       '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
+  const ownerAddress = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266';
 
+  // Pre-set address for unit tests (avoids RPC). Same sender used in JS fixtures.
   final mockAddress =
       EthereumAddress.fromHex('0x1234567890123456789012345678901234567890');
 
-  // Fixed UserOperation fields matching permissionless.js / viem fixture
-  // (chainId=1, sender=mockAddress, no factory/paymaster).
-  //
-  // JS fixture (viem getUserOperationHash + localOwner.signMessage raw hash):
-  // userOpHash: 0x152aa3402c1452b6e84bd92cdf80a83d4a93c90fa5bf441053bb90075df2191d
-  // signature:  0x00538c3d1fb4197de5a15394fcaf23ca1a570c63576424c0615656be0e112f5964840719f944a8d5b0e21ad3a262725d1004ac6a9926ac6299b3f48d1c0c0d8d1b
-  const jsFixtureUserOpSignature =
-      '0x00538c3d1fb4197de5a15394fcaf23ca1a570c63576424c0615656be0e112f59'
-      '64840719f944a8d5b0e21ad3a262725d1004ac6a9926ac6299b3f48d1c0c0d8d1b';
+  final singleCall = Call(
+    to: EthereumAddress.fromHex('0x2222222222222222222222222222222222222222'),
+    value: BigInt.one,
+    data: '0xdeadbeef',
+  );
+  final batchCalls = [
+    singleCall,
+    Call(
+      to: EthereumAddress.fromHex('0x3333333333333333333333333333333333333333'),
+      value: BigInt.zero,
+      data: '0x',
+    ),
+  ];
 
-  UserOperationV07 fixtureUserOp(EthereumAddress sender) => UserOperationV07(
+  final sampleTypedData = TypedData(
+    domain: TypedDataDomain(
+      name: 'Mail',
+      version: '1',
+      chainId: BigInt.one,
+      verifyingContract: mockAddress,
+    ),
+    types: {
+      'Mail': [const TypedDataField(name: 'contents', type: 'string')],
+    },
+    primaryType: 'Mail',
+    message: {'contents': 'Hello'},
+  );
+
+  UserOperationV07 fixtureUserOpV07(EthereumAddress sender) =>
+      UserOperationV07(
         sender: sender,
         nonce: BigInt.zero,
         callData: '0x',
@@ -29,6 +58,73 @@ void main() {
         maxFeePerGas: BigInt.from(1000000000),
         maxPriorityFeePerGas: BigInt.from(1000000000),
       );
+
+  // ---- permissionless.js fixtures ----
+  const jsFactoryData =
+      '0x0d51f0b7000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cf'
+      'ffb9226600000000000000000000000000000000000000000000000000000000'
+      '0000000000000000000000000000000000000000000000000000000000000000'
+      '0000008000000000000000000000000000000000000000000000000000000000'
+      '0000000000000000000000000000000000000000000000000000000000000000'
+      '00000000';
+
+  const jsInitCode =
+      '0x00000bb19a3579f4d779215def97afbd0e30db550d51f0b70000000000000000'
+      '00000000f39fd6e51aad88f6f4ce6ab8827279cfffb922660000000000000000'
+      '0000000000000000000000000000000000000000000000000000000000000000'
+      '0000000000000000000000000000000000000000000000800000000000000000'
+      '0000000000000000000000000000000000000000000000000000000000000000'
+      '000000000000000000000000000000000000000000000000';
+
+  const jsStubSignature =
+      '0x0000000000000000000000000000000000000000000000000000000000000040'
+      '00000000000000000000000000000004171351c442b202678c48d8ab5b321e8f'
+      '0000000000000000000000000000000000000000000000000000000000000041'
+      '81d4b4981670cb18f99f0b4a66446df1bf5b204d24cfcb659bf38ba27a4359b5'
+      '711649ec2423c5e1247245eba2964679b6a1dbb85c992ae40b9b00c6935b02ff'
+      '1b00000000000000000000000000000000000000000000000000000000000000';
+
+  const jsEncodeCallsSingle =
+      '0xe9ae5c5300000000000000000000000000000000000000000000000000000000'
+      '0000000000000000000000000000000000000000000000000000000000000000'
+      '0000004000000000000000000000000000000000000000000000000000000000'
+      '0000003822222222222222222222222222222222222222220000000000000000'
+      '000000000000000000000000000000000000000000000001deadbeef00000000'
+      '00000000';
+
+  const jsEncodeCallsBatch =
+      '0xe9ae5c5301000000000000000000000000000000000000000000000000000000'
+      '0000000000000000000000000000000000000000000000000000000000000000'
+      '0000004000000000000000000000000000000000000000000000000000000000'
+      '000001a000000000000000000000000000000000000000000000000000000000'
+      '0000002000000000000000000000000000000000000000000000000000000000'
+      '0000000200000000000000000000000000000000000000000000000000000000'
+      '0000004000000000000000000000000000000000000000000000000000000000'
+      '000000e000000000000000000000000022222222222222222222222222222222'
+      '2222222200000000000000000000000000000000000000000000000000000000'
+      '0000000100000000000000000000000000000000000000000000000000000000'
+      '0000006000000000000000000000000000000000000000000000000000000000'
+      '00000004deadbeef000000000000000000000000000000000000000000000000'
+      '0000000000000000000000000000000033333333333333333333333333333333'
+      '3333333300000000000000000000000000000000000000000000000000000000'
+      '0000000000000000000000000000000000000000000000000000000000000000'
+      '0000006000000000000000000000000000000000000000000000000000000000'
+      '00000000';
+
+  const jsSignUserOperation =
+      '0x00538c3d1fb4197de5a15394fcaf23ca1a570c63576424c0615656be0e112f59'
+      '64840719f944a8d5b0e21ad3a262725d1004ac6a9926ac6299b3f48d1c0c0d8d'
+      '1b';
+
+  const jsSignMessage =
+      '0x00000004171351c442b202678c48d8ab5b321e8fc3531b0bf5e9557d802246e8'
+      'a4c71d4bcd37324f686c1c8b880a08662253c952537a603b4f98ac4a321f28f7'
+      '5b3f7aec20f40be9765409903ab30e328b7cd71b1b';
+
+  const jsSignTypedData =
+      '0x00000004171351c442b202678c48d8ab5b321e8fcf7df200fcddb8965cf2e49b'
+      '9566bf97aa1b645097f72ec8086ff240844358130b2091f1368fa3187f5f0b6b'
+      'fb52fe300a38461ff03d2a0a71cfe76f86a79b8b1c';
 
   group('NexusAddresses', () {
     test('k1ValidatorFactory address matches permissionless.js', () {
@@ -48,12 +144,10 @@ void main() {
 
   group('NexusSelectors', () {
     test('createAccount selector is correct', () {
-      // keccak256("createAccount(address,uint256,address[],uint8)")[0:4]
       expect(NexusSelectors.createAccount, equals('0x0d51f0b7'));
     });
 
     test('computeAccountAddress selector is correct', () {
-      // keccak256("computeAccountAddress(address,uint256,address[],uint8)")[0:4]
       expect(NexusSelectors.computeAccountAddress, equals('0x322cc8ca'));
     });
   });
@@ -64,6 +158,7 @@ void main() {
 
     setUp(() {
       owner = PrivateKeyOwner(testPrivateKey);
+      expect(owner.address.hex.toLowerCase(), equals(ownerAddress.toLowerCase()));
       account = createNexusSmartAccount(
         owner: owner,
         chainId: BigInt.one,
@@ -84,67 +179,104 @@ void main() {
         expect(
             address.hex.toLowerCase(), equals(mockAddress.hex.toLowerCase()));
       });
+
+      test('throws without address or publicClient', () {
+        final bare = createNexusSmartAccount(
+          owner: owner,
+          chainId: BigInt.one,
+        );
+        expect(() => bare.getAddress(), throwsA(isA<StateError>()));
+      });
+    });
+
+    group('factoryData / initCode', () {
+      test('factoryData matches permissionless.js', () async {
+        final factoryData = await account.getFactoryData();
+        expect(factoryData, isNotNull);
+        expect(
+          factoryData!.factory.hex.toLowerCase(),
+          equals('0x00000bb19a3579f4d779215def97afbd0e30db55'),
+        );
+        expect(factoryData.factoryData.toLowerCase(), equals(jsFactoryData));
+      });
+
+      test('initCode is factory ++ factoryData', () async {
+        final initCode = await account.getInitCode();
+        expect(initCode.toLowerCase(), equals(jsInitCode));
+      });
+    });
+
+    group('stub signature', () {
+      test('matches permissionless.js validator-wrapped dummy', () {
+        expect(account.getStubSignature().toLowerCase(), equals(jsStubSignature));
+      });
+
+      test('includes validator address for gas estimation', () {
+        final stub = account.getStubSignature();
+        final validatorHex =
+            Hex.strip0x(NexusAddresses.k1Validator.hex).toLowerCase();
+        expect(Hex.strip0x(stub).toLowerCase().contains(validatorHex), isTrue);
+      });
+    });
+
+    group('encodeCalls', () {
+      test('single call matches permissionless.js ERC-7579 execute', () {
+        expect(
+          account.encodeCalls([singleCall]).toLowerCase(),
+          equals(jsEncodeCallsSingle),
+        );
+      });
+
+      test('batch matches permissionless.js ERC-7579 batch execute', () {
+        expect(
+          account.encodeCalls(batchCalls).toLowerCase(),
+          equals(jsEncodeCallsBatch),
+        );
+      });
+
+      test('throws on empty calls', () {
+        expect(() => account.encodeCalls([]), throwsA(isA<ArgumentError>()));
+      });
     });
 
     group('signUserOperation', () {
-      test('returns bare 65-byte ECDSA signature (no validator prefix)',
-          () async {
+      test('returns bare 65-byte ECDSA signature (no validator prefix)', () async {
         final signature =
-            await account.signUserOperation(fixtureUserOp(mockAddress));
-
+            await account.signUserOperation(fixtureUserOpV07(mockAddress));
         expect(signature, startsWith('0x'));
-        // 65 bytes = 130 hex chars + 0x prefix
-        expect(signature.length, equals(132));
+        expect(signature.length, equals(132)); // 65 bytes
         expect((signature.length - 2) ~/ 2, equals(65));
       });
 
       test('does not prepend K1 validator address', () async {
         final signature =
-            await account.signUserOperation(fixtureUserOp(mockAddress));
-
+            await account.signUserOperation(fixtureUserOpV07(mockAddress));
         final validatorHex =
             Hex.strip0x(NexusAddresses.k1Validator.hex).toLowerCase();
         final sigBody = Hex.strip0x(signature).toLowerCase();
-
-        // Bug was packing validator (20B) + sig (65B) = 85B starting with validator
         expect(sigBody.startsWith(validatorHex), isFalse);
-        expect(signature.length, isNot(equals(172))); // 85 bytes + 0x
+        expect(signature.length, isNot(equals(172))); // not 85 bytes
       });
 
       test('byte-matches permissionless.js for same key and userOp', () async {
         final signature =
-            await account.signUserOperation(fixtureUserOp(mockAddress));
-
-        expect(
-          signature.toLowerCase(),
-          equals(jsFixtureUserOpSignature.toLowerCase()),
-        );
+            await account.signUserOperation(fixtureUserOpV07(mockAddress));
+        expect(signature.toLowerCase(), equals(jsSignUserOperation));
       });
     });
 
-    group('signMessage (ERC-1271)', () {
-      test('still packs validator address + 65-byte signature', () async {
-        final signature = await account.signMessage('hello nexus');
-
-        expect(signature, startsWith('0x'));
-        // 20-byte validator + 65-byte ECDSA = 85 bytes = 170 hex + 0x
-        expect(signature.length, equals(172));
+    group('ERC-1271 signing', () {
+      test('signMessage matches permissionless.js (validator ++ sig)', () async {
+        final signature = await account.signMessage('hello');
+        expect(signature.toLowerCase(), equals(jsSignMessage));
+        // 20-byte validator + 65-byte ECDSA = 85 bytes
         expect((signature.length - 2) ~/ 2, equals(85));
-
-        final validatorHex =
-            Hex.strip0x(NexusAddresses.k1Validator.hex).toLowerCase();
-        final sigBody = Hex.strip0x(signature).toLowerCase();
-        expect(sigBody.startsWith(validatorHex), isTrue);
       });
-    });
 
-    group('getStubSignature', () {
-      test('includes validator address for gas estimation', () {
-        final stub = account.getStubSignature();
-        expect(stub, startsWith('0x'));
-        final validatorHex =
-            Hex.strip0x(NexusAddresses.k1Validator.hex).toLowerCase();
-        expect(Hex.strip0x(stub).toLowerCase().contains(validatorHex), isTrue);
+      test('signTypedData matches permissionless.js (validator ++ sig)', () async {
+        final signature = await account.signTypedData(sampleTypedData);
+        expect(signature.toLowerCase(), equals(jsSignTypedData));
+        expect((signature.length - 2) ~/ 2, equals(85));
       });
     });
   });

--- a/packages/permissionless/test/accounts/nexus/nexus_account_test.dart
+++ b/packages/permissionless/test/accounts/nexus/nexus_account_test.dart
@@ -9,7 +9,6 @@ import 'package:test/test.dart';
 /// - sender: 0x1234...7890
 /// - message: "hello"
 void main() {
-
   // Hardhat account #0 — do not use in production
   const testPrivateKey =
       '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
@@ -47,8 +46,7 @@ void main() {
     message: {'contents': 'Hello'},
   );
 
-  UserOperationV07 fixtureUserOpV07(EthereumAddress sender) =>
-      UserOperationV07(
+  UserOperationV07 fixtureUserOpV07(EthereumAddress sender) => UserOperationV07(
         sender: sender,
         nonce: BigInt.zero,
         callData: '0x',
@@ -158,7 +156,8 @@ void main() {
 
     setUp(() {
       owner = PrivateKeyOwner(testPrivateKey);
-      expect(owner.address.hex.toLowerCase(), equals(ownerAddress.toLowerCase()));
+      expect(
+          owner.address.hex.toLowerCase(), equals(ownerAddress.toLowerCase()));
       account = createNexusSmartAccount(
         owner: owner,
         chainId: BigInt.one,
@@ -208,7 +207,8 @@ void main() {
 
     group('stub signature', () {
       test('matches permissionless.js validator-wrapped dummy', () {
-        expect(account.getStubSignature().toLowerCase(), equals(jsStubSignature));
+        expect(
+            account.getStubSignature().toLowerCase(), equals(jsStubSignature));
       });
 
       test('includes validator address for gas estimation', () {
@@ -240,7 +240,8 @@ void main() {
     });
 
     group('signUserOperation', () {
-      test('returns bare 65-byte ECDSA signature (no validator prefix)', () async {
+      test('returns bare 65-byte ECDSA signature (no validator prefix)',
+          () async {
         final signature =
             await account.signUserOperation(fixtureUserOpV07(mockAddress));
         expect(signature, startsWith('0x'));
@@ -266,14 +267,16 @@ void main() {
     });
 
     group('ERC-1271 signing', () {
-      test('signMessage matches permissionless.js (validator ++ sig)', () async {
+      test('signMessage matches permissionless.js (validator ++ sig)',
+          () async {
         final signature = await account.signMessage('hello');
         expect(signature.toLowerCase(), equals(jsSignMessage));
         // 20-byte validator + 65-byte ECDSA = 85 bytes
         expect((signature.length - 2) ~/ 2, equals(85));
       });
 
-      test('signTypedData matches permissionless.js (validator ++ sig)', () async {
+      test('signTypedData matches permissionless.js (validator ++ sig)',
+          () async {
         final signature = await account.signTypedData(sampleTypedData);
         expect(signature.toLowerCase(), equals(jsSignTypedData));
         expect((signature.length - 2) ~/ 2, equals(85));

--- a/packages/permissionless/test/accounts/thirdweb/thirdweb_account_test.dart
+++ b/packages/permissionless/test/accounts/thirdweb/thirdweb_account_test.dart
@@ -9,7 +9,6 @@ import 'package:test/test.dart';
 /// - sender: 0x1234...7890
 /// - message: "hello"
 void main() {
-
   // Hardhat account #0 — do not use in production
   const testPrivateKey =
       '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
@@ -51,8 +50,7 @@ void main() {
     message: {'contents': 'Hello'},
   );
 
-  UserOperationV06 fixtureUserOpV06(EthereumAddress sender) =>
-      UserOperationV06(
+  UserOperationV06 fixtureUserOpV06(EthereumAddress sender) => UserOperationV06(
         sender: sender,
         nonce: BigInt.zero,
         initCode: '0x',
@@ -65,8 +63,7 @@ void main() {
         paymasterAndData: '0x',
       );
 
-  UserOperationV07 fixtureUserOpV07(EthereumAddress sender) =>
-      UserOperationV07(
+  UserOperationV07 fixtureUserOpV07(EthereumAddress sender) => UserOperationV07(
         sender: sender,
         nonce: BigInt.zero,
         callData: '0x',
@@ -155,7 +152,6 @@ void main() {
       '72cf5d3982d8eff0352a34b3e45047e35de19bd966f88f94af88c3ea617eee11'
       '1b';
 
-
   group('ThirdwebAddresses', () {
     test('factory v0.7 matches permissionless.js', () {
       expect(
@@ -178,7 +174,8 @@ void main() {
 
     setUp(() {
       owner = PrivateKeyOwner(testPrivateKey);
-      expect(owner.address.hex.toLowerCase(), equals(ownerAddress.toLowerCase()));
+      expect(
+          owner.address.hex.toLowerCase(), equals(ownerAddress.toLowerCase()));
       account = createThirdwebSmartAccount(
         owner: owner,
         chainId: BigInt.one,
@@ -194,7 +191,8 @@ void main() {
 
       test('getAddress returns configured address', () async {
         final address = await account.getAddress();
-        expect(address.hex.toLowerCase(), equals(mockAddress.hex.toLowerCase()));
+        expect(
+            address.hex.toLowerCase(), equals(mockAddress.hex.toLowerCase()));
       });
 
       test('throws without address or publicClient', () {
@@ -207,7 +205,8 @@ void main() {
     });
 
     group('factoryData / initCode / salt', () {
-      test('default (empty) salt factoryData matches permissionless.js', () async {
+      test('default (empty) salt factoryData matches permissionless.js',
+          () async {
         final factoryData = await account.getFactoryData();
         expect(factoryData, isNotNull);
         expect(
@@ -225,9 +224,11 @@ void main() {
           address: mockAddress,
         );
         final factoryData = await salted.getFactoryData();
-        expect(factoryData!.factoryData.toLowerCase(), equals(jsFactoryDataTestSalt));
+        expect(factoryData!.factoryData.toLowerCase(),
+            equals(jsFactoryDataTestSalt));
         // UTF-8 of "test-salt"
-        expect(factoryData.factoryData.toLowerCase(), contains('746573742d73616c74'));
+        expect(factoryData.factoryData.toLowerCase(),
+            contains('746573742d73616c74'));
       });
 
       test('initCode embeds factoryData', () async {
@@ -253,7 +254,8 @@ void main() {
 
     group('stub signature', () {
       test('matches permissionless.js dummy signature', () {
-        expect(account.getStubSignature().toLowerCase(), equals(jsStubSignature));
+        expect(
+            account.getStubSignature().toLowerCase(), equals(jsStubSignature));
       });
     });
 
@@ -339,7 +341,8 @@ void main() {
     });
 
     group('ERC-1271 signing', () {
-      test('signMessage matches permissionless.js AccountMessage wrapper', () async {
+      test('signMessage matches permissionless.js AccountMessage wrapper',
+          () async {
         final signature = await account.signMessage('hello');
         expect(signature.toLowerCase(), equals(jsSignMessage));
       });

--- a/packages/permissionless/test/accounts/thirdweb/thirdweb_account_test.dart
+++ b/packages/permissionless/test/accounts/thirdweb/thirdweb_account_test.dart
@@ -1,151 +1,298 @@
 import 'package:permissionless/permissionless.dart';
 import 'package:test/test.dart';
 
+/// Unit tests for Thirdweb smart account.
+///
+/// Fixtures generated from permissionless.js v0.3.5 / viem with:
+/// - privateKey: Hardhat #0
+/// - chainId: 1
+/// - sender: 0x1234...7890
+/// - message: "hello"
 void main() {
-  // Hardhat account 0 — do not use in production
+
+  // Hardhat account #0 — do not use in production
   const testPrivateKey =
       '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
-
-  // Same owner address as privateKeyToAccount(testPrivateKey) in viem
   const ownerAddress = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266';
 
+  // Pre-set address for unit tests (avoids RPC). Same sender used in JS fixtures.
   final mockAddress =
       EthereumAddress.fromHex('0x1234567890123456789012345678901234567890');
 
-  // Fixtures from permissionless.js / viem:
-  //   salt omitted → "0x" empty bytes
-  //   salt "test-salt" → toHex("test-salt") = 0x746573742d73616c74
-  // encodeFunctionData(createAccount(admin, saltBytes))
-  const jsFactoryDataDefaultSalt =
-      '0xd8fd8f44000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb92266'
-      '0000000000000000000000000000000000000000000000000000000000000040'
-      '0000000000000000000000000000000000000000000000000000000000000000';
+  final singleCall = Call(
+    to: EthereumAddress.fromHex('0x2222222222222222222222222222222222222222'),
+    value: BigInt.one,
+    data: '0xdeadbeef',
+  );
+  final batchCalls = [
+    singleCall,
+    Call(
+      to: EthereumAddress.fromHex('0x3333333333333333333333333333333333333333'),
+      value: BigInt.zero,
+      data: '0x',
+    ),
+  ];
+
+  // verifyingContract != account so AccountMessage wrapper path is exercised
+  // (self-verifying-contract short-circuit is a separate path).
+  final sampleTypedData = TypedData(
+    domain: TypedDataDomain(
+      name: 'Mail',
+      version: '1',
+      chainId: BigInt.one,
+      verifyingContract: EthereumAddress.fromHex(
+        '0x2222222222222222222222222222222222222222',
+      ),
+    ),
+    types: {
+      'Mail': [const TypedDataField(name: 'contents', type: 'string')],
+    },
+    primaryType: 'Mail',
+    message: {'contents': 'Hello'},
+  );
+
+  UserOperationV06 fixtureUserOpV06(EthereumAddress sender) =>
+      UserOperationV06(
+        sender: sender,
+        nonce: BigInt.zero,
+        initCode: '0x',
+        callData: '0x',
+        callGasLimit: BigInt.from(100000),
+        verificationGasLimit: BigInt.from(100000),
+        preVerificationGas: BigInt.from(21000),
+        maxFeePerGas: BigInt.from(1000000000),
+        maxPriorityFeePerGas: BigInt.from(1000000000),
+        paymasterAndData: '0x',
+      );
+
+  UserOperationV07 fixtureUserOpV07(EthereumAddress sender) =>
+      UserOperationV07(
+        sender: sender,
+        nonce: BigInt.zero,
+        callData: '0x',
+        callGasLimit: BigInt.from(100000),
+        verificationGasLimit: BigInt.from(100000),
+        preVerificationGas: BigInt.from(21000),
+        maxFeePerGas: BigInt.from(1000000000),
+        maxPriorityFeePerGas: BigInt.from(1000000000),
+      );
+
+  // ---- permissionless.js fixtures ----
+  const jsFactoryData =
+      '0xd8fd8f44000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cf'
+      'ffb9226600000000000000000000000000000000000000000000000000000000'
+      '0000004000000000000000000000000000000000000000000000000000000000'
+      '00000000';
 
   const jsFactoryDataTestSalt =
-      '0xd8fd8f44000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb92266'
-      '0000000000000000000000000000000000000000000000000000000000000040'
-      '0000000000000000000000000000000000000000000000000000000000000009'
-      '746573742d73616c740000000000000000000000000000000000000000000000';
+      '0xd8fd8f44000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cf'
+      'ffb9226600000000000000000000000000000000000000000000000000000000'
+      '0000004000000000000000000000000000000000000000000000000000000000'
+      '00000009746573742d73616c7400000000000000000000000000000000000000'
+      '00000000';
 
-  group('ThirdwebSmartAccount salt encoding', () {
+  const jsFactoryDataV06 =
+      '0xd8fd8f44000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cf'
+      'ffb9226600000000000000000000000000000000000000000000000000000000'
+      '0000004000000000000000000000000000000000000000000000000000000000'
+      '00000000';
+
+  const jsInitCode =
+      '0x4be0ddfebca9a5a4a617dee4dece99e7c862dcebd8fd8f440000000000000000'
+      '00000000f39fd6e51aad88f6f4ce6ab8827279cfffb922660000000000000000'
+      '0000000000000000000000000000000000000000000000400000000000000000'
+      '000000000000000000000000000000000000000000000000';
+
+  const jsStubSignature =
+      '0xfffffffffffffffffffffffffffffff000000000000000000000000000000000'
+      '7aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+      '1c';
+
+  const jsEncodeCallsSingle =
+      '0xb61d27f600000000000000000000000022222222222222222222222222222222'
+      '2222222200000000000000000000000000000000000000000000000000000000'
+      '0000000100000000000000000000000000000000000000000000000000000000'
+      '0000006000000000000000000000000000000000000000000000000000000000'
+      '00000004deadbeef000000000000000000000000000000000000000000000000'
+      '00000000';
+
+  const jsEncodeCallsBatch =
+      '0x47e1da2a00000000000000000000000000000000000000000000000000000000'
+      '0000006000000000000000000000000000000000000000000000000000000000'
+      '000000c000000000000000000000000000000000000000000000000000000000'
+      '0000012000000000000000000000000000000000000000000000000000000000'
+      '0000000200000000000000000000000022222222222222222222222222222222'
+      '2222222200000000000000000000000033333333333333333333333333333333'
+      '3333333300000000000000000000000000000000000000000000000000000000'
+      '0000000200000000000000000000000000000000000000000000000000000000'
+      '0000000100000000000000000000000000000000000000000000000000000000'
+      '0000000000000000000000000000000000000000000000000000000000000000'
+      '0000000200000000000000000000000000000000000000000000000000000000'
+      '0000004000000000000000000000000000000000000000000000000000000000'
+      '0000008000000000000000000000000000000000000000000000000000000000'
+      '00000004deadbeef000000000000000000000000000000000000000000000000'
+      '0000000000000000000000000000000000000000000000000000000000000000'
+      '00000000';
+
+  const jsSignUserOperation =
+      '0x00538c3d1fb4197de5a15394fcaf23ca1a570c63576424c0615656be0e112f59'
+      '64840719f944a8d5b0e21ad3a262725d1004ac6a9926ac6299b3f48d1c0c0d8d'
+      '1b';
+
+  const jsSignUserOperationV06 =
+      '0x722cff5408f0bfb44be7b89c1352926b788b13e3aab3ca90eba3f140541ef0e8'
+      '4f013c007081d3f0d27f5fccbdb10d1d33c7582f930504f7b874134d1781c55d'
+      '1b';
+
+  const jsSignMessage =
+      '0x8e4a8b16b48ba2a07170cf2c9bce6d31131e5781ba5075505daedcd13fe968a3'
+      '37dd2d3ddb7805a3c4d3bc1a1922eb100bcfdcc22489b0883b52ab88fd7ca93b'
+      '1c';
+
+  // AccountMessage-wrapped Mail typed data (verifyingContract = 0x2222…, not account)
+  const jsSignTypedData =
+      '0x9ba4681a98b55f06ee90731308a6f49f7fa9059b68ffa59584cee32ccccc3772'
+      '72cf5d3982d8eff0352a34b3e45047e35de19bd966f88f94af88c3ea617eee11'
+      '1b';
+
+
+  group('ThirdwebAddresses', () {
+    test('factory v0.7 matches permissionless.js', () {
+      expect(
+        ThirdwebAddresses.factoryV07.hex.toLowerCase(),
+        equals('0x4be0ddfebca9a5a4a617dee4dece99e7c862dceb'),
+      );
+    });
+
+    test('factory v0.6 matches permissionless.js', () {
+      expect(
+        ThirdwebAddresses.factoryV06.hex.toLowerCase(),
+        equals('0x85e23b94e7f5e9cc1ff78bce78cfb15b81f0df00'),
+      );
+    });
+  });
+
+  group('ThirdwebSmartAccount', () {
     late PrivateKeyOwner owner;
+    late ThirdwebSmartAccount account;
 
     setUp(() {
       owner = PrivateKeyOwner(testPrivateKey);
-      expect(
-          owner.address.hex.toLowerCase(), equals(ownerAddress.toLowerCase()));
-    });
-
-    test('default (empty) salt factoryData matches permissionless.js',
-        () async {
-      final account = createThirdwebSmartAccount(
+      expect(owner.address.hex.toLowerCase(), equals(ownerAddress.toLowerCase()));
+      account = createThirdwebSmartAccount(
         owner: owner,
         chainId: BigInt.one,
         address: mockAddress,
       );
-
-      final factoryData = await account.getFactoryData();
-      expect(factoryData, isNotNull);
-      expect(
-        factoryData!.factoryData.toLowerCase(),
-        equals(jsFactoryDataDefaultSalt.toLowerCase()),
-      );
-      expect(
-        factoryData.factory.hex.toLowerCase(),
-        equals(ThirdwebAddresses.factoryV07.hex.toLowerCase()),
-      );
     });
 
-    test(
-      'custom salt "test-salt" factoryData UTF-8-encodes like JS toHex',
-      () async {
-        final account = createThirdwebSmartAccount(
+    group('creation', () {
+      test('defaults to EntryPoint v0.7', () {
+        expect(account.entryPointVersion, equals(EntryPointVersion.v07));
+        expect(account.chainId, equals(BigInt.one));
+      });
+
+      test('getAddress returns configured address', () async {
+        final address = await account.getAddress();
+        expect(address.hex.toLowerCase(), equals(mockAddress.hex.toLowerCase()));
+      });
+
+      test('throws without address or publicClient', () {
+        final bare = createThirdwebSmartAccount(
+          owner: owner,
+          chainId: BigInt.one,
+        );
+        expect(() => bare.getAddress(), throwsA(isA<StateError>()));
+      });
+    });
+
+    group('factoryData / initCode / salt', () {
+      test('default (empty) salt factoryData matches permissionless.js', () async {
+        final factoryData = await account.getFactoryData();
+        expect(factoryData, isNotNull);
+        expect(
+          factoryData!.factory.hex.toLowerCase(),
+          equals(ThirdwebAddresses.factoryV07.hex.toLowerCase()),
+        );
+        expect(factoryData.factoryData.toLowerCase(), equals(jsFactoryData));
+      });
+
+      test('custom salt "test-salt" UTF-8-encodes like JS toHex', () async {
+        final salted = createThirdwebSmartAccount(
           owner: owner,
           chainId: BigInt.one,
           salt: 'test-salt',
           address: mockAddress,
         );
+        final factoryData = await salted.getFactoryData();
+        expect(factoryData!.factoryData.toLowerCase(), equals(jsFactoryDataTestSalt));
+        // UTF-8 of "test-salt"
+        expect(factoryData.factoryData.toLowerCase(), contains('746573742d73616c74'));
+      });
 
-        final factoryData = await account.getFactoryData();
-        expect(factoryData, isNotNull);
+      test('initCode embeds factoryData', () async {
+        final initCode = await account.getInitCode();
+        expect(initCode.toLowerCase(), equals(jsInitCode));
+      });
+
+      test('v0.6 factoryData uses factoryV06', () async {
+        final v06 = createThirdwebSmartAccount(
+          owner: owner,
+          chainId: BigInt.one,
+          entryPointVersion: EntryPointVersion.v06,
+          address: mockAddress,
+        );
+        final factoryData = await v06.getFactoryData();
         expect(
-          factoryData!.factoryData.toLowerCase(),
-          equals(jsFactoryDataTestSalt.toLowerCase()),
+          factoryData!.factory.hex.toLowerCase(),
+          equals(ThirdwebAddresses.factoryV06.hex.toLowerCase()),
         );
-      },
-    );
-
-    test('initCode embeds the same factoryData for custom salt', () async {
-      final account = createThirdwebSmartAccount(
-        owner: owner,
-        chainId: BigInt.one,
-        salt: 'test-salt',
-        address: mockAddress,
-      );
-
-      final factoryData = await account.getFactoryData();
-      final initCode = await account.getInitCode();
-
-      expect(
-        initCode.toLowerCase(),
-        equals(
-          '${factoryData!.factory.hex}${factoryData.factoryData.substring(2)}'
-              .toLowerCase(),
-        ),
-      );
-      expect(
-        initCode.toLowerCase(),
-        endsWith(jsFactoryDataTestSalt.substring(2).toLowerCase()),
-      );
+        expect(factoryData.factoryData.toLowerCase(), equals(jsFactoryDataV06));
+      });
     });
 
-    test('custom salt must not be hex-decoded (regression)', () async {
-      // If salt were hex-decoded, "test-salt" would throw or produce garbage.
-      // JS toHex UTF-8-encodes → salt bytes include ASCII 't','e','s','t',...
-      final account = createThirdwebSmartAccount(
-        owner: owner,
-        chainId: BigInt.one,
-        salt: 'test-salt',
-        address: mockAddress,
-      );
-
-      final factoryData = await account.getFactoryData();
-      // UTF-8 of "test-salt" appears after the length word (0x09)
-      expect(
-        factoryData!.factoryData.toLowerCase(),
-        contains('746573742d73616c74'),
-      );
-      // Must not contain a short hex-decode of the string as hex digits
-      expect(
-        factoryData.factoryData.toLowerCase(),
-        isNot(equals(jsFactoryDataDefaultSalt.toLowerCase())),
-      );
-    });
-  });
-
-  group('ThirdwebSmartAccount signUserOperation', () {
-    late PrivateKeyOwner owner;
-
-    setUp(() {
-      owner = PrivateKeyOwner(testPrivateKey);
+    group('stub signature', () {
+      test('matches permissionless.js dummy signature', () {
+        expect(account.getStubSignature().toLowerCase(), equals(jsStubSignature));
+      });
     });
 
-    UserOperationV07 fixtureUserOpV07(EthereumAddress sender) =>
-        UserOperationV07(
-          sender: sender,
-          nonce: BigInt.one,
-          callData: '0xabcdef',
-          callGasLimit: BigInt.from(100000),
-          verificationGasLimit: BigInt.from(200000),
-          preVerificationGas: BigInt.from(50000),
-          maxFeePerGas: BigInt.from(1000000000),
-          maxPriorityFeePerGas: BigInt.from(100000000),
-          signature: '0x',
+    group('encodeCalls', () {
+      test('single call matches permissionless.js execute', () {
+        expect(
+          account.encodeCalls([singleCall]).toLowerCase(),
+          equals(jsEncodeCallsSingle),
         );
+      });
 
-    UserOperationV06 fixtureUserOpV06(EthereumAddress sender) =>
-        UserOperationV06(
-          sender: sender,
+      test('batch matches permissionless.js executeBatch', () {
+        expect(
+          account.encodeCalls(batchCalls).toLowerCase(),
+          equals(jsEncodeCallsBatch),
+        );
+      });
+
+      test('throws on empty calls', () {
+        expect(() => account.encodeCalls([]), throwsA(isA<ArgumentError>()));
+      });
+    });
+
+    group('signUserOperation', () {
+      test('v0.7 matches permissionless.js', () async {
+        final signature =
+            await account.signUserOperation(fixtureUserOpV07(mockAddress));
+        expect(signature.toLowerCase(), equals(jsSignUserOperation));
+      });
+
+      test('v0.6 matches permissionless.js / viem fixture', () async {
+        final v06 = createThirdwebSmartAccount(
+          owner: owner,
+          chainId: BigInt.one,
+          entryPointVersion: EntryPointVersion.v06,
+          address: mockAddress,
+        );
+        final userOp = UserOperationV06(
+          sender: mockAddress,
           nonce: BigInt.one,
           initCode: '0x',
           callData: '0xabcdef',
@@ -155,66 +302,53 @@ void main() {
           maxFeePerGas: BigInt.from(1000000000),
           maxPriorityFeePerGas: BigInt.from(100000000),
           paymasterAndData: '0x',
-          signature: '0x',
         );
+        final signature = await v06.signUserOperationV06(userOp);
+        expect(signature.toLowerCase(), equals(jsSignUserOperationV06));
+      });
 
-    test('v0.6 personal-signs v0.6 userOpHash matching viem fixture', () async {
-      final account = createThirdwebSmartAccount(
-        owner: owner,
-        chainId: BigInt.one,
-        entryPointVersion: EntryPointVersion.v06,
-        address: mockAddress,
-      );
+      test('v0.6 throws when signUserOperation (v0.7 API) is used', () {
+        final v06 = createThirdwebSmartAccount(
+          owner: owner,
+          chainId: BigInt.one,
+          entryPointVersion: EntryPointVersion.v06,
+          address: mockAddress,
+        );
+        expect(
+          () => v06.signUserOperation(fixtureUserOpV07(mockAddress)),
+          throwsA(isA<UnsupportedError>()),
+        );
+      });
 
-      final signature =
-          await account.signUserOperationV06(fixtureUserOpV06(mockAddress));
+      test('v0.7 throws when signUserOperationV06 is used', () {
+        expect(
+          () => account.signUserOperationV06(fixtureUserOpV06(mockAddress)),
+          throwsA(isA<UnsupportedError>()),
+        );
+      });
 
-      // viem getUserOperationHash (v0.6) + signMessage({ raw: hash })
-      expect(
-        signature.toLowerCase(),
-        equals(
-          '0x722cff5408f0bfb44be7b89c1352926b788b13e3aab3ca90eba3f140541ef0e84f013c007081d3f0d27f5fccbdb10d1d33c7582f930504f7b874134d1781c55d1b',
-        ),
-      );
+      test('implements SmartAccountV06 for client v0.6 pipeline', () {
+        final v06 = createThirdwebSmartAccount(
+          owner: owner,
+          chainId: BigInt.one,
+          entryPointVersion: EntryPointVersion.v06,
+          address: mockAddress,
+        );
+        expect(v06, isA<SmartAccountV06>());
+      });
     });
 
-    test('v0.6 throws when signUserOperation (v0.7 API) is used', () async {
-      final account = createThirdwebSmartAccount(
-        owner: owner,
-        chainId: BigInt.one,
-        entryPointVersion: EntryPointVersion.v06,
-        address: mockAddress,
-      );
+    group('ERC-1271 signing', () {
+      test('signMessage matches permissionless.js AccountMessage wrapper', () async {
+        final signature = await account.signMessage('hello');
+        expect(signature.toLowerCase(), equals(jsSignMessage));
+      });
 
-      expect(
-        () => account.signUserOperation(fixtureUserOpV07(mockAddress)),
-        throwsA(isA<UnsupportedError>()),
-      );
-    });
-
-    test('v0.7 throws when signUserOperationV06 is used', () async {
-      final account = createThirdwebSmartAccount(
-        owner: owner,
-        chainId: BigInt.one,
-        entryPointVersion: EntryPointVersion.v07,
-        address: mockAddress,
-      );
-
-      expect(
-        () => account.signUserOperationV06(fixtureUserOpV06(mockAddress)),
-        throwsA(isA<UnsupportedError>()),
-      );
-    });
-
-    test('implements SmartAccountV06 for client v0.6 pipeline', () {
-      final account = createThirdwebSmartAccount(
-        owner: owner,
-        chainId: BigInt.one,
-        entryPointVersion: EntryPointVersion.v06,
-        address: mockAddress,
-      );
-
-      expect(account, isA<SmartAccountV06>());
+      test('signTypedData matches permissionless.js AccountMessage wrapper',
+          () async {
+        final signature = await account.signTypedData(sampleTypedData);
+        expect(signature.toLowerCase(), equals(jsSignTypedData));
+      });
     });
   });
 }

--- a/packages/permissionless/test/accounts/trust/trust_account_test.dart
+++ b/packages/permissionless/test/accounts/trust/trust_account_test.dart
@@ -1,0 +1,267 @@
+import 'package:permissionless/permissionless.dart';
+import 'package:test/test.dart';
+
+/// Unit tests for Trust (Barz) smart account (EP v0.6).
+///
+/// Fixtures generated from permissionless.js v0.3.5 / viem with:
+/// - privateKey: Hardhat #0
+/// - chainId: 1
+/// - sender: 0x1234...7890
+/// - message: "hello"
+void main() {
+
+  // Hardhat account #0 — do not use in production
+  const testPrivateKey =
+      '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
+  const ownerAddress = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266';
+
+  // Pre-set address for unit tests (avoids RPC). Same sender used in JS fixtures.
+  final mockAddress =
+      EthereumAddress.fromHex('0x1234567890123456789012345678901234567890');
+
+  final singleCall = Call(
+    to: EthereumAddress.fromHex('0x2222222222222222222222222222222222222222'),
+    value: BigInt.one,
+    data: '0xdeadbeef',
+  );
+  final batchCalls = [
+    singleCall,
+    Call(
+      to: EthereumAddress.fromHex('0x3333333333333333333333333333333333333333'),
+      value: BigInt.zero,
+      data: '0x',
+    ),
+  ];
+
+  final sampleTypedData = TypedData(
+    domain: TypedDataDomain(
+      name: 'Mail',
+      version: '1',
+      chainId: BigInt.one,
+      verifyingContract: mockAddress,
+    ),
+    types: {
+      'Mail': [const TypedDataField(name: 'contents', type: 'string')],
+    },
+    primaryType: 'Mail',
+    message: {'contents': 'Hello'},
+  );
+
+  UserOperationV06 fixtureUserOpV06(EthereumAddress sender) =>
+      UserOperationV06(
+        sender: sender,
+        nonce: BigInt.zero,
+        initCode: '0x',
+        callData: '0x',
+        callGasLimit: BigInt.from(100000),
+        verificationGasLimit: BigInt.from(100000),
+        preVerificationGas: BigInt.from(21000),
+        maxFeePerGas: BigInt.from(1000000000),
+        maxPriorityFeePerGas: BigInt.from(1000000000),
+        paymasterAndData: '0x',
+      );
+
+  // ---- permissionless.js fixtures ----
+  const jsFactoryData =
+      '0x296601cd00000000000000000000000081b9e3689390c7e74cf526594a105dea'
+      '21a8cdd500000000000000000000000000000000000000000000000000000000'
+      '0000006000000000000000000000000000000000000000000000000000000000'
+      '0000000000000000000000000000000000000000000000000000000000000000'
+      '00000014f39fd6e51aad88f6f4ce6ab8827279cfffb922660000000000000000'
+      '00000000';
+
+  const jsInitCode =
+      '0x729c310186a57833f622630a16d13f710b83272a296601cd0000000000000000'
+      '0000000081b9e3689390c7e74cf526594a105dea21a8cdd50000000000000000'
+      '0000000000000000000000000000000000000000000000600000000000000000'
+      '0000000000000000000000000000000000000000000000000000000000000000'
+      '000000000000000000000000000000000000000000000014f39fd6e51aad88f6'
+      'f4ce6ab8827279cfffb92266000000000000000000000000';
+
+  const jsStubSignature =
+      '0xfffffffffffffffffffffffffffffff000000000000000000000000000000000'
+      '7aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+      '1c';
+
+  const jsEncodeCallsSingle =
+      '0xb61d27f600000000000000000000000022222222222222222222222222222222'
+      '2222222200000000000000000000000000000000000000000000000000000000'
+      '0000000100000000000000000000000000000000000000000000000000000000'
+      '0000006000000000000000000000000000000000000000000000000000000000'
+      '00000004deadbeef000000000000000000000000000000000000000000000000'
+      '00000000';
+
+  const jsEncodeCallsBatch =
+      '0x47e1da2a00000000000000000000000000000000000000000000000000000000'
+      '0000006000000000000000000000000000000000000000000000000000000000'
+      '000000c000000000000000000000000000000000000000000000000000000000'
+      '0000012000000000000000000000000000000000000000000000000000000000'
+      '0000000200000000000000000000000022222222222222222222222222222222'
+      '2222222200000000000000000000000033333333333333333333333333333333'
+      '3333333300000000000000000000000000000000000000000000000000000000'
+      '0000000200000000000000000000000000000000000000000000000000000000'
+      '0000000100000000000000000000000000000000000000000000000000000000'
+      '0000000000000000000000000000000000000000000000000000000000000000'
+      '0000000200000000000000000000000000000000000000000000000000000000'
+      '0000004000000000000000000000000000000000000000000000000000000000'
+      '0000008000000000000000000000000000000000000000000000000000000000'
+      '00000004deadbeef000000000000000000000000000000000000000000000000'
+      '0000000000000000000000000000000000000000000000000000000000000000'
+      '00000000';
+
+  const jsSignUserOperation =
+      '0xc6a17ddf898b2b92ca9ad4ca38b8d3eb73d538e199b939b416ebbe746debeac2'
+      '57952180f7c4e4f5433bf20caf4b1bc5330104661b71f16f8cafeecba1aba762'
+      '1b';
+
+  const jsSignMessage =
+      '0xa122dd8b23c31f309fef8d1fc19573a88eac9adb07cc4ffc7c21f39c9af46aa3'
+      '5910a5a6cc389c7ea09483dd2c6ff02eae6a7a2d2d13d4e532377b188b85a5fa'
+      '1c';
+
+  const jsSignTypedData =
+      '0xe8daf41f4e69ebf2ed45751142f77ba5071675ee48fa11c6bc4f3da9dfeb8b24'
+      '2a2089763d70ba54fa7b8a77faac46ca0100beb841484c4b37006e45cb0f12e5'
+      '1b';
+
+
+  group('TrustAddresses', () {
+    test('factory matches permissionless.js', () {
+      expect(
+        TrustAddresses.factory.hex.toLowerCase(),
+        equals('0x729c310186a57833f622630a16d13f710b83272a'),
+      );
+    });
+
+    test('secp256k1 verification facet matches permissionless.js', () {
+      expect(
+        TrustAddresses.secp256k1VerificationFacet.hex.toLowerCase(),
+        equals('0x81b9e3689390c7e74cf526594a105dea21a8cdd5'),
+      );
+    });
+  });
+
+  group('TrustSmartAccount', () {
+    late PrivateKeyOwner owner;
+    late TrustSmartAccount account;
+
+    setUp(() {
+      owner = PrivateKeyOwner(testPrivateKey);
+      expect(owner.address.hex.toLowerCase(), equals(ownerAddress.toLowerCase()));
+      account = createTrustSmartAccount(
+        owner: owner,
+        chainId: BigInt.one,
+        address: mockAddress,
+      );
+    });
+
+    group('creation', () {
+      test('defaults to EntryPoint v0.6', () {
+        expect(account.entryPoint, equals(EntryPointAddresses.v06));
+        expect(account.chainId, equals(BigInt.one));
+        expect(account.index, equals(BigInt.zero));
+      });
+    });
+
+    group('counterfactual address', () {
+      test('returns pre-set address (unit path; RPC address via getSenderAddress)',
+          () async {
+        // Trust derives address via EntryPoint.getSenderAddress when no
+        // address is supplied — that path needs a publicClient (integration).
+        // Unit tests assert the pre-set address path used by clients offline.
+        final address = await account.getAddress();
+        expect(address.hex.toLowerCase(), equals(mockAddress.hex.toLowerCase()));
+      });
+
+      test('throws without address or publicClient', () {
+        final bare = createTrustSmartAccount(
+          owner: owner,
+          chainId: BigInt.one,
+        );
+        expect(() => bare.getAddress(), throwsA(isA<StateError>()));
+      });
+    });
+
+    group('factoryData / initCode', () {
+      test('factoryData matches permissionless.js', () async {
+        final factoryData = await account.getFactoryData();
+        expect(factoryData, isNotNull);
+        expect(
+          factoryData!.factory.hex.toLowerCase(),
+          equals('0x729c310186a57833f622630a16d13f710b83272a'),
+        );
+        expect(factoryData.factoryData.toLowerCase(), equals(jsFactoryData));
+      });
+
+      test('initCode is factory ++ factoryData', () async {
+        final initCode = await account.getInitCode();
+        expect(initCode.toLowerCase(), equals(jsInitCode));
+      });
+    });
+
+    group('stub signature', () {
+      test('matches permissionless.js dummy signature', () {
+        expect(account.getStubSignature().toLowerCase(), equals(jsStubSignature));
+      });
+    });
+
+    group('encodeCalls', () {
+      test('single call matches permissionless.js execute', () {
+        expect(
+          account.encodeCalls([singleCall]).toLowerCase(),
+          equals(jsEncodeCallsSingle),
+        );
+      });
+
+      test('batch matches permissionless.js executeBatch', () {
+        expect(
+          account.encodeCalls(batchCalls).toLowerCase(),
+          equals(jsEncodeCallsBatch),
+        );
+      });
+
+      test('throws on empty calls', () {
+        expect(() => account.encodeCalls([]), throwsA(isA<ArgumentError>()));
+      });
+    });
+
+    group('signUserOperation', () {
+      test('matches permissionless.js personal-sign of userOpHash', () async {
+        final signature =
+            await account.signUserOperationV06(fixtureUserOpV06(mockAddress));
+        expect(signature.toLowerCase(), equals(jsSignUserOperation));
+      });
+
+      test('v0.7 API throws UnsupportedError', () {
+        expect(
+          () => account.signUserOperation(
+            UserOperationV07(
+              sender: mockAddress,
+              nonce: BigInt.zero,
+              callData: '0x',
+              callGasLimit: BigInt.from(100000),
+              verificationGasLimit: BigInt.from(100000),
+              preVerificationGas: BigInt.from(21000),
+              maxFeePerGas: BigInt.from(1000000000),
+              maxPriorityFeePerGas: BigInt.from(1000000000),
+            ),
+          ),
+          throwsA(isA<UnsupportedError>()),
+        );
+      });
+    });
+
+    group('ERC-1271 signing', () {
+      test('signMessage matches permissionless.js Barz EIP-712 wrapper', () async {
+        final signature = await account.signMessage('hello');
+        expect(signature.toLowerCase(), equals(jsSignMessage));
+      });
+
+      test('signTypedData matches permissionless.js Barz EIP-712 wrapper',
+          () async {
+        final signature = await account.signTypedData(sampleTypedData);
+        expect(signature.toLowerCase(), equals(jsSignTypedData));
+      });
+    });
+  });
+}

--- a/packages/permissionless/test/accounts/trust/trust_account_test.dart
+++ b/packages/permissionless/test/accounts/trust/trust_account_test.dart
@@ -9,7 +9,6 @@ import 'package:test/test.dart';
 /// - sender: 0x1234...7890
 /// - message: "hello"
 void main() {
-
   // Hardhat account #0 — do not use in production
   const testPrivateKey =
       '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
@@ -47,8 +46,7 @@ void main() {
     message: {'contents': 'Hello'},
   );
 
-  UserOperationV06 fixtureUserOpV06(EthereumAddress sender) =>
-      UserOperationV06(
+  UserOperationV06 fixtureUserOpV06(EthereumAddress sender) => UserOperationV06(
         sender: sender,
         nonce: BigInt.zero,
         initCode: '0x',
@@ -124,7 +122,6 @@ void main() {
       '2a2089763d70ba54fa7b8a77faac46ca0100beb841484c4b37006e45cb0f12e5'
       '1b';
 
-
   group('TrustAddresses', () {
     test('factory matches permissionless.js', () {
       expect(
@@ -147,7 +144,8 @@ void main() {
 
     setUp(() {
       owner = PrivateKeyOwner(testPrivateKey);
-      expect(owner.address.hex.toLowerCase(), equals(ownerAddress.toLowerCase()));
+      expect(
+          owner.address.hex.toLowerCase(), equals(ownerAddress.toLowerCase()));
       account = createTrustSmartAccount(
         owner: owner,
         chainId: BigInt.one,
@@ -164,13 +162,15 @@ void main() {
     });
 
     group('counterfactual address', () {
-      test('returns pre-set address (unit path; RPC address via getSenderAddress)',
+      test(
+          'returns pre-set address (unit path; RPC address via getSenderAddress)',
           () async {
         // Trust derives address via EntryPoint.getSenderAddress when no
         // address is supplied — that path needs a publicClient (integration).
         // Unit tests assert the pre-set address path used by clients offline.
         final address = await account.getAddress();
-        expect(address.hex.toLowerCase(), equals(mockAddress.hex.toLowerCase()));
+        expect(
+            address.hex.toLowerCase(), equals(mockAddress.hex.toLowerCase()));
       });
 
       test('throws without address or publicClient', () {
@@ -201,7 +201,8 @@ void main() {
 
     group('stub signature', () {
       test('matches permissionless.js dummy signature', () {
-        expect(account.getStubSignature().toLowerCase(), equals(jsStubSignature));
+        expect(
+            account.getStubSignature().toLowerCase(), equals(jsStubSignature));
       });
     });
 
@@ -252,7 +253,8 @@ void main() {
     });
 
     group('ERC-1271 signing', () {
-      test('signMessage matches permissionless.js Barz EIP-712 wrapper', () async {
+      test('signMessage matches permissionless.js Barz EIP-712 wrapper',
+          () async {
         final signature = await account.signMessage('hello');
         expect(signature.toLowerCase(), equals(jsSignMessage));
       });

--- a/packages/permissionless/test/utils/encode_function_data_test.dart
+++ b/packages/permissionless/test/utils/encode_function_data_test.dart
@@ -1,0 +1,350 @@
+import 'dart:typed_data';
+
+import 'package:permissionless/permissionless.dart';
+import 'package:test/test.dart';
+
+/// Fixtures generated with viem `encodeFunctionData` (permissionless.js peer).
+/// Acceptance for parity-audit issue 011.
+void main() {
+  group('AbiEncoder.encodeFunctionData', () {
+    test('static params: transfer(address,uint256)', () {
+      final encoded = AbiEncoder.encodeFunctionData(
+        'transfer(address,uint256)',
+        [
+          EthereumAddress.fromHex('0x1234567890123456789012345678901234567890'),
+          BigInt.from(1000),
+        ],
+      );
+      expect(
+        encoded,
+        equals(
+          '0xa9059cbb'
+          '0000000000000000000000001234567890123456789012345678901234567890'
+          '00000000000000000000000000000000000000000000000000000000000003e8',
+        ),
+      );
+    });
+
+    test('no args: increment()', () {
+      expect(
+        AbiEncoder.encodeFunctionData('increment()'),
+        equals('0xd09de08a'),
+      );
+    });
+
+    test('static bool', () {
+      expect(
+        AbiEncoder.encodeFunctionData('setFlag(bool)', [true]),
+        equals(
+          '0x3927f6af'
+          '0000000000000000000000000000000000000000000000000000000000000001',
+        ),
+      );
+    });
+
+    test('bytes32', () {
+      expect(
+        AbiEncoder.encodeFunctionData(
+          'setHash(bytes32)',
+          [
+            '0xabcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789',
+          ],
+        ),
+        equals(
+          '0x0c4c4285'
+          'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789',
+        ),
+      );
+    });
+
+    test('dynamic bytes alone includes offset head', () {
+      expect(
+        AbiEncoder.encodeFunctionData('setData(bytes)', ['0xdeadbeef']),
+        equals(
+          '0xab62f0e1'
+          '0000000000000000000000000000000000000000000000000000000000000020'
+          '0000000000000000000000000000000000000000000000000000000000000004'
+          'deadbeef00000000000000000000000000000000000000000000000000000000',
+        ),
+      );
+    });
+
+    test('execute(address,uint256,bytes) offsets dynamic bytes correctly', () {
+      // Critical bug case: previously inlined bytes tail with no offset.
+      expect(
+        AbiEncoder.encodeFunctionData(
+          'execute(address,uint256,bytes)',
+          [
+            EthereumAddress.fromHex(
+              '0x1234567890123456789012345678901234567890',
+            ),
+            BigInt.zero,
+            '0xabcdef',
+          ],
+        ),
+        equals(
+          '0xb61d27f6'
+          '0000000000000000000000001234567890123456789012345678901234567890'
+          '0000000000000000000000000000000000000000000000000000000000000000'
+          '0000000000000000000000000000000000000000000000000000000000000060'
+          '0000000000000000000000000000000000000000000000000000000000000003'
+          'abcdef0000000000000000000000000000000000000000000000000000000000',
+        ),
+      );
+    });
+
+    test('empty bytes', () {
+      expect(
+        AbiEncoder.encodeFunctionData('setData(bytes)', ['0x']),
+        equals(
+          '0xab62f0e1'
+          '0000000000000000000000000000000000000000000000000000000000000020'
+          '0000000000000000000000000000000000000000000000000000000000000000',
+        ),
+      );
+    });
+
+    test('string', () {
+      expect(
+        AbiEncoder.encodeFunctionData('setName(string)', ['hello']),
+        equals(
+          '0xc47f0027'
+          '0000000000000000000000000000000000000000000000000000000000000020'
+          '0000000000000000000000000000000000000000000000000000000000000005'
+          '68656c6c6f000000000000000000000000000000000000000000000000000000',
+        ),
+      );
+    });
+
+    test('dynamic uint256[]', () {
+      expect(
+        AbiEncoder.encodeFunctionData(
+          'setValues(uint256[])',
+          [
+            [BigInt.one, BigInt.two, BigInt.from(3)],
+          ],
+        ),
+        equals(
+          '0x6da2c5d0'
+          '0000000000000000000000000000000000000000000000000000000000000020'
+          '0000000000000000000000000000000000000000000000000000000000000003'
+          '0000000000000000000000000000000000000000000000000000000000000001'
+          '0000000000000000000000000000000000000000000000000000000000000002'
+          '0000000000000000000000000000000000000000000000000000000000000003',
+        ),
+      );
+    });
+
+    test('address[]', () {
+      expect(
+        AbiEncoder.encodeFunctionData(
+          'setOwners(address[])',
+          [
+            [
+              EthereumAddress.fromHex(
+                '0x1111111111111111111111111111111111111111',
+              ),
+              EthereumAddress.fromHex(
+                '0x2222222222222222222222222222222222222222',
+              ),
+            ],
+          ],
+        ),
+        equals(
+          '0xfa4d3698'
+          '0000000000000000000000000000000000000000000000000000000000000020'
+          '0000000000000000000000000000000000000000000000000000000000000002'
+          '0000000000000000000000001111111111111111111111111111111111111111'
+          '0000000000000000000000002222222222222222222222222222222222222222',
+        ),
+      );
+    });
+
+    test('fixed-length array uint256[2]', () {
+      expect(
+        AbiEncoder.encodeFunctionData(
+          'setPair(uint256[2])',
+          [
+            [BigInt.from(10), BigInt.from(20)],
+          ],
+        ),
+        equals(
+          '0x4df6a9b1'
+          '000000000000000000000000000000000000000000000000000000000000000a'
+          '0000000000000000000000000000000000000000000000000000000000000014',
+        ),
+      );
+    });
+
+    test('tuple (uint256,uint256)', () {
+      expect(
+        AbiEncoder.encodeFunctionData(
+          'setPoint((uint256,uint256))',
+          [
+            [BigInt.one, BigInt.two],
+          ],
+        ),
+        equals(
+          '0xc81a8916'
+          '0000000000000000000000000000000000000000000000000000000000000001'
+          '0000000000000000000000000000000000000000000000000000000000000002',
+        ),
+      );
+    });
+
+    test('mixed static + dynamic params', () {
+      expect(
+        AbiEncoder.encodeFunctionData(
+          'multi(address,bytes,string,uint256)',
+          [
+            EthereumAddress.fromHex(
+              '0x1234567890123456789012345678901234567890',
+            ),
+            '0xdead',
+            'hi',
+            BigInt.from(42),
+          ],
+        ),
+        equals(
+          '0x264a3c4b'
+          '0000000000000000000000001234567890123456789012345678901234567890'
+          '0000000000000000000000000000000000000000000000000000000000000080'
+          '00000000000000000000000000000000000000000000000000000000000000c0'
+          '000000000000000000000000000000000000000000000000000000000000002a'
+          '0000000000000000000000000000000000000000000000000000000000000002'
+          'dead000000000000000000000000000000000000000000000000000000000000'
+          '0000000000000000000000000000000000000000000000000000000000000002'
+          '6869000000000000000000000000000000000000000000000000000000000000',
+        ),
+      );
+    });
+
+    test('nested tuple with dynamic components', () {
+      // Solidity: f(S memory s, T memory t, uint a)
+      // S { uint a; uint[] b; T[] c; } T { uint x; uint y; }
+      expect(
+        AbiEncoder.encodeFunctionData(
+          'f((uint256,uint256[],(uint256,uint256)[]),(uint256,uint256),uint256)',
+          [
+            [
+              BigInt.one,
+              [BigInt.two, BigInt.from(3)],
+              [
+                [BigInt.from(4), BigInt.from(5)],
+                [BigInt.from(6), BigInt.from(7)],
+              ],
+            ],
+            [BigInt.from(8), BigInt.from(9)],
+            BigInt.from(10),
+          ],
+        ),
+        equals(
+          '0x6f2be728'
+          '0000000000000000000000000000000000000000000000000000000000000080'
+          '0000000000000000000000000000000000000000000000000000000000000008'
+          '0000000000000000000000000000000000000000000000000000000000000009'
+          '000000000000000000000000000000000000000000000000000000000000000a'
+          '0000000000000000000000000000000000000000000000000000000000000001'
+          '0000000000000000000000000000000000000000000000000000000000000060'
+          '00000000000000000000000000000000000000000000000000000000000000c0'
+          '0000000000000000000000000000000000000000000000000000000000000002'
+          '0000000000000000000000000000000000000000000000000000000000000002'
+          '0000000000000000000000000000000000000000000000000000000000000003'
+          '0000000000000000000000000000000000000000000000000000000000000002'
+          '0000000000000000000000000000000000000000000000000000000000000004'
+          '0000000000000000000000000000000000000000000000000000000000000005'
+          '0000000000000000000000000000000000000000000000000000000000000006'
+          '0000000000000000000000000000000000000000000000000000000000000007',
+        ),
+      );
+    });
+
+    test('accepts hex string addresses and Uint8List bytes', () {
+      final encoded = AbiEncoder.encodeFunctionData(
+        'execute(address,uint256,bytes)',
+        [
+          '0x1234567890123456789012345678901234567890',
+          0,
+          Uint8List.fromList([0xab, 0xcd, 0xef]),
+        ],
+      );
+      expect(
+        encoded,
+        equals(
+          AbiEncoder.encodeFunctionData(
+            'execute(address,uint256,bytes)',
+            [
+              EthereumAddress.fromHex(
+                '0x1234567890123456789012345678901234567890',
+              ),
+              BigInt.zero,
+              '0xabcdef',
+            ],
+          ),
+        ),
+      );
+    });
+
+    test('throws on invalid signature', () {
+      expect(
+        () => AbiEncoder.encodeFunctionData('notAFunction'),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws on arg count mismatch', () {
+      expect(
+        () => AbiEncoder.encodeFunctionData('setFlag(bool)'),
+        throwsArgumentError,
+      );
+    });
+
+    test('dataSuffix appends after encoded calldata (writeContract parity)',
+        () {
+      // Mirrors JS: `${data}${dataSuffix.replace("0x", "")}`
+      final data = AbiEncoder.encodeFunctionData('increment()');
+      final withSuffix = Hex.concat([data, '0xdeadbeef']);
+      expect(withSuffix, equals('0xd09de08adeadbeef'));
+    });
+
+    test('throws on bytes32 size mismatch', () {
+      expect(
+        () => AbiEncoder.encodeFunctionData(
+          'setHash(bytes32)',
+          ['0xdeadbeef'],
+        ),
+        throwsArgumentError,
+      );
+      expect(
+        () => AbiEncoder.encodeFunctionData(
+          'setHash(bytes32)',
+          [
+            '0xabcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789ff',
+          ],
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws on fixed array length mismatch', () {
+      expect(
+        () => AbiEncoder.encodeFunctionData(
+          'setPair(uint256[2])',
+          [
+            [BigInt.one],
+          ],
+        ),
+        throwsArgumentError,
+      );
+      expect(
+        () => AbiEncoder.encodeFunctionData(
+          'setPair(uint256[2])',
+          [
+            [BigInt.one, BigInt.two, BigInt.from(3)],
+          ],
+        ),
+        throwsArgumentError,
+      );
+    });
+  });
+}

--- a/packages/permissionless/test/utils/erc7579_test.dart
+++ b/packages/permissionless/test/utils/erc7579_test.dart
@@ -240,7 +240,8 @@ void main() {
         );
       });
 
-      test('optimizes single call to non-batch encoding', () {
+      test('keeps batch mode for a single-element batch (no silent downgrade)',
+          () {
         final calls = [
           Call(
             to: EthereumAddress.fromHex(
@@ -254,8 +255,18 @@ void main() {
         final batchEncoded = encode7579ExecuteBatch(calls);
         final singleEncoded = encode7579Execute(calls.first);
 
-        // Should be identical for single call
-        expect(batchEncoded, equals(singleEncoded));
+        // Mode byte 0 must stay batch (0x01), not collapse to call (0x00).
+        final mode = batchEncoded.substring(10, 74);
+        expect(mode.substring(0, 2), equals('01'));
+        expect(batchEncoded, isNot(equals(singleEncoded)));
+
+        final decoded = decode7579Calls(batchEncoded);
+        expect(decoded.mode.type, equals(Erc7579CallKind.batchCall));
+        expect(decoded.calls, hasLength(1));
+        expect(
+          decoded.calls[0].to.hex.toLowerCase(),
+          equals(calls[0].to.hex.toLowerCase()),
+        );
       });
 
       test('uses batch mode for multiple calls', () {
@@ -306,6 +317,51 @@ void main() {
         expect(
           encoded.substring(2, 10).toLowerCase(),
           equals(Erc7579Selectors.execute.substring(2).toLowerCase()),
+        );
+      });
+    });
+
+    group('encode7579ExecuteDelegateCall', () {
+      test('uses delegatecall mode 0xff', () {
+        final call = Call(
+          to: EthereumAddress.fromHex(
+            '0x1234567890123456789012345678901234567890',
+          ),
+          value: BigInt.zero,
+          data: '0xabcdef',
+        );
+
+        final encoded = encode7579ExecuteDelegateCall(call);
+        expect(
+          encoded.substring(2, 10).toLowerCase(),
+          equals(Erc7579Selectors.execute.substring(2).toLowerCase()),
+        );
+        final mode = encoded.substring(10, 74);
+        expect(mode.substring(0, 2), equals('ff'));
+        expect(mode.substring(2, 4), equals('00')); // default execType
+      });
+
+      test('round-trips through decode7579Calls', () {
+        final call = Call(
+          to: EthereumAddress.fromHex(
+            '0x1234567890123456789012345678901234567890',
+          ),
+          value: BigInt.from(42),
+          data: '0xdeadbeef',
+        );
+
+        final decoded = decode7579Calls(encode7579ExecuteDelegateCall(call));
+        expect(decoded.mode.type, equals(Erc7579CallKind.delegateCall));
+        expect(decoded.mode.revertOnError, isFalse);
+        expect(decoded.calls, hasLength(1));
+        expect(
+          decoded.calls[0].to.hex.toLowerCase(),
+          equals(call.to.hex.toLowerCase()),
+        );
+        expect(decoded.calls[0].value, equals(call.value));
+        expect(
+          decoded.calls[0].data.toLowerCase(),
+          equals(call.data.toLowerCase()),
         );
       });
     });
@@ -768,7 +824,8 @@ void main() {
         const mode = ExecutionMode(type: Erc7579CallKind.call);
 
         expect(mode.type, equals(Erc7579CallKind.call));
-        expect(mode.revertOnError, isTrue);
+        // Default matches permissionless.js (undefined → falsy → execType 0x00).
+        expect(mode.revertOnError, isFalse);
         expect(mode.selector, isNull);
         expect(mode.context, isNull);
       });
@@ -776,19 +833,63 @@ void main() {
       test('creates with custom values', () {
         const mode = ExecutionMode(
           type: Erc7579CallKind.batchCall,
-          revertOnError: false,
+          revertOnError: true,
           selector: '0x12345678',
           context: '0xaabbccdd',
         );
 
         expect(mode.type, equals(Erc7579CallKind.batchCall));
-        expect(mode.revertOnError, isFalse);
+        expect(mode.revertOnError, isTrue);
         expect(mode.selector, equals('0x12345678'));
         expect(mode.context, equals('0xaabbccdd'));
       });
 
       group('encode', () {
-        test('encodes single call with revert on error', () {
+        // Wire vectors from permissionless.js encodeExecutionMode
+        // (actions/erc7579/supportsExecutionMode.ts):
+        //   revertOnError ? 0x01 : 0x00
+        test('byte-matches JS for all (callType, revertOnError) combos', () {
+          const cases = <(Erc7579CallKind, bool, String)>[
+            // call + false → 0x00 0x00
+            (
+              Erc7579CallKind.call,
+              false,
+              '0x0000000000000000000000000000000000000000000000000000000000000000',
+            ),
+            // call + true → 0x00 0x01
+            (
+              Erc7579CallKind.call,
+              true,
+              '0x0001000000000000000000000000000000000000000000000000000000000000',
+            ),
+            // batchcall + false → 0x01 0x00
+            (
+              Erc7579CallKind.batchCall,
+              false,
+              '0x0100000000000000000000000000000000000000000000000000000000000000',
+            ),
+            // batchcall + true → 0x01 0x01
+            (
+              Erc7579CallKind.batchCall,
+              true,
+              '0x0101000000000000000000000000000000000000000000000000000000000000',
+            ),
+          ];
+
+          for (final (type, revertOnError, expected) in cases) {
+            final encoded = ExecutionMode(
+              type: type,
+              revertOnError: revertOnError,
+            ).encode();
+            expect(
+              encoded.toLowerCase(),
+              equals(expected),
+              reason: 'type=$type revertOnError=$revertOnError',
+            );
+          }
+        });
+
+        test('default mode emits execType 0x00 (JS undefined polarity)', () {
           const mode = ExecutionMode(type: Erc7579CallKind.call);
           final encoded = mode.encode();
 
@@ -797,29 +898,42 @@ void main() {
 
           // Byte 0: call type = 0x00
           expect(encoded.substring(2, 4), equals('00'));
-          // Byte 1: revert on error = 0x00
+          // Byte 1: default / JS falsy = 0x00
           expect(encoded.substring(4, 6), equals('00'));
         });
 
-        test('encodes batch call with try mode', () {
+        test('revertOnError true emits execType 0x01 (try / JS polarity)', () {
           const mode = ExecutionMode(
             type: Erc7579CallKind.batchCall,
-            revertOnError: false,
+            revertOnError: true,
           );
           final encoded = mode.encode();
 
           // Byte 0: batch call = 0x01
           expect(encoded.substring(2, 4), equals('01'));
-          // Byte 1: try mode (no revert) = 0x01
+          // Byte 1: JS true → 0x01 (ERC-7579 try)
           expect(encoded.substring(4, 6), equals('01'));
         });
 
-        test('encodes delegate call', () {
-          const mode = ExecutionMode(type: Erc7579CallKind.delegateCall);
-          final encoded = mode.encode();
-
-          // Byte 0: delegate call = 0xff
-          expect(encoded.substring(2, 4), equals('ff'));
+        test('encodes delegate call with JS polarity', () {
+          // JS: delegatecall + false → 0xff00..., + true → 0xff01...
+          expect(
+            const ExecutionMode(type: Erc7579CallKind.delegateCall)
+                .encode()
+                .toLowerCase(),
+            equals(
+              '0xff00000000000000000000000000000000000000000000000000000000000000',
+            ),
+          );
+          expect(
+            const ExecutionMode(
+              type: Erc7579CallKind.delegateCall,
+              revertOnError: true,
+            ).encode().toLowerCase(),
+            equals(
+              '0xff01000000000000000000000000000000000000000000000000000000000000',
+            ),
+          );
         });
 
         test('encodes with selector', () {
@@ -829,7 +943,7 @@ void main() {
           );
           final encoded = mode.encode();
 
-          // Bytes 6-9 contain the selector
+          // Bytes 6-9 contain the selector (ERC-7579 / JS encoder layout)
           // Position: 0x + 2 chars per byte * 6 = 14
           expect(encoded.substring(14, 22), equals('aabbccdd'));
         });
@@ -851,7 +965,7 @@ void main() {
             const ExecutionMode(type: Erc7579CallKind.call),
             const ExecutionMode(
               type: Erc7579CallKind.batchCall,
-              revertOnError: false,
+              revertOnError: true,
             ),
             const ExecutionMode(
               type: Erc7579CallKind.delegateCall,
@@ -873,12 +987,12 @@ void main() {
       test('toString returns readable format', () {
         const mode = ExecutionMode(
           type: Erc7579CallKind.batchCall,
-          revertOnError: false,
+          revertOnError: true,
         );
         final str = mode.toString();
 
         expect(str, contains('batchCall'));
-        expect(str, contains('revertOnError: false'));
+        expect(str, contains('revertOnError: true'));
       });
     });
 
@@ -915,14 +1029,14 @@ void main() {
       test('includes mode bytes after selector', () {
         const mode = ExecutionMode(
           type: Erc7579CallKind.batchCall,
-          revertOnError: false,
+          revertOnError: true,
         );
         final callData = encode7579SupportsExecutionMode(mode);
 
         // After selector (4 bytes = 8 hex chars), mode starts
         // Byte 0 of mode should be 0x01 (batchCall)
         expect(callData.substring(10, 12), equals('01'));
-        // Byte 1 of mode should be 0x01 (try mode)
+        // Byte 1 of mode should be 0x01 (JS true / ERC-7579 try)
         expect(callData.substring(12, 14), equals('01'));
       });
     });
@@ -1048,6 +1162,44 @@ void main() {
     });
 
     group('decode7579Calls', () {
+      test('round-trips ExecutionMode with explicit revertOnError true', () {
+        // Build execute calldata whose mode has execType 0x01 (JS true).
+        const mode = ExecutionMode(
+          type: Erc7579CallKind.call,
+          revertOnError: true,
+          selector: '0xaabbccdd',
+          context: '0x11223344556677889900112233445566778899001122',
+        );
+        final call = Call(
+          to: EthereumAddress.fromHex(
+            '0x1234567890123456789012345678901234567890',
+          ),
+          value: BigInt.from(7),
+          data: '0xabcdef',
+        );
+        final executionData = encode7579SingleCallData(call);
+        const executionDataOffset = 2 * 32;
+        final encoded = Hex.concat([
+          Erc7579Selectors.execute,
+          Hex.strip0x(mode.encode()),
+          AbiEncoder.encodeUint256(BigInt.from(executionDataOffset)),
+          Hex.strip0x(AbiEncoder.encodeBytes(executionData)),
+        ]);
+
+        final decoded = decode7579Calls(encoded);
+
+        expect(decoded.mode.type, equals(Erc7579CallKind.call));
+        expect(decoded.mode.revertOnError, isTrue);
+        // Spec-aligned offsets (bytes 6-9 / 10-31), not JS's lossy 3-6 / 7-31.
+        expect(decoded.mode.selector?.toLowerCase(), equals('0xaabbccdd'));
+        expect(
+          decoded.mode.context?.toLowerCase(),
+          equals('0x11223344556677889900112233445566778899001122'),
+        );
+        expect(decoded.calls, hasLength(1));
+        expect(decoded.calls[0].value, equals(BigInt.from(7)));
+      });
+
       test('decodes single call execution', () {
         final call = Call(
           to: EthereumAddress.fromHex(
@@ -1061,6 +1213,7 @@ void main() {
         final decoded = decode7579Calls(encoded);
 
         expect(decoded.mode.type, equals(Erc7579CallKind.call));
+        expect(decoded.mode.revertOnError, isFalse);
         expect(decoded.calls, hasLength(1));
         expect(
           decoded.calls[0].to.hex.toLowerCase(),


### PR DESCRIPTION
Chunk 3 of 6 splitting the parity-audit backlog into reviewable PRs. Builds on #39.

- **erc7579**: match JS revertOnError polarity and encode parity
- **actions**: encode writeContract via web3dart ABI encoder
- **tests**: add unit tests for biconomy, nexus, thirdweb, trust accounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)