### PR TITLE
feat(permissionless): port PasskeyServerClient (pks_* RPC)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **PasskeyServerClient** (`createPasskeyServerClient`) — port of permissionless.js
+  passkey server RPC surface (`pks_*`). Lives in core `permissionless` for JS parity;
+  on-device passkey creation stays in `permissionless_passkeys`.
+
 ## [permissionless_passkeys 0.1.1] - 2026-04-21
 
 ### Changed

--- a/packages/permissionless/CHANGELOG.md
+++ b/packages/permissionless/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **PasskeyServerClient** (`createPasskeyServerClient`) — port of permissionless.js
+  `clients/passkeyServer` + `actions/passkeyServer`. Exposes all five `pks_*` RPC
+  methods: `startRegistration`, `verifyRegistration`, `startAuthentication`,
+  `verifyAuthentication`, and `getCredentials`. Placed in the core `permissionless`
+  package for JS layout parity (client-side passkey creation remains in
+  `permissionless_passkeys`).
+
 ### Changed
 
 - **Safe default threshold** is now `owners.length` (all owners must sign), matching

--- a/packages/permissionless/lib/permissionless.dart
+++ b/packages/permissionless/lib/permissionless.dart
@@ -39,6 +39,7 @@ export 'src/actions/smart_account/smart_account.dart';
 // Clients
 export 'src/clients/bundler/bundler.dart';
 export 'src/clients/etherspot/etherspot.dart';
+export 'src/clients/passkey_server/passkey_server.dart';
 export 'src/clients/paymaster/paymaster.dart';
 export 'src/clients/pimlico/pimlico.dart';
 export 'src/clients/public/public.dart';

--- a/packages/permissionless/lib/src/clients/passkey_server/passkey_server.dart
+++ b/packages/permissionless/lib/src/clients/passkey_server/passkey_server.dart
@@ -1,0 +1,7 @@
+/// Passkey server client (`pks_*` RPC) for WebAuthn registration and auth.
+///
+/// Port of permissionless.js `clients/passkeyServer` + `actions/passkeyServer`.
+library;
+
+export 'passkey_server_client.dart';
+export 'types.dart';

--- a/packages/permissionless/lib/src/clients/passkey_server/passkey_server_client.dart
+++ b/packages/permissionless/lib/src/clients/passkey_server/passkey_server_client.dart
@@ -1,0 +1,383 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:http/http.dart' as http;
+
+import '../../types/hex.dart';
+import '../bundler/rpc_client.dart';
+import 'types.dart';
+
+/// Client for a permissionless-compatible passkey server (`pks_*` RPC).
+///
+/// Ports permissionless.js `createPasskeyServerClient` / passkeyServer actions:
+/// registration, authentication, and credential listing against a remote
+/// WebAuthn ceremony server.
+///
+/// This lives in the core package (JS layout parity). Client-side passkey
+/// creation and on-device signing remain in `permissionless_passkeys`.
+///
+/// Example:
+/// ```dart
+/// final client = createPasskeyServerClient(
+///   url: 'https://passkeys.example.com',
+/// );
+///
+/// final options = await client.startRegistration(
+///   context: {'userName': 'alice@example.com'},
+/// );
+/// // ... create credential via platform WebAuthn / passkeys package ...
+/// final result = await client.verifyRegistration(
+///   credential: registrationCredential,
+///   context: {'userName': 'alice@example.com'},
+/// );
+/// ```
+class PasskeyServerClient {
+  /// Creates a passkey server client with the given RPC client.
+  ///
+  /// Prefer [createPasskeyServerClient] for URL-based setup.
+  PasskeyServerClient({
+    required this.rpcClient,
+  });
+
+  /// The underlying JSON-RPC client.
+  final JsonRpcClient rpcClient;
+
+  /// Starts WebAuthn registration (`pks_startRegistration`).
+  ///
+  /// [context] is opaque server context (e.g. `{userName: ...}`), matching
+  /// permissionless.js `StartRegistrationParameters.context`.
+  ///
+  /// Decodes base64 `challenge` and `user.id` into bytes, matching JS.
+  Future<PasskeyRegistrationOptions> startRegistration({
+    Map<String, dynamic>? context,
+  }) async {
+    final result = await rpcClient.call(
+      'pks_startRegistration',
+      [context],
+    );
+
+    if (result is! Map<String, dynamic>) {
+      throw const FormatException(
+        'Invalid response from server - expected object for pks_startRegistration',
+      );
+    }
+
+    _validateRegistrationResponse(result);
+
+    final userJson = result['user'] as Map<String, dynamic>;
+    final authenticatorSelectionJson =
+        result['authenticatorSelection'] as Map<String, dynamic>?;
+    final extensionsJson = result['extensions'] as Map<String, dynamic>?;
+
+    return PasskeyRegistrationOptions(
+      rp: PasskeyRp.fromJson(result['rp'] as Map<String, dynamic>),
+      user: PasskeyUser(
+        id: _base64ToBytes(userJson['id'] as String),
+        name: userJson['name'] as String,
+        displayName: userJson['displayName'] as String,
+      ),
+      challenge: _base64ToBytes(result['challenge'] as String),
+      attestation: result['attestation'] as String,
+      timeout: result['timeout'] as int?,
+      authenticatorSelection: authenticatorSelectionJson != null
+          ? PasskeyAuthenticatorSelection.fromJson(authenticatorSelectionJson)
+          : null,
+      extensions: extensionsJson != null
+          ? Map<String, dynamic>.from(extensionsJson)
+          : null,
+    );
+  }
+
+  /// Completes registration (`pks_verifyRegistration`).
+  ///
+  /// Encodes binary fields to base64 / base64url the same way as
+  /// permissionless.js `verifyRegistration`.
+  Future<PasskeyVerificationResult> verifyRegistration({
+    required PasskeyRegistrationCredential credential,
+    dynamic context,
+  }) async {
+    final response = credential.response;
+    final params = <dynamic>[
+      {
+        'id': credential.id,
+        'rawId': _base64UrlEncode(credential.rawId, pad: false),
+        'response': {
+          'clientDataJSON': _base64Encode(response.clientDataJSON),
+          'attestationObject':
+              _base64UrlEncode(response.attestationObject, pad: true),
+          if (response.transports != null) 'transports': response.transports,
+          if (response.publicKeyAlgorithm != null)
+            'publicKeyAlgorithm': response.publicKeyAlgorithm,
+          if (response.authenticatorData != null)
+            'authenticatorData': _base64Encode(response.authenticatorData!),
+          if (response.publicKeyType != null)
+            'publicKeyType': response.publicKeyType,
+        },
+        'authenticatorAttachment': credential.authenticatorAttachment,
+        'clientExtensionResults': credential.clientExtensionResults,
+        'type': credential.type,
+      },
+      context,
+    ];
+
+    final result = await rpcClient.call('pks_verifyRegistration', params);
+    return _parseVerificationResult(result);
+  }
+
+  /// Starts WebAuthn authentication (`pks_startAuthentication`).
+  ///
+  /// Decodes the server's base64 challenge and returns it as `0x` hex,
+  /// matching permissionless.js `startAuthentication`.
+  Future<PasskeyAuthenticationOptions> startAuthentication() async {
+    final result = await rpcClient.call('pks_startAuthentication', []);
+
+    if (result is! Map<String, dynamic>) {
+      throw const FormatException(
+        'Invalid response from server - expected object for pks_startAuthentication',
+      );
+    }
+
+    final challengeB64 = result['challenge'] as String?;
+    final rpId = result['rpId'] as String?;
+    final uuid = result['uuid'] as String?;
+
+    if (challengeB64 == null || rpId == null || uuid == null) {
+      throw const FormatException(
+        'Invalid response from server - missing challenge, rpId, or uuid',
+      );
+    }
+
+    final challengeBytes = _base64ToBytes(challengeB64);
+
+    return PasskeyAuthenticationOptions(
+      challenge: Hex.fromBytes(challengeBytes),
+      rpId: rpId,
+      uuid: uuid,
+      timeout: result['timeout'] as int?,
+      userVerification: result['userVerification'] as String?,
+    );
+  }
+
+  /// Completes authentication (`pks_verifyAuthentication`).
+  ///
+  /// [uuid] is the session id from [startAuthentication].
+  /// Encodes binary fields as base64url (no pad) like permissionless.js.
+  Future<PasskeyVerificationResult> verifyAuthentication({
+    required PasskeyAuthenticationCredential credential,
+    required String uuid,
+  }) async {
+    final response = credential.response;
+    final params = <dynamic>[
+      {
+        'id': credential.id,
+        'rawId': _base64UrlEncode(credential.rawId, pad: false),
+        'authenticatorAttachment': credential.authenticatorAttachment,
+        'response': {
+          'clientDataJSON':
+              _base64UrlEncode(response.clientDataJSON, pad: false),
+          'authenticatorData':
+              _base64UrlEncode(response.authenticatorData, pad: true),
+          'signature': _base64UrlEncode(response.signature, pad: false),
+          if (response.userHandle != null)
+            'userHandle': _base64UrlEncode(response.userHandle!, pad: false),
+        },
+        'clientExtensionResults': credential.clientExtensionResults,
+        'type': credential.type,
+      },
+      {'uuid': uuid},
+    ];
+
+    final result = await rpcClient.call('pks_verifyAuthentication', params);
+    return _parseVerificationResult(result);
+  }
+
+  /// Lists registered credentials (`pks_getCredentials`).
+  ///
+  /// [context] is opaque server context, matching permissionless.js.
+  Future<List<PasskeyCredentialInfo>> getCredentials({
+    Map<String, dynamic>? context,
+  }) async {
+    final result = await rpcClient.call(
+      'pks_getCredentials',
+      [context],
+    );
+
+    if (result is! List) {
+      throw const FormatException(
+        'Invalid response from server - expected array for pks_getCredentials',
+      );
+    }
+
+    final credentials = <PasskeyCredentialInfo>[];
+    for (final item in result) {
+      if (item is! Map<String, dynamic>) {
+        throw const FormatException('Invalid passkey entry returned from server');
+      }
+      final id = item['id'];
+      final publicKey = item['publicKey'];
+      if (id is! String) {
+        throw const FormatException('Invalid passkey id returned from server');
+      }
+      if (publicKey is! String || !publicKey.startsWith('0x')) {
+        throw const FormatException(
+          'Invalid public key returned from server - must be hex string starting with 0x',
+        );
+      }
+      credentials.add(PasskeyCredentialInfo(id: id, publicKey: publicKey));
+    }
+    return credentials;
+  }
+
+  PasskeyVerificationResult _parseVerificationResult(dynamic result) {
+    if (result is! Map<String, dynamic>) {
+      throw const FormatException(
+        'Invalid response from server - expected object for verification',
+      );
+    }
+
+    final success = result['success'] == true;
+    final id = result['id'];
+    final publicKey = result['publicKey'];
+    final userName = result['userName'];
+
+    if (id is! String) {
+      throw const FormatException('Invalid passkey id returned from server');
+    }
+    if (publicKey is! String || !publicKey.startsWith('0x')) {
+      throw const FormatException(
+        'Invalid public key returned from server - must be hex string starting with 0x',
+      );
+    }
+    if (userName is! String) {
+      throw const FormatException('Invalid user name returned from server');
+    }
+
+    return PasskeyVerificationResult(
+      success: success,
+      id: id,
+      publicKey: publicKey,
+      userName: userName,
+    );
+  }
+
+  void _validateRegistrationResponse(Map<String, dynamic> response) {
+    const validAttestations = {'direct', 'enterprise', 'indirect', 'none'};
+    const validAttachments = {'platform', 'cross-platform'};
+    const validKeyOptions = {'required', 'preferred', 'discouraged'};
+
+    final attestation = response['attestation'];
+    if (attestation is! String || !validAttestations.contains(attestation)) {
+      throw const FormatException('Invalid response format from passkey server');
+    }
+
+    final selection = response['authenticatorSelection'];
+    if (selection is! Map<String, dynamic>) {
+      throw const FormatException('Invalid response format from passkey server');
+    }
+    final attachment = selection['authenticatorAttachment'];
+    final requireResidentKey = selection['requireResidentKey'];
+    final residentKey = selection['residentKey'];
+    final userVerification = selection['userVerification'];
+    if (attachment is! String ||
+        !validAttachments.contains(attachment) ||
+        requireResidentKey is! bool ||
+        residentKey is! String ||
+        !validKeyOptions.contains(residentKey) ||
+        userVerification is! String ||
+        !validKeyOptions.contains(userVerification)) {
+      throw const FormatException('Invalid response format from passkey server');
+    }
+
+    if (response['challenge'] is! String ||
+        (response['challenge'] as String).isEmpty) {
+      throw const FormatException('Invalid response format from passkey server');
+    }
+
+    final extensions = response['extensions'];
+    if (extensions != null) {
+      if (extensions is! Map) {
+        throw const FormatException('Invalid response format from passkey server');
+      }
+      final ext = Map<String, dynamic>.from(extensions);
+      if (ext.containsKey('appid') && ext['appid'] is! String) {
+        throw const FormatException('Invalid response format from passkey server');
+      }
+      if (ext.containsKey('credProps') && ext['credProps'] is! bool) {
+        throw const FormatException('Invalid response format from passkey server');
+      }
+      if (ext.containsKey('hmacCreateSecret') &&
+          ext['hmacCreateSecret'] is! bool) {
+        throw const FormatException('Invalid response format from passkey server');
+      }
+      if (ext.containsKey('minPinLength') && ext['minPinLength'] is! bool) {
+        throw const FormatException('Invalid response format from passkey server');
+      }
+    }
+
+    final rp = response['rp'];
+    if (rp is! Map || rp['id'] is! String || rp['name'] is! String) {
+      throw const FormatException('Invalid response format from passkey server');
+    }
+
+    final user = response['user'];
+    if (user is! Map ||
+        user['id'] is! String ||
+        user['name'] is! String ||
+        user['displayName'] is! String) {
+      throw const FormatException('Invalid response format from passkey server');
+    }
+  }
+
+  /// Closes the underlying HTTP client.
+  void close() => rpcClient.close();
+}
+
+/// Creates a [PasskeyServerClient] from a passkey server URL.
+///
+/// Example:
+/// ```dart
+/// final client = createPasskeyServerClient(
+///   url: 'https://passkeys.example.com',
+/// );
+/// ```
+PasskeyServerClient createPasskeyServerClient({
+  required String url,
+  http.Client? httpClient,
+  Map<String, String>? headers,
+  Duration? timeout,
+}) =>
+    PasskeyServerClient(
+      rpcClient: JsonRpcClient(
+        url: Uri.parse(url),
+        httpClient: httpClient,
+        headers: headers ?? {},
+        timeout: timeout ?? const Duration(seconds: 30),
+      ),
+    );
+
+// ---------------------------------------------------------------------------
+// Base64 helpers matching ox Base64.fromBytes / toBytes used by permissionless.js
+// ---------------------------------------------------------------------------
+
+Uint8List _base64ToBytes(String value) {
+  var normalized = value.replaceAll('-', '+').replaceAll('_', '/');
+  final remainder = normalized.length % 4;
+  if (remainder == 2) {
+    normalized = '$normalized==';
+  } else if (remainder == 3) {
+    normalized = '$normalized=';
+  } else if (remainder == 1) {
+    // Invalid length; let base64Decode throw
+  }
+  return Uint8List.fromList(base64Decode(normalized));
+}
+
+String _base64Encode(List<int> bytes) => base64Encode(bytes);
+
+String _base64UrlEncode(List<int> bytes, {required bool pad}) {
+  var encoded = base64Url.encode(bytes);
+  if (!pad) {
+    encoded = encoded.replaceAll('=', '');
+  }
+  return encoded;
+}

--- a/packages/permissionless/lib/src/clients/passkey_server/passkey_server_client.dart
+++ b/packages/permissionless/lib/src/clients/passkey_server/passkey_server_client.dart
@@ -211,7 +211,8 @@ class PasskeyServerClient {
     final credentials = <PasskeyCredentialInfo>[];
     for (final item in result) {
       if (item is! Map<String, dynamic>) {
-        throw const FormatException('Invalid passkey entry returned from server');
+        throw const FormatException(
+            'Invalid passkey entry returned from server');
       }
       final id = item['id'];
       final publicKey = item['publicKey'];
@@ -267,12 +268,14 @@ class PasskeyServerClient {
 
     final attestation = response['attestation'];
     if (attestation is! String || !validAttestations.contains(attestation)) {
-      throw const FormatException('Invalid response format from passkey server');
+      throw const FormatException(
+          'Invalid response format from passkey server');
     }
 
     final selection = response['authenticatorSelection'];
     if (selection is! Map<String, dynamic>) {
-      throw const FormatException('Invalid response format from passkey server');
+      throw const FormatException(
+          'Invalid response format from passkey server');
     }
     final attachment = selection['authenticatorAttachment'];
     final requireResidentKey = selection['requireResidentKey'];
@@ -285,38 +288,46 @@ class PasskeyServerClient {
         !validKeyOptions.contains(residentKey) ||
         userVerification is! String ||
         !validKeyOptions.contains(userVerification)) {
-      throw const FormatException('Invalid response format from passkey server');
+      throw const FormatException(
+          'Invalid response format from passkey server');
     }
 
     if (response['challenge'] is! String ||
         (response['challenge'] as String).isEmpty) {
-      throw const FormatException('Invalid response format from passkey server');
+      throw const FormatException(
+          'Invalid response format from passkey server');
     }
 
     final extensions = response['extensions'];
     if (extensions != null) {
       if (extensions is! Map) {
-        throw const FormatException('Invalid response format from passkey server');
+        throw const FormatException(
+            'Invalid response format from passkey server');
       }
       final ext = Map<String, dynamic>.from(extensions);
       if (ext.containsKey('appid') && ext['appid'] is! String) {
-        throw const FormatException('Invalid response format from passkey server');
+        throw const FormatException(
+            'Invalid response format from passkey server');
       }
       if (ext.containsKey('credProps') && ext['credProps'] is! bool) {
-        throw const FormatException('Invalid response format from passkey server');
+        throw const FormatException(
+            'Invalid response format from passkey server');
       }
       if (ext.containsKey('hmacCreateSecret') &&
           ext['hmacCreateSecret'] is! bool) {
-        throw const FormatException('Invalid response format from passkey server');
+        throw const FormatException(
+            'Invalid response format from passkey server');
       }
       if (ext.containsKey('minPinLength') && ext['minPinLength'] is! bool) {
-        throw const FormatException('Invalid response format from passkey server');
+        throw const FormatException(
+            'Invalid response format from passkey server');
       }
     }
 
     final rp = response['rp'];
     if (rp is! Map || rp['id'] is! String || rp['name'] is! String) {
-      throw const FormatException('Invalid response format from passkey server');
+      throw const FormatException(
+          'Invalid response format from passkey server');
     }
 
     final user = response['user'];
@@ -324,7 +335,8 @@ class PasskeyServerClient {
         user['id'] is! String ||
         user['name'] is! String ||
         user['displayName'] is! String) {
-      throw const FormatException('Invalid response format from passkey server');
+      throw const FormatException(
+          'Invalid response format from passkey server');
     }
   }
 

--- a/packages/permissionless/lib/src/clients/passkey_server/types.dart
+++ b/packages/permissionless/lib/src/clients/passkey_server/types.dart
@@ -1,0 +1,360 @@
+import 'dart:typed_data';
+
+/// Relying Party (RP) info from `pks_startRegistration`.
+class PasskeyRp {
+  /// Creates RP metadata.
+  const PasskeyRp({
+    required this.id,
+    required this.name,
+  });
+
+  /// Creates from a JSON-RPC response object.
+  factory PasskeyRp.fromJson(Map<String, dynamic> json) => PasskeyRp(
+        id: json['id'] as String,
+        name: json['name'] as String,
+      );
+
+  /// Relying Party ID (typically a domain).
+  final String id;
+
+  /// Human-readable RP name.
+  final String name;
+
+  /// Serializes to JSON.
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'name': name,
+      };
+
+  @override
+  String toString() => 'PasskeyRp(id: $id, name: $name)';
+}
+
+/// User entity from `pks_startRegistration` (decoded from base64).
+class PasskeyUser {
+  /// Creates a WebAuthn user entity.
+  const PasskeyUser({
+    required this.id,
+    required this.name,
+    required this.displayName,
+  });
+
+  /// User handle bytes (decoded from base64 in the RPC response).
+  final Uint8List id;
+
+  /// User name (e.g. email).
+  final String name;
+
+  /// Display name shown in the authenticator UI.
+  final String displayName;
+
+  @override
+  String toString() => 'PasskeyUser(name: $name, displayName: $displayName)';
+}
+
+/// Authenticator selection criteria from registration options.
+class PasskeyAuthenticatorSelection {
+  /// Creates authenticator selection criteria.
+  const PasskeyAuthenticatorSelection({
+    this.authenticatorAttachment,
+    this.requireResidentKey,
+    this.residentKey,
+    this.userVerification,
+  });
+
+  /// Creates from a JSON-RPC response object.
+  factory PasskeyAuthenticatorSelection.fromJson(Map<String, dynamic> json) =>
+      PasskeyAuthenticatorSelection(
+        authenticatorAttachment: json['authenticatorAttachment'] as String?,
+        requireResidentKey: json['requireResidentKey'] as bool?,
+        residentKey: json['residentKey'] as String?,
+        userVerification: json['userVerification'] as String?,
+      );
+
+  /// Preferred authenticator attachment: `platform` or `cross-platform`.
+  final String? authenticatorAttachment;
+
+  /// Whether a resident (discoverable) key is required.
+  final bool? requireResidentKey;
+
+  /// Resident key preference: `required`, `preferred`, or `discouraged`.
+  final String? residentKey;
+
+  /// User verification preference: `required`, `preferred`, or `discouraged`.
+  final String? userVerification;
+
+  /// Serializes to JSON.
+  Map<String, dynamic> toJson() => {
+        if (authenticatorAttachment != null)
+          'authenticatorAttachment': authenticatorAttachment,
+        if (requireResidentKey != null)
+          'requireResidentKey': requireResidentKey,
+        if (residentKey != null) 'residentKey': residentKey,
+        if (userVerification != null) 'userVerification': userVerification,
+      };
+}
+
+/// WebAuthn credential creation options from `pks_startRegistration`.
+///
+/// Pass these options to the platform WebAuthn API
+/// (`navigator.credentials.create` / passkeys package).
+class PasskeyRegistrationOptions {
+  /// Creates registration options returned by the passkey server.
+  const PasskeyRegistrationOptions({
+    required this.rp,
+    required this.user,
+    required this.challenge,
+    required this.attestation,
+    this.timeout,
+    this.authenticatorSelection,
+    this.extensions,
+  });
+
+  /// Relying Party information.
+  final PasskeyRp rp;
+
+  /// User entity (id is decoded bytes).
+  final PasskeyUser user;
+
+  /// Challenge bytes (decoded from base64 in the RPC response).
+  final Uint8List challenge;
+
+  /// Attestation conveyance preference:
+  /// `direct`, `enterprise`, `indirect`, or `none`.
+  final String attestation;
+
+  /// Optional timeout in milliseconds.
+  final int? timeout;
+
+  /// Authenticator selection criteria.
+  final PasskeyAuthenticatorSelection? authenticatorSelection;
+
+  /// Optional WebAuthn client extensions.
+  final Map<String, dynamic>? extensions;
+}
+
+/// Authentication challenge options from `pks_startAuthentication`.
+class PasskeyAuthenticationOptions {
+  /// Creates authentication options returned by the passkey server.
+  const PasskeyAuthenticationOptions({
+    required this.challenge,
+    required this.rpId,
+    required this.uuid,
+    this.timeout,
+    this.userVerification,
+  });
+
+  /// Creates from a JSON-RPC response (challenge already hex-encoded).
+  factory PasskeyAuthenticationOptions.fromJson(Map<String, dynamic> json) =>
+      PasskeyAuthenticationOptions(
+        challenge: json['challenge'] as String,
+        rpId: json['rpId'] as String,
+        uuid: json['uuid'] as String,
+        timeout: json['timeout'] as int?,
+        userVerification: json['userVerification'] as String?,
+      );
+
+  /// Challenge as a `0x`-prefixed hex string (matches permissionless.js).
+  final String challenge;
+
+  /// Relying Party ID.
+  final String rpId;
+
+  /// Server session UUID used when verifying authentication.
+  final String uuid;
+
+  /// Optional timeout in milliseconds.
+  final int? timeout;
+
+  /// User verification preference.
+  final String? userVerification;
+}
+
+/// A registered passkey credential summary from `pks_getCredentials`.
+class PasskeyCredentialInfo {
+  /// Creates a credential summary.
+  const PasskeyCredentialInfo({
+    required this.id,
+    required this.publicKey,
+  });
+
+  /// Creates from a JSON-RPC response object.
+  factory PasskeyCredentialInfo.fromJson(Map<String, dynamic> json) =>
+      PasskeyCredentialInfo(
+        id: json['id'] as String,
+        publicKey: json['publicKey'] as String,
+      );
+
+  /// Credential ID (typically base64url).
+  final String id;
+
+  /// Public key as a `0x`-prefixed hex string.
+  final String publicKey;
+
+  /// Serializes to JSON.
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'publicKey': publicKey,
+      };
+
+  @override
+  String toString() => 'PasskeyCredentialInfo(id: $id, publicKey: $publicKey)';
+}
+
+/// Result of `pks_verifyRegistration` / `pks_verifyAuthentication`.
+class PasskeyVerificationResult {
+  /// Creates a verification result.
+  const PasskeyVerificationResult({
+    required this.success,
+    required this.id,
+    required this.publicKey,
+    required this.userName,
+  });
+
+  /// Creates from a JSON-RPC response object.
+  factory PasskeyVerificationResult.fromJson(Map<String, dynamic> json) =>
+      PasskeyVerificationResult(
+        success: json['success'] as bool,
+        id: json['id'] as String,
+        publicKey: json['publicKey'] as String,
+        userName: json['userName'] as String,
+      );
+
+  /// Whether the server accepted the credential.
+  final bool success;
+
+  /// Credential ID.
+  final String id;
+
+  /// Public key as a `0x`-prefixed hex string.
+  final String publicKey;
+
+  /// Associated user name.
+  final String userName;
+
+  @override
+  String toString() =>
+      'PasskeyVerificationResult(success: $success, id: $id, userName: $userName)';
+}
+
+/// Attestation response fields for registration verification.
+///
+/// Binary fields are raw bytes; the client encodes them for the RPC payload
+/// to match permissionless.js (standard / URL-safe base64).
+class PasskeyAttestationResponse {
+  /// Creates an attestation response.
+  const PasskeyAttestationResponse({
+    required this.clientDataJSON,
+    required this.attestationObject,
+    this.authenticatorData,
+    this.transports,
+    this.publicKeyAlgorithm,
+    this.publicKeyType,
+  });
+
+  /// Client data JSON bytes from the authenticator.
+  final Uint8List clientDataJSON;
+
+  /// Attestation object bytes.
+  final Uint8List attestationObject;
+
+  /// Optional authenticator data bytes.
+  final Uint8List? authenticatorData;
+
+  /// Optional transport hints (e.g. `usb`, `internal`, `hybrid`).
+  final List<String>? transports;
+
+  /// COSE algorithm identifier from `getPublicKeyAlgorithm()`.
+  final int? publicKeyAlgorithm;
+
+  /// Optional public key type string.
+  final String? publicKeyType;
+}
+
+/// Credential payload for `pks_verifyRegistration`.
+///
+/// Mirrors the browser `PublicKeyCredential` fields used by permissionless.js
+/// `verifyRegistration`, using [Uint8List] instead of `ArrayBuffer`.
+class PasskeyRegistrationCredential {
+  /// Creates a registration credential for server verification.
+  const PasskeyRegistrationCredential({
+    required this.id,
+    required this.rawId,
+    required this.response,
+    required this.authenticatorAttachment,
+    this.clientExtensionResults = const {},
+    this.type = 'public-key',
+  });
+
+  /// Credential ID string from the authenticator.
+  final String id;
+
+  /// Raw credential ID bytes.
+  final Uint8List rawId;
+
+  /// Attestation response.
+  final PasskeyAttestationResponse response;
+
+  /// `platform` or `cross-platform`.
+  final String authenticatorAttachment;
+
+  /// Client extension results map.
+  final Map<String, dynamic> clientExtensionResults;
+
+  /// Credential type (always `public-key` for WebAuthn).
+  final String type;
+}
+
+/// Assertion response fields for authentication verification.
+class PasskeyAssertionResponse {
+  /// Creates an assertion response.
+  const PasskeyAssertionResponse({
+    required this.clientDataJSON,
+    required this.authenticatorData,
+    required this.signature,
+    this.userHandle,
+  });
+
+  /// Client data JSON bytes.
+  final Uint8List clientDataJSON;
+
+  /// Authenticator data bytes.
+  final Uint8List authenticatorData;
+
+  /// Signature bytes.
+  final Uint8List signature;
+
+  /// Optional user handle bytes.
+  final Uint8List? userHandle;
+}
+
+/// Credential payload for `pks_verifyAuthentication`.
+class PasskeyAuthenticationCredential {
+  /// Creates an authentication credential for server verification.
+  const PasskeyAuthenticationCredential({
+    required this.id,
+    required this.rawId,
+    required this.response,
+    required this.authenticatorAttachment,
+    this.clientExtensionResults = const {},
+    this.type = 'public-key',
+  });
+
+  /// Credential ID string from the authenticator.
+  final String id;
+
+  /// Raw credential ID bytes.
+  final Uint8List rawId;
+
+  /// Assertion response.
+  final PasskeyAssertionResponse response;
+
+  /// `platform` or `cross-platform`.
+  final String authenticatorAttachment;
+
+  /// Client extension results map.
+  final Map<String, dynamic> clientExtensionResults;
+
+  /// Credential type (always `public-key` for WebAuthn).
+  final String type;
+}

--- a/packages/permissionless/test/clients/passkey_server/passkey_server_client_test.dart
+++ b/packages/permissionless/test/clients/passkey_server/passkey_server_client_test.dart
@@ -1,0 +1,416 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:permissionless/permissionless.dart';
+import 'package:test/test.dart';
+
+/// Recorded-style fixtures matching permissionless.js passkey server RPC shapes.
+void main() {
+  group('PasskeyServerClient', () {
+    late List<Map<String, dynamic>> capturedRequests;
+
+    MockClient createMockClient(
+      dynamic Function(Map<String, dynamic> request) responseFactory,
+    ) {
+      capturedRequests = [];
+      return MockClient((request) async {
+        final body = jsonDecode(request.body) as Map<String, dynamic>;
+        capturedRequests.add(body);
+        final response = responseFactory(body);
+        return http.Response(
+          jsonEncode({
+            'jsonrpc': '2.0',
+            'id': body['id'],
+            'result': response,
+          }),
+          200,
+        );
+      });
+    }
+
+    /// Sample bytes used across encode/decode fixtures.
+    /// ASCII "challenge-bytes!!" → base64 "Y2hhbGxlbmdlLWJ5dGVzISE="
+    Uint8List challengeBytes() =>
+        Uint8List.fromList(utf8.encode('challenge-bytes!!'));
+
+    /// base64 of challengeBytes (standard, padded)
+    String challengeB64() => base64Encode(challengeBytes());
+
+    /// user id bytes
+    Uint8List userIdBytes() => Uint8List.fromList(utf8.encode('user-id-01'));
+
+    String userIdB64() => base64Encode(userIdBytes());
+
+    Map<String, dynamic> validStartRegistrationResult() => {
+          'rp': {'id': 'example.com', 'name': 'Example'},
+          'user': {
+            'id': userIdB64(),
+            'name': 'alice@example.com',
+            'displayName': 'Alice',
+          },
+          'challenge': challengeB64(),
+          'timeout': 60000,
+          'authenticatorSelection': {
+            'authenticatorAttachment': 'platform',
+            'requireResidentKey': true,
+            'residentKey': 'required',
+            'userVerification': 'required',
+          },
+          'attestation': 'none',
+          'extensions': {
+            'credProps': true,
+          },
+        };
+
+    group('startRegistration', () {
+      test('calls pks_startRegistration with context and decodes fields',
+          () async {
+        final mock = createMockClient((_) => validStartRegistrationResult());
+        final client = createPasskeyServerClient(
+          url: 'http://localhost:3000',
+          httpClient: mock,
+        );
+
+        final options = await client.startRegistration(
+          context: {'userName': 'alice@example.com'},
+        );
+
+        expect(capturedRequests.single['method'], 'pks_startRegistration');
+        expect(
+          capturedRequests.single['params'],
+          equals([
+            {'userName': 'alice@example.com'},
+          ]),
+        );
+
+        expect(options.rp.id, 'example.com');
+        expect(options.rp.name, 'Example');
+        expect(options.user.name, 'alice@example.com');
+        expect(options.user.displayName, 'Alice');
+        expect(options.user.id, equals(userIdBytes()));
+        expect(options.challenge, equals(challengeBytes()));
+        expect(options.attestation, 'none');
+        expect(options.timeout, 60000);
+        expect(
+          options.authenticatorSelection?.authenticatorAttachment,
+          'platform',
+        );
+        expect(options.authenticatorSelection?.requireResidentKey, isTrue);
+        expect(options.extensions?['credProps'], isTrue);
+      });
+
+      test('sends null context when omitted', () async {
+        final mock = createMockClient((_) => validStartRegistrationResult());
+        final client = createPasskeyServerClient(
+          url: 'http://localhost:3000',
+          httpClient: mock,
+        );
+
+        await client.startRegistration();
+
+        expect(capturedRequests.single['params'], equals([null]));
+      });
+
+      test('rejects invalid registration response shape', () async {
+        final mock = createMockClient(
+          (_) => {
+            'rp': {'id': 'example.com', 'name': 'Example'},
+            'user': {
+              'id': userIdB64(),
+              'name': 'alice',
+              'displayName': 'Alice',
+            },
+            'challenge': challengeB64(),
+            // missing authenticatorSelection / bad attestation
+            'attestation': 'invalid',
+          },
+        );
+        final client = createPasskeyServerClient(
+          url: 'http://localhost:3000',
+          httpClient: mock,
+        );
+
+        expect(
+          () => client.startRegistration(),
+          throwsA(isA<FormatException>()),
+        );
+      });
+    });
+
+    group('startAuthentication', () {
+      test('calls pks_startAuthentication and returns hex challenge', () async {
+        final mock = createMockClient(
+          (_) => {
+            'challenge': challengeB64(),
+            'rpId': 'example.com',
+            'timeout': 30000,
+            'userVerification': 'preferred',
+            'uuid': 'session-uuid-1',
+          },
+        );
+        final client = createPasskeyServerClient(
+          url: 'http://localhost:3000',
+          httpClient: mock,
+        );
+
+        final options = await client.startAuthentication();
+
+        expect(capturedRequests.single['method'], 'pks_startAuthentication');
+        expect(capturedRequests.single['params'], equals(<dynamic>[]));
+        expect(options.rpId, 'example.com');
+        expect(options.uuid, 'session-uuid-1');
+        expect(options.userVerification, 'preferred');
+        expect(options.timeout, 30000);
+        // permissionless.js: toHex(Base64.toBytes(challenge))
+        expect(options.challenge, Hex.fromBytes(challengeBytes()));
+        expect(options.challenge.startsWith('0x'), isTrue);
+      });
+    });
+
+    group('getCredentials', () {
+      test('calls pks_getCredentials and parses list', () async {
+        final mock = createMockClient(
+          (_) => [
+            {
+              'id': 'cred-1',
+              'publicKey':
+                  '0x04aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            },
+            {
+              'id': 'cred-2',
+              'publicKey':
+                  '0x04bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+            },
+          ],
+        );
+        final client = createPasskeyServerClient(
+          url: 'http://localhost:3000',
+          httpClient: mock,
+        );
+
+        final credentials = await client.getCredentials(
+          context: {'userName': 'alice@example.com'},
+        );
+
+        expect(capturedRequests.single['method'], 'pks_getCredentials');
+        expect(
+          capturedRequests.single['params'],
+          equals([
+            {'userName': 'alice@example.com'},
+          ]),
+        );
+        expect(credentials, hasLength(2));
+        expect(credentials[0].id, 'cred-1');
+        expect(credentials[0].publicKey.startsWith('0x'), isTrue);
+        expect(credentials[1].id, 'cred-2');
+      });
+
+      test('rejects non-array response', () async {
+        final mock = createMockClient((_) => {'not': 'array'});
+        final client = createPasskeyServerClient(
+          url: 'http://localhost:3000',
+          httpClient: mock,
+        );
+
+        expect(
+          () => client.getCredentials(),
+          throwsA(isA<FormatException>()),
+        );
+      });
+
+      test('rejects invalid public key format', () async {
+        final mock = createMockClient(
+          (_) => [
+            {'id': 'cred-1', 'publicKey': 'not-hex'},
+          ],
+        );
+        final client = createPasskeyServerClient(
+          url: 'http://localhost:3000',
+          httpClient: mock,
+        );
+
+        expect(
+          () => client.getCredentials(),
+          throwsA(isA<FormatException>()),
+        );
+      });
+    });
+
+    group('verifyRegistration', () {
+      test('encodes credential payload matching JS base64 rules', () async {
+        final rawId = Uint8List.fromList([1, 2, 3, 4, 5]);
+        final clientDataJSON =
+            Uint8List.fromList(utf8.encode('{"type":"webauthn.create"}'));
+        final attestationObject = Uint8List.fromList([10, 20, 30, 40, 50]);
+        final authenticatorData = Uint8List.fromList([9, 8, 7]);
+
+        final mock = createMockClient(
+          (_) => {
+            'success': true,
+            'id': 'cred-id-1',
+            'publicKey': '0x04abcd',
+            'userName': 'alice@example.com',
+          },
+        );
+        final client = createPasskeyServerClient(
+          url: 'http://localhost:3000',
+          httpClient: mock,
+        );
+
+        final result = await client.verifyRegistration(
+          credential: PasskeyRegistrationCredential(
+            id: 'cred-id-1',
+            rawId: rawId,
+            authenticatorAttachment: 'platform',
+            response: PasskeyAttestationResponse(
+              clientDataJSON: clientDataJSON,
+              attestationObject: attestationObject,
+              authenticatorData: authenticatorData,
+              transports: const ['internal'],
+              publicKeyAlgorithm: -7,
+            ),
+            clientExtensionResults: const {
+              'credProps': {'rk': true},
+            },
+          ),
+          context: {'userName': 'alice@example.com'},
+        );
+
+        expect(capturedRequests.single['method'], 'pks_verifyRegistration');
+        final params = capturedRequests.single['params'] as List<dynamic>;
+        expect(params, hasLength(2));
+
+        final body = params[0] as Map<String, dynamic>;
+        expect(body['id'], 'cred-id-1');
+        // rawId: base64url, no pad
+        expect(body['rawId'], base64Url.encode(rawId).replaceAll('=', ''));
+        expect(body['authenticatorAttachment'], 'platform');
+        expect(body['type'], 'public-key');
+        expect(body['clientExtensionResults'], {
+          'credProps': {'rk': true},
+        });
+
+        final response = body['response'] as Map<String, dynamic>;
+        // clientDataJSON: standard base64 (pad true, url false)
+        expect(response['clientDataJSON'], base64Encode(clientDataJSON));
+        // attestationObject: base64url with pad
+        expect(
+            response['attestationObject'], base64Url.encode(attestationObject));
+        // authenticatorData: standard base64
+        expect(response['authenticatorData'], base64Encode(authenticatorData));
+        expect(response['transports'], ['internal']);
+        expect(response['publicKeyAlgorithm'], -7);
+
+        expect(params[1], {'userName': 'alice@example.com'});
+
+        expect(result.success, isTrue);
+        expect(result.id, 'cred-id-1');
+        expect(result.publicKey, '0x04abcd');
+        expect(result.userName, 'alice@example.com');
+      });
+
+      test('rejects verification result without 0x public key', () async {
+        final mock = createMockClient(
+          (_) => {
+            'success': true,
+            'id': 'cred-id-1',
+            'publicKey': 'deadbeef',
+            'userName': 'alice',
+          },
+        );
+        final client = createPasskeyServerClient(
+          url: 'http://localhost:3000',
+          httpClient: mock,
+        );
+
+        expect(
+          () => client.verifyRegistration(
+            credential: PasskeyRegistrationCredential(
+              id: 'x',
+              rawId: Uint8List.fromList([1]),
+              authenticatorAttachment: 'platform',
+              response: PasskeyAttestationResponse(
+                clientDataJSON: Uint8List.fromList([1]),
+                attestationObject: Uint8List.fromList([2]),
+              ),
+            ),
+          ),
+          throwsA(isA<FormatException>()),
+        );
+      });
+    });
+
+    group('verifyAuthentication', () {
+      test('encodes assertion payload matching JS base64url rules', () async {
+        final rawId = Uint8List.fromList([1, 2, 3, 4]);
+        final clientDataJSON =
+            Uint8List.fromList(utf8.encode('{"type":"webauthn.get"}'));
+        final authenticatorData = Uint8List.fromList([5, 6, 7, 8]);
+        final signature = Uint8List.fromList([9, 10, 11]);
+        final userHandle = Uint8List.fromList([12, 13]);
+
+        final mock = createMockClient(
+          (_) => {
+            'success': true,
+            'id': 'cred-id-1',
+            'publicKey': '0x04ff',
+            'userName': 'alice@example.com',
+          },
+        );
+        final client = createPasskeyServerClient(
+          url: 'http://localhost:3000',
+          httpClient: mock,
+        );
+
+        final result = await client.verifyAuthentication(
+          credential: PasskeyAuthenticationCredential(
+            id: 'cred-id-1',
+            rawId: rawId,
+            authenticatorAttachment: 'platform',
+            response: PasskeyAssertionResponse(
+              clientDataJSON: clientDataJSON,
+              authenticatorData: authenticatorData,
+              signature: signature,
+              userHandle: userHandle,
+            ),
+          ),
+          uuid: 'session-uuid-1',
+        );
+
+        expect(capturedRequests.single['method'], 'pks_verifyAuthentication');
+        final params = capturedRequests.single['params'] as List<dynamic>;
+        expect(params, hasLength(2));
+
+        final body = params[0] as Map<String, dynamic>;
+        expect(body['rawId'], base64Url.encode(rawId).replaceAll('=', ''));
+        expect(body['type'], 'public-key');
+
+        final response = body['response'] as Map<String, dynamic>;
+        // clientDataJSON / signature / userHandle: base64url no pad
+        expect(
+          response['clientDataJSON'],
+          base64Url.encode(clientDataJSON).replaceAll('=', ''),
+        );
+        // authenticatorData: base64url with pad (url: true only)
+        expect(
+          response['authenticatorData'],
+          base64Url.encode(authenticatorData),
+        );
+        expect(
+          response['signature'],
+          base64Url.encode(signature).replaceAll('=', ''),
+        );
+        expect(
+          response['userHandle'],
+          base64Url.encode(userHandle).replaceAll('=', ''),
+        );
+
+        expect(params[1], {'uuid': 'session-uuid-1'});
+        expect(result.success, isTrue);
+        expect(result.publicKey, '0x04ff');
+      });
+    });
+  });
+}


### PR DESCRIPTION
Chunk 5 of 6 splitting the parity-audit backlog into reviewable PRs. Builds on #41.

Ports the permissionless.js PasskeyServerClient: `pks_*` RPC methods for passkey registration and authentication flows, with types and unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)