### PR TITLE
docs: add Dart-vs-JS parity audit report

### DIFF
--- a/docs/parity-audit/00-summary.md
+++ b/docs/parity-audit/00-summary.md
@@ -1,0 +1,66 @@
+# Parity Audit Summary — permissionless.dart v0.3.0 vs permissionless.js v0.3.5
+
+**Date:** 2026-07-11
+**Method:** 15 parallel deep-comparison passes (one per module area; every account type audited separately), each producing a cited report in this directory. High-stakes findings were adversarially re-verified: selectors re-derived with `cast sig`, signature paths cross-executed against viem with identical keys, address tables diffed by hand. Baseline: `dart test -P quick` green (683 tests) before any change.
+
+## Bottom line
+
+The port is **structurally complete** — all 9 account types (incl. EIP-7702 variants), all smart-account and ERC-7579 actions, the Pimlico/Etherspot extensions, and the experimental ERC-20 paymaster exist, and the core byte-level machinery (UserOperation packing, userOpHash for v0.6/v0.7/v0.8, CREATE2/initcode derivation, EntryPoint addresses, MultiSend, ERC-20 state overrides) **mirrors the reference faithfully**. The `signUserOperation` happy path is byte-identical for Safe (v1.4.1), Kernel v0.3.x, Light, Trust, Etherspot, Biconomy, and Simple v0.7.
+
+However, the audit found **7 confirmed runtime-breaking divergences (P0)** and **one systemic bug (P1)** that breaks ERC-1271 `signMessage`/`signTypedData` across nearly every account. Four of the nine account types have no unit tests, and the ERC-7579 tests assert the wrong selector values — which is exactly how the P0 bugs survived a green suite.
+
+## Parity matrix
+
+| Unit | mirrors | diverges | missing | dart-only | Report |
+|---|---|---|---|---|---|
+| Safe account | 12 | 9 | 9 | 1 | [01-account-safe.md](01-account-safe.md) |
+| Kernel account | 15 | 5 | 6 | 3 | [01-account-kernel.md](01-account-kernel.md) |
+| Nexus account | 14 | 1 | 3 | 1 | [01-account-nexus.md](01-account-nexus.md) |
+| Light account | 7 | 1 | 4 | 1 | [01-account-light.md](01-account-light.md) |
+| Simple account | 15 | 5 | 3 | 1 | [01-account-simple.md](01-account-simple.md) |
+| Thirdweb account | 9 | 4 | 3 | 0 | [01-account-thirdweb.md](01-account-thirdweb.md) |
+| Trust (Barz) account | 10 | 3 | 2 | 0 | [01-account-trust.md](01-account-trust.md) |
+| Etherspot account | 11 | 2 | 3 | 0 | [01-account-etherspot.md](01-account-etherspot.md) |
+| Biconomy (legacy) account | 18 | 1 | 5 | 1 | [01-account-biconomy.md](01-account-biconomy.md) |
+| UserOp types/packing/hashing | 15 | 4 | 3 | 1 | [02-userop-encoding.md](02-userop-encoding.md) |
+| Actions (smartAccount + 7579) | 8 | 10 | 0 | 1 | [03-actions.md](03-actions.md) |
+| Pimlico/Etherspot clients | 5 | 3 | 0 | 2 | [04a-clients-pimlico-etherspot.md](04a-clients-pimlico-etherspot.md) |
+| Core client pipeline | 7 | 6 | 2 | 1 | [04b-clients-core.md](04b-clients-core.md) |
+| Utils | 9 | 4 | 2 | 5 | [05-utils.md](05-utils.md) |
+| Experimental/errors/types | 12 | 5 | 2 | 2 | [06-experimental-errors-types.md](06-experimental-errors-types.md) |
+
+## P0 — Runtime-breaking, independently verified
+
+1. **Four wrong ERC-7579 selectors** (`lib/src/utils/erc7579.dart:81-93`): `uninstallModule` `0xa4d6f1d2`→should be `0xa71763a8`, `isModuleInstalled` `0x6d61fe70`→`0x112d3a7d` (that value is actually `onInstall(bytes)`), `supportsModule` `0x12d79da3`→`0xf2dc691d`, `accountId` `0x7b60424a`→`0x9cfd7cff`. Uninstall calldata reverts; queries silently return `false`/`''`. Tests lock in the wrong values (`test/utils/erc7579_test.dart:327-343`). *Verified with `cast sig`; found independently by two audit passes.* → Ticket 001
+2. **Kernel v0.2.4 execute/executeBatch use SimpleAccount selectors** (`accounts/kernel/constants.dart:132,135`): `0xb61d27f6`/`0x47e1da2a` instead of Kernel v2's `0x51945447`/`0x34fcd5be`; parameter bodies don't match either. Every v0.2.4 call reverts. *Verified with `cast sig`.* → Ticket 002
+3. **Nexus `signUserOperation` prepends the K1 validator address** (85 bytes, `accounts/nexus/nexus_account.dart:264-275`); JS returns the bare 65-byte signature (`toNexusSmartAccount.ts:346-348`). Nexus selects the validator via the nonce key and forwards the signature untouched → AA24 on-chain. *Verified by reading both sides.* → Ticket 003
+4. **Thirdweb salt encoding**: JS UTF-8-encodes the salt string (`toThirdwebSmartAccount.ts:144,159`); Dart hex-decodes it (`thirdweb_account.dart:173-174`) → different factoryData and **different counterfactual addresses** for any non-default salt. → Ticket 004
+5. **Three broken Pimlico client actions** (`clients/pimlico/pimlico_client.dart`): `validateSponsorshipPolicies` sends `pimlico_validateSponsorshipPolicies` instead of `pm_validateSponsorshipPolicies` (:286-309); `estimateErc20PaymasterCost` calls a nonexistent RPC method instead of computing locally (:239-255); `sendCompressedUserOperation` sends 4 params in the wrong shape vs the API's 3 (:?). → Ticket 005
+6. **Safe v1.5.0 `MULTI_SEND_CALL_ONLY` address wrong** (`accounts/safe/constants.dart:196`): `0x0c28E9886f79618371c5Af86aA7e5Cf62dddd8dC` vs reference `0xA83c336B20401Af773B6219BA5027174338D1836`. *Verified by diffing both tables; all other v1.5.0 addresses match.* → Ticket 006
+7. **Simple account v0.6 `executeBatch` emits the v0.7 selector** `0x47e1da2a` (3 arrays) instead of v0.6's `0x18dfb3c7` (`address[],bytes[]`); v0.8 non-7702 batching and signing also follow v0.7 shapes instead of the v0.8 forms. → Ticket 007
+
+## P1 — Systemic
+
+8. **ERC-1271 `signMessage`/`signTypedData` broken across accounts** — one root cause, many sites: Dart computes the account's EIP-712 wrapper digest and then signs it via `signPersonalMessage`, adding a second EIP-191 prefix (Light :392, Thirdweb :334-349, Trust :353-355, Etherspot :423-446, Biconomy :354-358 double-prefix variant), Kernel skips the wrap + validator prefix entirely (:655-690), and Safe omits the whole SafeMessage wrapper + eth_sign V adjustment (:865-911). Cross-executed byte-for-byte against viem for Trust and Etherspot: outputs differ; on-chain `isValidSignature` fails. The 7702 Kernel class does it correctly and Nexus's ERC-7739 path mirrors — proof the right pattern exists in-repo. → Ticket 008
+9. **EP v0.6 signing configured-but-unimplemented** in Light, Thirdweb, Simple (accounts accept `v06` config, derive v0.6 addresses, then throw or mis-pack at signing); Safe has the v0.6 address table but signs SafeOp v0.7-only. → Ticket 009
+10. **Missing library-wide vs JS**: `decodeCalls`, `sign({hash})`, configurable `nonceKey`, EntryPoint address override. → Ticket 014
+11. **No unit tests** for Biconomy, Nexus, Thirdweb, Trust — precisely where P0/P1 bugs hid. → Ticket 012
+
+## P2 — Behavioral divergences (see unit reports)
+
+- `revertOnError` execution-mode bit inverted (`utils/erc7579.dart:202`) → Ticket 010
+- `writeContract`'s hand-rolled ABI encoder mis-encodes dynamic `bytes`, lacks strings/arrays/tuples (`actions/smart_account/smart_account_actions.dart:122-338`) → Ticket 011
+- Client pipeline semantics: no partial-override merge, always re-estimates gas, `waitForUserOperationReceipt` returns null on timeout (viem throws), paymaster RPC param arity, revert-decoding `getSenderAddress`, no fee-estimation middleware hook → Ticket 013
+- Kernel: default version 0.3.1 vs JS 0.3.0-beta (different counterfactual addresses), missing versions/`useMetaFactory`/migration path, ECDSA signUserOperation signs raw hash where JS EIP-191-wraps → Ticket 015
+- Safe: default threshold 1 vs owners.length (different multi-owner addresses), batches via MultiSend-delegatecall vs MultiSendCallOnly, divergent stub signatures, hardcoded proxy creation code, missing setup params/7579-v1.5.0 guard → Ticket 016
+- passkeyServer actions/client not ported (the `permissionless_passkeys` package is client-side only) → Ticket 017
+- Misc edges: sendTransaction returns userOpHash on timeout instead of throwing; EIP-5792 status edge handling; shallow AA## error mapping; EIP-712 edge cases (custom domain type, `codeUnits` vs UTF-8); ERC-20 paymaster extra round-trip + API shape → Ticket 018
+- Stale root `CLAUDE.md` (wrong directory names/layout for this workspace) → Ticket 019
+
+## Notes on "mirrors" confidence
+
+Several agents validated mirrors claims by *execution*, not inspection: Trust and Etherspot cross-executed every byte-producing path against viem with identical inputs; Safe verified CREATE2 math against JS-0.3.5-generated test vectors; Biconomy diffed proxy creation code byte-identical and re-derived all selectors. UserOp packing/hashing was verified against viem's `getUserOperationHash` for all three EP versions.
+
+## Gap tickets
+
+Agent-ready tickets live in `.scratch/parity-audit/issues/` (this repo), numbered 001–019 with priorities and blocking edges. Work P0s first; ticket 012 (tests) is blocked by the fixes it must not lock out.

--- a/docs/parity-audit/01-account-biconomy.md
+++ b/docs/parity-audit/01-account-biconomy.md
@@ -1,0 +1,137 @@
+# Parity Audit: Biconomy Smart Account (legacy/deprecated)
+
+**JS reference**: permissionless.js v0.3.5 — `accounts/biconomy/toBiconomySmartAccount.ts`, `accounts/biconomy/abi/BiconomySmartAccountAbi.ts`
+**Dart port**: permissionless.dart v0.3.0 — `lib/src/accounts/biconomy/biconomy_account.dart`, `lib/src/accounts/biconomy/constants.dart`, `lib/src/accounts/biconomy/biconomy.dart`
+
+Paths below are relative to:
+
+- JS: `/Users/liorag/Documents/development/permissionless/permissionless.js/packages/permissionless/`
+- Dart: `/Users/liorag/Documents/development/permissionless/permissionless.dart/packages/permissionless/`
+
+Scope: behavioral parity of the deprecated EntryPoint v0.6 Biconomy Smart Account. All constants were read on both sides; the proxy creation code strings were diffed programmatically (identical, 578 hex chars); all five function selectors were re-derived with `cast sig` and match both sides.
+
+## Verdict table
+
+| # | Aspect | Verdict | JS | Dart |
+|---|--------|---------|----|------|
+| 1 | Factory address `0x000000a56Aaca3e9a4C479ea6b6CD0DbcB6634F5` | mirrors | toBiconomySmartAccount.ts:54 | constants.dart:15-16 |
+| 2 | Account v2.0 logic address `0x0000002512019Dafb59528B82CB92D3c5D2423aC` | mirrors | toBiconomySmartAccount.ts:55 | constants.dart:19-20 |
+| 3 | Default fallback handler `0x0bBa6d96BD616BedC6BFaa341742FD43c60b83C1` | mirrors | toBiconomySmartAccount.ts:56-57 | constants.dart:23-24 |
+| 4 | ECDSA Ownership Registry Module `0x0000001c5b32F37F5beA87BDD5374eB2aC54eA8e` | mirrors | toBiconomySmartAccount.ts:52-53 | constants.dart:11-12 |
+| 5 | Proxy creation code (CREATE2 bytecode) | mirrors | toBiconomySmartAccount.ts:36-37 | biconomy_account.dart:200-201 |
+| 6 | Function selectors (execute_ncC `0x0000189a`, executeBatch_y6U `0x00004680`, deployCounterFactualAccount `0xdf20ffbc`, initForSmartAccount `0x2ede3bc0`, init `0x378dfd8e`) | mirrors | abi/BiconomySmartAccountAbi.ts:20,52,71,100,123 | constants.dart:37-53 |
+| 7 | factoryData: `deployCounterFactualAccount(module, initForSmartAccount(owner), index)` | mirrors | toBiconomySmartAccount.ts:67-91, 209-218 | biconomy_account.dart:214-240 |
+| 8 | initCode composition (factory ++ factoryData) | mirrors | via viem `toSmartAccount` + getFactoryArgs (toBiconomySmartAccount.ts:209-218) | biconomy_account.dart:204-211 |
+| 9 | Counterfactual address: CREATE2 over `init(fallbackHandler, module, initData)` salted with keccak(keccak(initData) ++ index), bytecode = creationCode ++ uint256(logic) | mirrors | toBiconomySmartAccount.ts:128-179 | biconomy_account.dart:148-196 |
+| 10 | Stub/dummy signature (module-wrapped, fixed 65-byte sig) | mirrors | toBiconomySmartAccount.ts:303-306 | biconomy_account.dart:323-332 |
+| 11 | signUserOperation: v0.6 userOpHash → EIP-191 personal sign of raw hash → abi.encode(bytes sig, address module) | mirrors | toBiconomySmartAccount.ts:347-372 | biconomy_account.dart:336-342, 382-413 |
+| 12 | Module signature wrapper `abi.encode(bytes, address)` layout | mirrors | toBiconomySmartAccount.ts:367-370 (also 324-327, 341-344) | biconomy_account.dart:374-379 |
+| 13 | Single call: `execute_ncC(to, value, data)` | mirrors | toBiconomySmartAccount.ts:266-271 | biconomy_account.dart:244-252 |
+| 14 | Batch call: `executeBatch_y6U(address[], uint256[], bytes[])` | mirrors | toBiconomySmartAccount.ts:248-259 | biconomy_account.dart:267-320 |
+| 15 | encodeCalls dispatch (0 calls → throw, 1 → single, >1 → batch) | mirrors | toBiconomySmartAccount.ts:247-272 | biconomy_account.dart:256-264 |
+| 16 | decodeCalls | missing | toBiconomySmartAccount.ts:273-301 | — (no counterpart) |
+| 17 | signMessage (ERC-1271 personal-sign path) | **diverges** | toBiconomySmartAccount.ts:310-328 | biconomy_account.dart:354-358 |
+| 18 | signTypedData (incl. v normalization) | mirrors | toBiconomySmartAccount.ts:329-345 | biconomy_account.dart:362-365; account_owner.dart:151-168 |
+| 19 | `sign({ hash })` method | missing | toBiconomySmartAccount.ts:307-309 | — (no counterpart) |
+| 20 | EntryPoint v0.6 only (v0.7 rejected) | mirrors | toBiconomySmartAccount.ts:107-110, 119-122 (type-enforced `"0.6"`) | biconomy_account.dart:104, 114-115, 344-350 (`signUserOperation` v0.7 throws `UnsupportedError`) |
+| 21 | EntryPoint v0.6 address `0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789` | mirrors | viem `entryPoint06Address` (toBiconomySmartAccount.ts:202) | constants/entry_point.dart:14-15 |
+| 22 | Custom entryPoint address override | missing | toBiconomySmartAccount.ts:107-110, 201-205 | — (hard-coded, biconomy_account.dart:114-115) |
+| 23 | `nonceKey` parameter | missing | toBiconomySmartAccount.ts:111, 239-246 | — (hard-coded `BigInt.zero`, biconomy_account.dart:117-119) |
+| 24 | `accountLogicAddress` / `fallbackHandlerAddress` overrides | missing | toBiconomySmartAccount.ts:115-116, 193-194 | — (config exposes only factory + ECDSA module, biconomy_account.dart:34-35, 50-53) |
+| 25 | Deprecation notes (points to Nexus) | mirrors | toBiconomySmartAccount.ts:181-184 (`@deprecated`) | biconomy_account.dart:16, 80, 419 (`@Deprecated`); constants.dart:6, 31; biconomy.dart:1-17 |
+| 26 | Inert `publicClient` config parameter | dart-only | — | biconomy_account.dart:28, 36, 55-56 |
+
+**Counts**: 18 mirrors, 1 diverges, 5 missing, 1 dart-only.
+
+Notes on verified byte-level details:
+
+- Selectors re-derived with `cast sig`: all five match the Dart constants and the JS ABI function signatures exactly.
+- The stub signature bodies are the identical hex string on both sides (offset `0x40`, module address word, length `0x41`, fixed 65-byte signature, trailing zero padding). The JS version embeds the module address with checksum casing and Dart with lowercase (`EthereumAddress.hex`), which is byte-identical after hex decoding — not a divergence.
+- The Dart v0.6 userOpHash (`_computeUserOpHashV06` / `_packUserOpForHashV06`, biconomy_account.dart:382-413) reproduces viem's `getUserOperationHash` for EP v0.6: `keccak256(abi.encode(keccak256(packedOp), entryPoint, chainId))` with `packedOp = abi.encode(sender, nonce, keccak(initCode), keccak(callData), callGasLimit, verificationGasLimit, preVerificationGas, maxFeePerGas, maxPriorityFeePerGas, keccak(paymasterAndData))`. Mirrors.
+- V-value normalization: JS normalizes non-27/28 v to +27 in signMessage/signTypedData (toBiconomySmartAccount.ts:315-323, 332-340). Dart's `PrivateKeyOwner` produces v=27/28 natively for personal sign (web3dart) and normalizes `v < 27 → +27` for raw/typed-data signing (account_owner.dart:142-147, 162-167). Equivalent behavior.
+
+---
+
+## Finding 17 (diverges): `signMessage` applies the EIP-191 prefix twice
+
+**JS** — `toBiconomySmartAccount.ts:310-313`:
+
+```ts
+async signMessage({ message }) {
+    let signature = await localOwner.signMessage({ message })
+```
+
+viem's `LocalAccount.signMessage` computes `digest = keccak256("\x19Ethereum Signed Message:\n" + len(message) + message)` and signs **that digest raw** (one prefix application). The result is then module-wrapped (ts:324-327).
+
+**Dart** — `biconomy_account.dart:354-358`:
+
+```dart
+Future<String> signMessage(String message) async {
+  final messageHash = hashMessage(message);
+  final signature = await _config.owner.signPersonalMessage(messageHash);
+  return _encodeModuleSignature(signature);
+}
+```
+
+`hashMessage` (utils/message_hash.dart:22-36) already produces `keccak256(prefix(message))` — the same digest viem signs. But `signPersonalMessage` (account_owner.dart:116-129, via web3dart `signPersonalMessageToUint8List`) then prefixes **again** with `"\x19Ethereum Signed Message:\n32"` before hashing and signing.
+
+Net effect:
+
+- JS signs: `keccak256(prefix_N ++ message)`
+- Dart signs: `keccak256(prefix_32 ++ keccak256(prefix_N ++ message))`
+
+For the same input message the two produce different signatures, so ERC-1271 verification against the ECDSA Ownership module will not agree between the two SDKs. (`signUserOperation` is NOT affected — there the JS side signs the raw userOpHash via `message: { raw: hash }`, i.e. one prefix over the 32-byte hash, which matches Dart's `signPersonalMessage(userOpHash)` exactly.)
+
+Fix direction: `signMessage` should sign the `hashMessage` digest raw (e.g. `signRawHash`) or pass the original message string through a personal-sign that prefixes once.
+
+---
+
+## Finding 16 (missing): `decodeCalls`
+
+**JS** — `toBiconomySmartAccount.ts:273-301` implements `decodeCalls`, decoding `execute_ncC` and `executeBatch_y6U` calldata back to `{to, value, data}[]` and throwing `"Invalid function name"` otherwise.
+
+**Dart** — no counterpart in `biconomy_account.dart`, and the `SmartAccountV06`/`SmartAccount` interface (lib/src/clients/smart_account/smart_account_interface.dart:20-120) defines no `decodeCalls` member at all — this is a port-wide interface gap, not Biconomy-specific, but it means calldata introspection available in JS has no Dart equivalent.
+
+---
+
+## Finding 19 (missing): `sign({ hash })`
+
+**JS** — `toBiconomySmartAccount.ts:307-309`:
+
+```ts
+async sign({ hash }) {
+    return this.signMessage({ message: hash })
+}
+```
+
+**Dart** — no `sign` method exists on `BiconomySmartAccount` or its interface. Minor; primarily used by viem's ERC-1271/hash-signing plumbing.
+
+---
+
+## Finding 22 (missing): custom EntryPoint address override
+
+**JS** — `ToBiconomySmartAccountParameters.entryPoint` accepts `{ address, version: "0.6" }` (toBiconomySmartAccount.ts:107-110) and the account uses `parameters.entryPoint?.address ?? entryPoint06Address` (ts:201-205).
+
+**Dart** — `entryPoint` is hard-coded to `EntryPointAddresses.v06` (biconomy_account.dart:114-115) with no config field. Default behavior is identical (canonical v0.6 address, verified constants/entry_point.dart:14-15); only the override capability is absent.
+
+---
+
+## Finding 23 (missing): configurable `nonceKey`
+
+**JS** — `nonceKey?: bigint` parameter (toBiconomySmartAccount.ts:111) is fed into `getAccountNonce` as the 2D-nonce key (ts:239-246).
+
+**Dart** — `nonceKey` is a fixed getter returning `BigInt.zero` (biconomy_account.dart:117-119); `BiconomySmartAccountConfig` has no such field. The client consumes `account.nonceKey` (clients/smart_account/smart_account_client.dart:225-228), so the plumbing exists — only the configuration knob is missing. Behavior at defaults is identical (key 0).
+
+---
+
+## Finding 24 (missing): `accountLogicAddress` / `fallbackHandlerAddress` overrides
+
+**JS** — both are optional parameters (toBiconomySmartAccount.ts:115-116) defaulted from `BICONOMY_ADDRESSES` (ts:193-194) and used in counterfactual address computation (ts:228-235).
+
+**Dart** — `BiconomySmartAccountConfig` exposes only `customFactoryAddress` and `customEcdsaModuleAddress` (biconomy_account.dart:34-35, 50-53); `_computeAccountAddress` reads `BiconomyAddresses.defaultFallbackHandler` and `BiconomyAddresses.accountV2Logic` directly (biconomy_account.dart:159, 180). Defaults produce byte-identical addresses; only non-default deployments cannot be targeted from Dart.
+
+---
+
+## Finding 26 (dart-only): inert `publicClient` config parameter
+
+`BiconomySmartAccountConfig.publicClient` (biconomy_account.dart:28, 36, 55-56) is documented as "Client for computing the account address via RPC" but is never referenced anywhere in the implementation — `getAddress` always computes the CREATE2 address locally (biconomy_account.dart:129-145). Harmless dead configuration; either wire it up or remove it. (Relatedly, Dart requires `chainId` in the config whereas JS derives it from `client.chain` — a constructor-shape difference with no behavioral impact given a correct chainId.)

--- a/docs/parity-audit/01-account-etherspot.md
+++ b/docs/parity-audit/01-account-etherspot.md
@@ -1,0 +1,88 @@
+# Parity Audit 01 — Etherspot Modular Smart Account
+
+**Scope:** `toEtherspotSmartAccount` (permissionless.js v0.3.5) vs `EtherspotSmartAccount` (permissionless.dart v0.3.0).
+
+**Reference (JS):**
+- `permissionless.js/packages/permissionless/accounts/etherspot/toEtherspotSmartAccount.ts`
+- `.../etherspot/constants.ts`, `.../etherspot/utils/getInitMSAData.ts`, `.../etherspot/utils/getNonceKey.ts`, `.../etherspot/utils/wrapMessageHash.ts`, `.../etherspot/abi/EtherspotBootstrapAbi.ts`
+- `permissionless.js/packages/permissionless/utils/encode7579Calls.ts`, `.../actions/erc7579/supportsExecutionMode.ts`
+
+**Port (Dart):**
+- `permissionless.dart/packages/permissionless/lib/src/accounts/etherspot/etherspot_account.dart`
+- `.../etherspot/constants.dart`, `.../etherspot/etherspot.dart`
+- `.../lib/src/utils/erc7579.dart`, `.../lib/src/accounts/account_owner.dart`
+
+## Method
+
+Every static aspect was compared by reading both sides. Every byte-producing path was executed on both sides with identical inputs (owner private key `0x…01`, chainId `11155111`, index `{0,5}`, fixed calls and a fixed UserOperation) and the outputs compared byte-for-byte. JS vectors were produced against the repo's own `viem`; Dart vectors against the package under `dart --packages`.
+
+## Verdict table
+
+| Aspect | Verdict |
+| --- | --- |
+| Factory / metaFactory address | mirrors |
+| Bootstrap address | mirrors |
+| Validator (multiple-owner ECDSA) address | mirrors |
+| initMSA bootstrap init data | mirrors |
+| initCode / factoryData (createAccount + salt/index) | mirrors |
+| Dummy / stub signature | mirrors |
+| execute calldata (ERC-7579 single, mode encoding) | mirrors |
+| execute calldata (ERC-7579 batch) | mirrors |
+| signUserOperation path (userOpHash + signature) | mirrors |
+| EntryPoint version / address handling | mirrors (default); custom EP address override **missing** |
+| Nonce key encoding (default key) | mirrors |
+| Configurable `nonceKey` parameter | missing |
+| signMessage wrapping | **diverges** |
+| signTypedData wrapping | **diverges** |
+| `sign({ hash })` (ERC-1271 style entry) | missing |
+
+## Byte-for-byte confirmations (mirrors)
+
+- **Addresses** — `constants.ts:23-27` and `constants.dart:15-27` are identical: metaFactory `0x2A40091f044e48DEB5C0FCbc442E443F3341B451`, bootstrap `0x0D5154d7751b6e2fDaa06F0cC9B400549394C8AA`, validator `0x0740Ed7c11b9da33d9C80Bd76b826e4E90CC1906`.
+- **Selectors** — createAccount `0xf8a59370`, initMSA `0x642219af`, onInstall `0x6d61fe70`, ERC-7579 execute `0xe9ae5c53`. Confirmed against `toFunctionSelector` and matching `EtherspotSelectors` (`constants.dart:36-50`) / `Erc7579Selectors.execute` (`erc7579.dart:70`). (Note `EtherspotSelectors.execute = 0x61461954` at `constants.dart:50` is dead — encoding uses the ERC-7579 selector `0xe9ae5c53`; harmless.)
+- **factoryData** — for index 0 and 5 the JS `getAccountInitCode` (`toEtherspotSmartAccount.ts:134-159`) and Dart `getFactoryData`/`_encodeInitCode`/`_encodeInitMSA` (`etherspot_account.dart:180-390`) produce identical bytes, including the `initMSA` header offsets `0x80/0x180/0x280/0x340`, the validators/executors/fallbacks arrays each containing one entry, the single hook tuple, and the `onInstall(0x)` payloads. Salt is `toHex(index,{size:32})` on both sides.
+- **Stub signature** — `DUMMY_ECDSA_SIGNATURE` (`constants.ts:3-4`) equals `etherspotDummyEcdsaSignature` (`constants.dart:54-55`); string-diff confirmed identical.
+- **execute calldata** — single-call (mode byte0 `0x00`, byte1 `0x00` because `revertOnError:false`) and batch (mode byte0 `0x01`) outputs match byte-for-byte. JS `encode7579Calls` (`encode7579Calls.ts`) with `encodeExecutionMode` (`supportsExecutionMode.ts:46-62`) vs Dart `encode7579Execute`/`encode7579ExecuteBatch` (`erc7579.dart:334-378`). Both encode single as packed `to‖value(32)‖data`, batch as `Execution[]` tuple array.
+- **signUserOperation** — v0.7 packing and `getUserOperationHash` agree: identical `userOpHash` `0x76a1…bb62` and identical signature `0x4de4…1b`. JS signs `localOwner.signMessage({ message: { raw: hash } })` (`toEtherspotSmartAccount.ts:347-366`); Dart signs `owner.signPersonalMessage(opHash)` (`etherspot_account.dart:410-418`). Both apply the EIP-191 prefix to the 32-byte hash exactly once, and neither wraps the result with the validator address — matching intent and bytes.
+- **Nonce key (default)** — JS `getNonceKeyWithEncoding` (`getNonceKey.ts:4-21`) and Dart `nonceKey` getter (`etherspot_account.dart:125-138`) both produce `0x740ed7c11b9da33d9c80bd76b826e4e90cc190600000000` (validator‖mode`00`‖type`00`‖key`0000`, left-padded to 24 bytes).
+- **EntryPoint** — both default to v0.7 at `0x0000000071727De22E5E9d8BAf0edAc6f37da032` (`entry_point.dart:21-22`) and v0.7 packing only.
+
+## Diverges / missing findings
+
+### 1. signMessage wrapping — diverges
+
+**JS** (`toEtherspotSmartAccount.ts:311-328`): signs the raw personal-message signature over the message, corrects V to 27/28, and packs `encodePacked(["address","bytes"], [validatorAddress, signature])`. Crucially, `localOwner.signMessage({ message })` computes `hashMessage(message)` and signs that hash **once** (EIP-191 applied a single time).
+
+**Dart** (`etherspot_account.dart:423-432`): computes `hashMessage(message)` and then calls `owner.signPersonalMessage(messageHash)`. `PrivateKeyOwner.signPersonalMessage` (`account_owner.dart:116-129`) applies the EIP-191 prefix **again** to the already-hashed message before signing — a double prefix.
+
+**Evidence (message `"hello etherspot"`):**
+- JS wrapped: `0x0740…1906` + body `7227dee3…336d1c`
+- Dart wrapped: `0x0740…1906` + body `2163475b…241d61b`
+
+The validator-prefix envelope matches, but the signature body differs. Signing the message hash *raw* on the Dart side reproduces the JS body exactly: `owner.signRawHash(hashMessage(...)) = 7227dee3…336d1c`. So the fix is to sign the hash raw (as viem does) rather than via `signPersonalMessage`. As written, an on-chain ERC-1271 `isValidSignature` check would recover a different signer than JS produces.
+
+### 2. signTypedData wrapping — diverges
+
+Same root cause. **JS** (`toEtherspotSmartAccount.ts:329-345`) signs the EIP-712 digest via `localOwner.signTypedData(typedData)` (digest signed raw, once), then packs `[validatorAddress, signature]`. **Dart** (`etherspot_account.dart:437-446`) computes `hashTypedData(typedData)` then `owner.signPersonalMessage(hash)`, adding an EIP-191 prefix over the 712 digest.
+
+**Evidence (fixed typed data):**
+- JS wrapped: `0x0740…1906` + body `dd2e6d36…f598e51b`
+- Dart wrapped: `0x0740…1906` + body `60751a9d…3b58321c`
+
+Signing the 712 digest raw on the Dart side reproduces JS: `owner.signRawHash(hashTypedData(...)) = dd2e6d36…f598e51b` (and `owner.signTypedData(typedData)` yields the same). The Dart method should use raw-hash signing, not `signPersonalMessage`.
+
+> Note: neither the JS nor the Dart `signMessage`/`signTypedData` applies the `wrapMessageHash` (ERC-7739 / EIP-712 nested-domain) wrapper that Nexus/Kernel use — the file `etherspot/utils/wrapMessageHash.ts` exists but is unused by `toEtherspotSmartAccount`. So this is purely the double-prefix bug, not a missing wrapper.
+
+### 3. Configurable `nonceKey` — missing
+
+**JS** threads `parameters.nonceKey ?? 0n` into `getNonceKeyWithEncoding` (`toEtherspotSmartAccount.ts:299-302`, `getNonceKey.ts:14-16`), placing the 2-byte user key at the tail of the 24-byte encoding.
+
+**Dart** hardcodes the suffix to `'0000'` (`etherspot_account.dart:133`) and exposes no `nonceKey` field on `EtherspotSmartAccountConfig`. Default (key 0) behavior is identical; a non-zero user nonce key cannot be expressed. Low severity.
+
+### 4. Custom EntryPoint address override — missing
+
+**JS** accepts `entryPoint: { address, version }` and uses `parameters.entryPoint?.address ?? entryPoint07Address` (`toEtherspotSmartAccount.ts:176-179, 222-226`). **Dart** hardcodes `entryPoint => EntryPointAddresses.v07` (`etherspot_account.dart:121-122`) with no override. Both restrict version to v0.7, so default behavior mirrors; only a non-standard EP address deployment is unsupported. Low severity.
+
+### 5. `sign({ hash })` entry point — missing
+
+**JS** exposes `sign({ hash })` routed to `signMessage({ message: hash })` (`toEtherspotSmartAccount.ts:308-310`), used by generic signing/ERC-1271 flows. The Dart `SmartAccount` surface exposes `signMessage`, `signTypedData`, and `signUserOperation` but no generic `sign(hash)`. Low severity; also note that even if added it would inherit the divergence in finding 1.

--- a/docs/parity-audit/01-account-kernel.md
+++ b/docs/parity-audit/01-account-kernel.md
@@ -1,0 +1,175 @@
+# Parity Audit: Kernel (ZeroDev) Smart Account
+
+**Scope:** permissionless.js v0.3.5 `accounts/kernel/` vs permissionless.dart v0.3.0 `lib/src/accounts/kernel/`
+
+**JS files audited:**
+- `permissionless.js/packages/permissionless/accounts/kernel/toKernelSmartAccount.ts`
+- `permissionless.js/packages/permissionless/accounts/kernel/toEcdsaKernelSmartAccount.ts`
+- `permissionless.js/packages/permissionless/accounts/kernel/to7702KernelSmartAccount.ts`
+- `permissionless.js/packages/permissionless/accounts/kernel/constants.ts`
+- `permissionless.js/packages/permissionless/accounts/kernel/utils/{encodeCallData,decodeCallData,getNonceKey,isKernelV2,signMessage,signTypedData,wrapMessageHash}.ts`
+- `permissionless.js/packages/permissionless/accounts/kernel/abi/*.ts`
+- `permissionless.js/packages/permissionless/utils/encode7579Calls.ts`, `actions/erc7579/supportsExecutionMode.ts` (mode encoding)
+
+**Dart files audited:**
+- `permissionless.dart/packages/permissionless/lib/src/accounts/kernel/kernel_account.dart`
+- `permissionless.dart/packages/permissionless/lib/src/accounts/kernel/eip7702_kernel_account.dart`
+- `permissionless.dart/packages/permissionless/lib/src/accounts/kernel/constants.dart`
+- `permissionless.dart/packages/permissionless/lib/src/accounts/kernel/kernel.dart`
+- Supporting: `lib/src/utils/erc7579.dart`, `lib/src/utils/webauthn_encoding.dart`, `lib/src/accounts/account_owner.dart`, `lib/src/utils/message_hash.dart`
+
+All function selectors below were independently verified with `cast sig`.
+
+---
+
+## Verdict Table
+
+| # | Aspect | Verdict |
+|---|--------|---------|
+| 1 | Contract addresses for shared versions (0.2.4, 0.3.1, 0.3.3) | mirrors |
+| 2 | Version coverage (0.2.1–0.2.3, 0.3.0-beta, 0.3.2) | missing (M1) |
+| 3 | Default Kernel version for EP v0.7 (JS: 0.3.0-beta, Dart: 0.3.1) | diverges (D4) |
+| 4 | EP v0.6 factoryData: `createAccount(address,bytes,uint256)` + `initialize(address,bytes)` | mirrors |
+| 5 | EP v0.7 factoryData: metaFactory `deployWithFactory(address,bytes,bytes32)`, salt = bytes32(index) | mirrors |
+| 6 | `useMetaFactory: false / "optional"` factory paths | missing (M2) |
+| 7 | v0.3.1+ `initialize(bytes21,address,bytes,bytes,bytes[])` rootValidator encoding (`0x01 ++ validator`, hook=0, initConfig=[]) | mirrors |
+| 8 | WebAuthn validator init data (`tuple(x,y)`, `keccak256(credentialId)`) | mirrors |
+| 9 | Address resolution via `getSenderAddress` / explicit address | mirrors |
+| 10 | **v0.2.x execute / executeBatch calldata selectors** | **diverges (D1, critical)** |
+| 11 | v0.3.x ERC-7579 execute encoding (mode bytes, packed single call, batch tuple[]) | mirrors |
+| 12 | Unpatched-kernel migration in `encodeCalls` (`MIGRATION_HELPER_ADDRESS`, `rootValidator` patch check) | missing (M4) |
+| 13 | `decodeCalls` | missing (M5) |
+| 14 | Nonce key structural encoding (v3: `00 ‖ 00 ‖ validator ‖ 0000` = 24 bytes; v2: plain) | mirrors |
+| 15 | Custom `nonceKey` parameter (JS: ≤ maxUint16 for v3, passthrough for v2) | missing (M3) |
+| 16 | Dummy/stub signature — v2 (`0x00000000 ++ dummy`) and v3 ECDSA | mirrors |
+| 17 | Dummy/stub signature — v3 WebAuthn | diverges (D5, minor) |
+| 18 | **signUserOperation (ECDSA): EIP-191 wrap of userOpHash** | **diverges (D3)** |
+| 19 | signUserOperation v2 sudo prefix `0x00000000` | mirrors |
+| 20 | **signMessage / signTypedData (ERC-1271): Kernel EIP-712 wrapping + root-validator prefix** | **diverges (D2, major)** |
+| 21 | EP v0.6 vs v0.7 dispatch & userOpHash computation (incl. `signUserOperationV06` path) | mirrors |
+| 22 | 7702: address = EOA, no factory, authorization → accountLogic (0.3.3) | mirrors |
+| 23 | 7702: userOp signing (EIP-191 wrap + raw ECDSA, no prefix) | mirrors |
+| 24 | 7702: 1271 signing (Kernel EIP-712 domain typed-data + `0x00` EIP7702 identifier prefix) | mirrors |
+| 25 | 7702: pre-delegation 1271 guard | mirrors (with caveat: Dart skips check when no `publicClient`) |
+| 26 | `toEcdsaKernelSmartAccount` deprecated alias | missing (M6, trivial) |
+| 27 | WebAuthn owner allowed on v0.3.3 (JS has no WEB_AUTHN_VALIDATOR for 0.3.2/0.3.3 and throws) | dart-only (O1) |
+| 28 | Dynamic RIP-7212 precompile detection for WebAuthn | dart-only (O2) |
+| 29 | Explicit `signUserOperationV06` / separate `Eip7702KernelSmartAccount` class | dart-only (O3, behavior-equivalent) |
+
+**Counts:** mirrors: 15 · diverges: 4 · missing: 6 · dart-only: 3
+
+---
+
+## D1 (critical) — Kernel v0.2.x execute/executeBatch use wrong function selectors
+
+**Verdict: diverges.** Any single or batch call on a Kernel v0.2.4 account produced by the Dart library targets non-existent functions and will revert on-chain.
+
+JS encodes v2 calls against `KernelExecuteAbi`:
+
+- `permissionless.js/.../accounts/kernel/utils/encodeCallData.ts:19-46` — `encodeFunctionData({ abi: KernelExecuteAbi, functionName: "execute" | "executeBatch", ... })`
+- `permissionless.js/.../accounts/kernel/abi/KernelAccountAbi.ts:4-60` — `execute(address to, uint256 value, bytes data, uint8 operation)` and `executeBatch((address,uint256,bytes)[] calls)`
+
+Correct selectors (verified with `cast sig`):
+
+- `execute(address,uint256,bytes,uint8)` → **`0x51945447`**
+- `executeBatch((address,uint256,bytes)[])` → **`0x34fcd5be`**
+
+Dart hardcodes the **SimpleAccount** selectors instead:
+
+- `permissionless.dart/.../lib/src/accounts/kernel/constants.dart:132` — `executeV2 = '0xb61d27f6'` — this is `execute(address,uint256,bytes)` (3-arg SimpleAccount form), yet `kernel_account.dart:471-478` appends **four** parameters (to, value, data-offset, operation) after it. Wrong selector *and* the body doesn't even match the selector's signature.
+- `permissionless.dart/.../lib/src/accounts/kernel/constants.dart:135` — `executeBatchV2 = '0x47e1da2a'` — this is `executeBatch(address[],uint256[],bytes[])` (SimpleAccount), while `kernel_account.dart:497-525` encodes the Kernel tuple-array layout after it.
+
+Fix: change `executeV2` to `0x51945447` and `executeBatchV2` to `0x34fcd5be` (parameter encoding in `_encodeCallV2` / `_encodeCallsV2` already matches the Kernel v2 ABI layout).
+
+---
+
+## D2 (major) — signMessage/signTypedData: no Kernel EIP-712 wrapping and no root-validator prefix (non-7702 account)
+
+**Verdict: diverges.** ERC-1271 signatures produced by the Dart `KernelSmartAccount` will not verify on-chain.
+
+JS behavior (`toKernelSmartAccount.ts:890-947` + `utils/signMessage.ts`, `utils/signTypedData.ts`, `utils/wrapMessageHash.ts`):
+
+1. For all versions except 0.2.1/0.2.2 (`signMessage.ts:100-104`), the EIP-191/EIP-712 hash is wrapped via `wrapMessageHash` (`wrapMessageHash.ts:19-43`): `digest = keccak256(0x1901 ‖ domainSeparator({name:"Kernel", version: kernelVersion, chainId, verifyingContract: account}) ‖ h)` where for v3 `h = keccak256(keccak256("Kernel(bytes32 hash)") ‖ messageHash)` and for v2 `h = messageHash`.
+2. For v3, the final signature is prefixed with the root validator identifier `0x01 ‖ validatorAddress` (`toKernelSmartAccount.ts:910-917`, `:939-946`, via `getEcdsaRootIdentifierForKernelV3` at `:255-263`). Kernel v2 returns the bare signature.
+
+Dart behavior:
+
+- `permissionless.dart/.../kernel_account.dart:655-669` (`signMessage`) — signs `hashMessage(message)` directly with `signRawHash`; no Kernel domain wrap, no `0x01 ‖ validator` prefix.
+- `permissionless.dart/.../kernel_account.dart:677-690` (`signTypedData`) — delegates to `owner.signTypedData(typedData)` (raw EIP-712 hash of the *user's* typed data, see `account_owner.dart:152-170`); no Kernel wrap, no prefix.
+- The WebAuthn branches (`kernel_account.dart:658-666`, `:678-687`) sign the unwrapped hash too, whereas JS wraps string messages/typed-data hashes before `owner.sign` (`signMessage.ts:33-44`, `signTypedData.ts:78-88`).
+
+This also affects v0.2.4: JS wraps for 0.2.3/0.2.4 (only 0.2.1/0.2.2 sign plainly, `signMessage.ts:100-104`), while Dart 0.2.4 signs plainly.
+
+Note the Dart **7702** variant does implement the correct wrapping and prefix (`eip7702_kernel_account.dart:479-510`), so the fix is to port that logic (with `0x01 ‖ validatorAddress` instead of `0x00`, and the `Kernel(bytes32 hash)` struct-hash step) into `KernelSmartAccount`.
+
+---
+
+## D3 — signUserOperation (ECDSA): Dart signs the raw userOpHash; JS signs the EIP-191-wrapped hash
+
+**Verdict: diverges.**
+
+- JS: `toKernelSmartAccount.ts:973-975` — `owner.signMessage({ message: { raw: hash } })`, i.e. the signed digest is `keccak256("\x19Ethereum Signed Message:\n32" ‖ userOpHash)`.
+- Dart: `kernel_account.dart:586` — `_config.owner.signRawHash(userOpHash)`, which signs the bare 32-byte hash with no prefix (`account_owner.dart:135-149`), for both v0.2.4 (`:588-593`, after which the `0x00000000` sudo prefix is added — the prefix itself mirrors JS `toKernelSmartAccount.ts:978-980`) and v0.3.x (`:594-597`). Same for `signUserOperationV06` (`kernel_account.dart:604-613`).
+
+Byte output differs from the JS reference. In practice ZeroDev's ECDSA validators accept **both** the raw and eth-signed digest, so operations still validate on-chain, but this is a reference divergence and is internally inconsistent with the Dart 7702 variant, which *does* apply the EIP-191 wrap (`eip7702_kernel_account.dart:329-337`, matching JS).
+
+---
+
+## D4 — Default Kernel version for EntryPoint v0.7
+
+**Verdict: diverges.**
+
+- JS: `toKernelSmartAccount.ts:195-210` — default is `"0.2.2"` for EP v0.6 and **`"0.3.0-beta"`** for EP v0.7 (and `0.3.3` when eip7702).
+- Dart: `kernel_account.dart:35` / `:784` — default is `KernelVersion.v0_3_1`; there is no v0.3.0-beta at all (see M1), and the Dart v0.6 default (v0.2.4) differs from JS's 0.2.2.
+
+Consequence: a user porting JS code without an explicit `version` gets a **different account implementation, factory, validator, and therefore a different counterfactual address**. JS 0.3.0-beta addresses (`toKernelSmartAccount.ts:163-169`): logic `0x94F097E1ebEB4ecA3AAE54cabb08905B239A7D27`, factory `0x6723b44Abeec4E71eBE3232BD5B455805baDD22f`, ECDSA validator `0x8104e3Ad430EA6d354d013A6789fDFc71E671c43` — none exist in `constants.dart`. Also note 0.3.0-beta uses the 4-arg `initialize(bytes21,address,bytes,bytes)` (`toKernelSmartAccount.ts:292-303`, selector `0x12af322c`), which Dart does not implement.
+
+---
+
+## D5 (minor) — WebAuthn stub signature contents and `usePrecompiled` flag
+
+**Verdict: diverges** (gas-estimation surface only, plus a flag difference in real signatures).
+
+- JS stub: `toKernelSmartAccount.ts:864-883` — fixed `authenticatorData` `0x49960de5...631d00000000` (37 bytes), a long fixed `clientDataJSON` (includes the "other_keys_can_be_added_here" filler), fixed r/s values, and `usePrecompiled` hard-coded to `false`. Real WebAuthn signatures also always encode `usePrecompiled: false` (`utils/signMessage.ts:63-79`, "TODO: check if it is a RIP 7212 supported network").
+- Dart stub: `kernel_account.dart:561-563` + `webauthn_encoding.dart:78-103` — 37 zero bytes of authenticatorData, a much shorter dummy clientDataJSON, different r/s, and `usePrecompiled` set dynamically from chain support (`shouldUseP256Precompile` / `isRip7212Supported`, `kernel_account.dart:543-548`, `:576-582`).
+
+Estimated calldata size differs (shorter clientDataJSON → potentially under-estimated gas vs JS), and on RIP-7212 chains Dart's real signatures set `usePrecompiled=true` where JS always sends `false`. Dart's dynamic detection is arguably an improvement, but it is a behavioral difference from the reference.
+
+---
+
+## M1 — Missing Kernel versions 0.2.1, 0.2.2, 0.2.3, 0.3.0-beta, 0.3.2
+
+JS supports eight versions (`toKernelSmartAccount.ts:123-126`, address map `:134-189`). Dart supports three (`constants.dart:4-27`, address map `:70-125`). For the three shared versions all addresses are byte-identical (verified: 0.2.4 logic `0xd3082872...`, factory `0x5de4839a...`, validator `0xd9AB5096...`; 0.3.1 logic `0xBAC849bB...`, factory `0xaac5D424...`, metaFactory `0xd703aaE7...`, validator `0x845ADb2C...`, WebAuthn `0x7ab16Ff3...`; 0.3.3 logic `0xd6CEDDe8...`, factory `0x2577507b...`, metaFactory `0xd703aaE7...`, validator `0x845ADb2C...`). Missing versions also imply the 0.3.0-beta 4-arg initialize path is absent (see D4). Additionally Dart's 0.3.3 entry declares a `webAuthnValidator` (`constants.dart:120-122`) that JS deliberately omits for 0.3.2/0.3.3 (`toKernelSmartAccount.ts:177-188`) — see O1.
+
+## M2 — Missing `useMetaFactory: false | "optional"` support
+
+JS: `toKernelSmartAccount.ts:404-410` (direct `KernelV3FactoryAbi.createAccount(bytes,bytes32)`, selector `0xea6d13ac`, when `useMetaFactory === false`) and `:659-691` (the `"optional"` probe: try meta factory, fall back to direct factory if `getSenderAddress` returns the zero address). Dart always routes v0.3.x deployment through the meta factory (`kernel_account.dart:353-379`) and returns `metaFactory` as the factory address. The `createAccountV3` selector is declared in `constants.dart:147` but never used.
+
+## M3 — Missing custom `nonceKey` parameter
+
+JS: `parameters.nonceKey` feeds `getNonceKeyWithEncoding` (`toKernelSmartAccount.ts:848-858`; `utils/getNonceKey.ts:6-34`) — for v2 the key passes through unchanged; for v3 it occupies the trailing 2 bytes of the 24-byte key (throws above `maxUint16`). Dart hardcodes the 2-byte salt to zero (`kernel_account.dart:136-161`) and returns `BigInt.zero` for v2 (`:144`); there is no config field. The structural encoding (mode `0x00` ‖ type ROOT `0x00` ‖ validator ‖ salt) otherwise mirrors JS exactly, including using the WebAuthn validator address when the owner is WebAuthn.
+
+## M4 — Missing unpatched-kernel migration logic in `encodeCalls`
+
+JS `encodeCalls` (`toKernelSmartAccount.ts:746-844`) detects accounts still rooted on the vulnerable WebAuthn validator `0xbA45a2BFb8De3D24cA9D7F1B551E14dFF5d690Fd` (`:725-726`, on-chain `rootValidator()` check against `0x017ab16ff...` at `:693-723`) and rewrites the batch into a `migrateWithCall` through `MIGRATION_HELPER_ADDRESS = 0x03EB97959433D55748839D27C93330Cb85F31A93` (`:128-129`), using a delegatecall-mode 7579 execute for v0.3.1+ (`:812-828`) or an install/migrate/uninstall sandwich for 0.3.0-beta (`:830-841`). Dart `encodeCall`/`encodeCalls` (`kernel_account.dart:462-495`) has none of this. Impact is limited because Dart never configures the vulnerable validator (its WebAuthn validator constant is the patched `0x7ab16Ff3...`), but accounts created elsewhere with the old validator cannot be migrated via the Dart SDK.
+
+## M5 — Missing `decodeCalls`
+
+JS exposes `decodeCalls` on the account (`toKernelSmartAccount.ts:845-847`, `utils/decodeCallData.ts` — v2 via `KernelExecuteAbi` decode, v3 via `decode7579Calls`). The Dart `SmartAccount` interface has no decode method for Kernel; a generic `decode7579Calls` exists in `lib/src/utils/erc7579.dart:756-833` but is not wired to the account and there is no v2 decoder.
+
+## M6 (trivial) — Missing `toEcdsaKernelSmartAccount` deprecated alias
+
+JS keeps a deprecated wrapper mapping `ecdsaValidatorAddress` → `validatorAddress` (`toEcdsaKernelSmartAccount.ts:42-62`). Dart has no equivalent; not behaviorally significant since `createKernelSmartAccount` covers it via `customAddresses`.
+
+## O1 (dart-only) — WebAuthn owners permitted on Kernel v0.3.3
+
+Dart's address map gives v0.3.3 a `webAuthnValidator` (`constants.dart:120-122`), so a WebAuthn owner on v0.3.3 resolves a validator and proceeds. In JS, `getDefaultAddresses` (`toKernelSmartAccount.ts:238-245`) would find `WEB_AUTHN_VALIDATOR` undefined for 0.3.2/0.3.3 and `toKernelSmartAccount` throws `"Validator address is required"` (`:609-611`). Whether the 0x7ab16... validator is actually deployed/registered for 0.3.3 accounts is unverified — treat as intentional extension, but flag for review.
+
+## O2 (dart-only) — Dynamic RIP-7212 precompile detection
+
+`kernel_account.dart:543-548` probes the chain (`isRip7212Supported`) or falls back to a static chain list to set `usePrecompiled` in WebAuthn signatures. JS always uses `false`. Covered under D5 for byte-level impact.
+
+## O3 (dart-only) — Structural differences with equivalent behavior
+
+- `signUserOperationV06` (`kernel_account.dart:604-647`) provides correct EP v0.6 packing/hashing for v0.2.4; JS achieves the same through viem's `getUserOperationHash` with `entryPointVersion: "0.6"`. Hash pre-images verified equivalent (v0.6 10-field pack, v0.7 packed-gas pack, both `keccak256(abi.encode(hash, entryPoint, chainId))`).
+- The 7702 variant is a separate class (`eip7702_kernel_account.dart:197`) rather than a flag on the main factory; behavior mirrors `toKernelSmartAccount` with `eip7702: true` / `to7702KernelSmartAccount.ts:42-63`: address = EOA (`:258` vs JS `:649`), factory args null (`:264-271` vs JS `:650-655`), authorization to the 0.3.3 account logic (`:280-285` vs JS `:737-742`), ECDSA dummy stub (`:311` vs JS `:885`), EIP-191-wrapped userOp signing (`:329-337` vs JS `:973-975`), Kernel-domain typed-data 1271 signing with single-byte `0x00` EIP7702 identifier prefix (`:479-510` vs JS `signMessage.ts:86-98` + `toKernelSmartAccount.ts:914-917` where `getEcdsaRootIdentifierForKernelV3(v, true)` = `0x00`). One caveat: the pre-delegation 1271 guard (`:463-474`) only fires when a `publicClient` is supplied; JS always checks `isDeployed()` (`toKernelSmartAccount.ts:891-899`).

--- a/docs/parity-audit/01-account-light.md
+++ b/docs/parity-audit/01-account-light.md
@@ -1,0 +1,91 @@
+# Parity Audit 01 — Light Account (Alchemy)
+
+**Reference:** permissionless.js v0.3.5 — `accounts/light/toLightSmartAccount.ts`
+**Port:** permissionless.dart v0.3.0 — `lib/src/accounts/light/` (`light_account.dart`, `constants.dart`, `light.dart`)
+
+Paths below are abbreviated:
+
+- **JS** = `/Users/liorag/Documents/development/permissionless/permissionless.js/packages/permissionless/accounts/light/toLightSmartAccount.ts`
+- **DART** = `/Users/liorag/Documents/development/permissionless/permissionless.dart/packages/permissionless/lib/src/accounts/light/light_account.dart`
+- **CONST** = `/Users/liorag/Documents/development/permissionless/permissionless.dart/packages/permissionless/lib/src/accounts/light/constants.dart`
+- **OWNER** = `/Users/liorag/Documents/development/permissionless/permissionless.dart/packages/permissionless/lib/src/accounts/account_owner.dart`
+
+Function selectors were independently verified with viem's `toFunctionSelector`:
+`execute(address,uint256,bytes)` = `0xb61d27f6`, `executeBatch(address[],uint256[],bytes[])` = `0x47e1da2a`, `createAccount(address,uint256)` = `0x5fbfb9cf` — all matching the Dart constants (CONST:68, CONST:72, CONST:76).
+
+## Verdict table
+
+| # | Aspect | Verdict | JS | Dart |
+|---|--------|---------|----|------|
+| 1 | Supported versions (1.1.0 / 2.0.0) + EP mapping | mirrors | JS:73-74 | CONST:9-36 |
+| 2 | Factory addresses per version | mirrors | JS:123-134 | CONST:44-49 |
+| 3 | initcode / factoryData (`createAccount(owner, salt)`, default salt 0) | mirrors | JS:35-71, 191, 222-227 | DART:35, 178-198 |
+| 4 | Dummy signature (incl. v2 `0x00` EOA prefix) | mirrors | JS:415-427 | DART:282-300 |
+| 5 | signUserOperation — EP v0.7 hash + raw EIP-191 sign + v2 prefix | mirrors | JS:465-494 | DART:302-319, 396-457 |
+| 6 | signUserOperation — EP v0.6 hash path | **missing** | JS:469-477 (via viem `getUserOperationHash`, version-aware) | DART:303, 396-457 (v0.7-only) |
+| 7 | signMessage / signTypedData — LightAccountMessage ERC-1271 wrapper | **diverges** | JS:100-121, 431-464 | DART:322-394 |
+| 8 | `sign({ hash })` | **missing** | JS:428-430 | — (no counterpart in `SmartAccount` interface) |
+| 9 | execute / executeBatch calldata | mirrors | JS:246-318 | DART:200-280 |
+| 10 | decodeCalls | **missing** | JS:319-407 | — |
+| 11 | Nonce handling — configurable `nonceKey` / per-call key | **missing** | JS:97, 192, 408-414 | DART:122 (hardcoded `BigInt.zero`) |
+| 12 | getAddress via `eth_getSenderAddress` / precomputed address | mirrors | JS:96, 210, 233-245 | DART:129-155 |
+| 13 | Version auto-selection from EntryPoint version | dart-only | JS:93 (explicit, type-enforced) | CONST:24-36, DART:36-37 |
+
+**Counts:** 7 mirrors, 1 diverges, 4 missing, 1 dart-only.
+
+---
+
+## Finding 7 — signMessage / signTypedData: EIP-191 prefix wrongly applied on top of the EIP-712 wrapper digest (**diverges**)
+
+**JS behavior.** `signWith1271WrapperV1` (JS:100-121) calls `signer.signTypedData(...)` with the `LightAccountMessage` typed data (domain `{ name: "LightAccount", version: "1", chainId, verifyingContract }`, type `LightAccountMessage(bytes message)`). viem's `LocalAccount.signTypedData` computes the EIP-712 digest (`keccak256("\x19\x01" ‖ domainSeparator ‖ structHash)`) and signs that digest **raw** — no EIP-191 personal-message prefix. This is what LightAccount's on-chain `isValidSignature` (ERC-1271) expects.
+
+**Dart behavior.** `_signLightAccountMessage` (DART:372-394) builds the identical typed data (DART:376-390 — domain and `LightAccountMessage(bytes message)` match JS byte-for-byte), then:
+
+```dart
+final hash = hashTypedData(typedData);
+return _config.owner.signPersonalMessage(hash);   // DART:392-393
+```
+
+`PrivateKeyOwner.signPersonalMessage` (OWNER:116-129) uses web3dart's `signPersonalMessageToUint8List`, which prepends `"\x19Ethereum Signed Message:\n32"` and re-hashes before signing. So the Dart signature is over `keccak256("\x19Ethereum Signed Message:\n32" ‖ eip712Digest)` instead of over `eip712Digest`.
+
+**Impact.** Every signature produced by `LightSmartAccount.signMessage` (DART:322-344) and `signTypedData` (DART:347-369) recovers to a different digest than the contract computes; on-chain ERC-1271 validation (`isValidSignature`) will fail for both v1.1.0 and v2.0.0. The fix is to sign the wrapper digest raw — e.g. `owner.signRawHash(hash)` or `owner.signTypedData(typedData)` (OWNER:132-149 / OWNER:151-169 both sign without a personal prefix).
+
+Note: the v2.0.0 `0x00` prefix concatenation itself (DART:333-341, 358-365) mirrors JS:439-446 / JS:456-463 correctly; only the inner ECDSA digest is wrong.
+
+Minor related gap: JS `signMessage` accepts viem's `SignableMessage` (UTF-8 string or `{ raw }` bytes, hashed via `hashMessage`, JS:436); Dart only accepts a UTF-8 `String` (DART:322-323, hashed by `hashMessage` in `utils/message_hash.dart:23-36`). For string messages the digests match.
+
+## Finding 6 — signUserOperation: EP v0.6 hash path missing (**missing**)
+
+**JS behavior.** `signUserOperation` (JS:465-494) computes the userOp hash with viem's `getUserOperationHash` passing `entryPointVersion: entryPoint.version` (JS:475), so it packs the v0.6 format (separate `initCode`/`paymasterAndData`, unpacked gas fields) when the account is configured for EP v0.6 with LightAccount v1.1.0, and the v0.7 packed format otherwise. The hash is then signed as a raw 32-byte EIP-191 message (JS:479-484).
+
+**Dart behavior.** `signUserOperation` accepts only `UserOperationV07` (DART:303) and `_computeUserOpHash`/`_packUserOpForHash` (DART:396-457) hardcode the v0.7 packed layout (`accountGasLimits`, `gasFees`, packed `paymasterAndData`). `LightSmartAccount` implements only `SmartAccount` (DART:89) and not `SmartAccountV06` (`lib/src/clients/smart_account/smart_account_interface.dart:120-130`, which other Dart accounts like Trust and Biconomy implement for v0.6 flows). Yet the config accepts `EntryPointVersion.v06` (DART:29) and correctly selects LightAccount v1.1.0 + the v0.6 factory (CONST:24-28, CONST:44-45) and the v0.6 EntryPoint address (DART:118-119).
+
+**Impact.** A Light account configured for EP v0.6 / v1.1.0 can be constructed and will build correct initcode, but there is no way to sign a v0.6 UserOperation: the only signing path packs the hash v0.7-style, which produces an invalid v0.6 userOpHash. EP v0.6 support is therefore effectively missing despite being half-exposed in the config (a footgun — either implement `SmartAccountV06.signUserOperationV06` with the v0.6 hash layout, or reject `EntryPointVersion.v06` in the constructor).
+
+The v0.7 hash computation itself (DART:396-457) was checked field-by-field against the ERC-4337 v0.7 spec (keccak over `abi.encode(sender, nonce, keccak(initCode), keccak(callData), accountGasLimits, preVerificationGas, gasFees, keccak(paymasterAndData))`, then `keccak(abi.encode(h, entryPoint, chainId))`) and mirrors what viem computes. The raw EIP-191 signing of the hash (DART:305 via OWNER:116-129) also mirrors JS:479-484, including the v2 `0x00` prefix (DART:308-315 vs JS:486-493).
+
+## Finding 8 — `sign({ hash })` (**missing**)
+
+JS exposes `sign` (JS:428-430) which delegates to `signMessage({ message: hash })` — used by viem for things like SIWE and generic hash signing. The Dart `SmartAccount` interface has no `sign` method and `LightSmartAccount` provides no equivalent. Low severity; callers can approximate it with `signMessage`, though only for UTF-8 string inputs.
+
+## Finding 10 — decodeCalls (**missing**)
+
+JS implements `decodeCalls` (JS:319-407), decoding `executeBatch(address[],uint256[],bytes[])` first and falling back to `execute(address,uint256,bytes)`, returning the structured call list. Dart has no decode capability for Light account calldata (the `SmartAccount` interface in `smart_account_interface.dart:20-114` defines only encoding). Affects tooling/introspection only, not transaction correctness.
+
+## Finding 11 — Nonce handling: no configurable nonce key (**missing**)
+
+JS accepts a `nonceKey` constructor parameter (JS:97, destructured at JS:192) and `getNonce(args)` uses `nonceKey ?? args?.key` when querying `EntryPoint.getNonce` (JS:408-414), enabling parallel (2D) nonces. Dart hardcodes `nonceKey => BigInt.zero` (DART:122) and `LightSmartAccountConfig` (DART:16-68) offers no nonce-key option, so the SmartAccountClient always fetches key-0 nonces. Sequential-nonce behavior mirrors JS defaults; the ability to opt into a custom key is missing.
+
+## Finding 13 — Version auto-selection (dart-only)
+
+JS requires an explicit `version` parameter whose allowed value is tied to the EntryPoint version at the type level (`LightAccountVersion<entryPointVersion>`, JS:73-74, JS:93) — "1.1.0" only with EP v0.6, "2.0.0" only with EP v0.7. Dart makes `version` optional and derives it via `LightAccountVersion.forEntryPoint` (CONST:24-36, applied at DART:36-37), which also explicitly rejects EP v0.8. This is a convenience addition with identical default behavior.
+
+Caveat: because Dart's pairing is only a default, a caller can explicitly pass a mismatched combination (e.g. `version: v110` with `entryPointVersion: v07`), which neither side validates at runtime — JS relies on TypeScript types to prevent it. Not counted as a divergence since JS has no runtime check either.
+
+## Mirrors — verification notes
+
+- **Factory addresses** byte-for-byte: v1.1.0 `0x00004EC70002a32400f8ae005A26081065620D20` (JS:129 = CONST:45), v2.0.0 `0x0000000000400CdFef5E2714E63d8040b700BC24` (JS:132 = CONST:49). Custom factory override supported on both sides (JS:94, 136-151; DART:31, 94-96).
+- **initcode/factoryData**: both encode `createAccount(address owner, uint256 salt)` with the owner address and index/salt (default 0) — JS:35-71 + JS:191 vs DART:194-198 + DART:35; selector `0x5fbfb9cf` verified. Dart's `getInitCode` (DART:179-185) is `factory ‖ factoryData`, matching the v0.6 initCode convention; `getFactoryData` (DART:188-192) matches the v0.7 split used by JS `getFactoryArgs` (JS:222-227).
+- **Dummy signature**: identical 65-byte constant `0xfffffffffffffffffffffffffffffff0000000000000000000000000000000007aaa...aaa1c` (JS:417 = DART:286), with `0x00` (SignatureType.EOA, JS:169-173 = CONST:80-91) prepended only for v2.0.0 (JS:419-426 = DART:289-299).
+- **execute/executeBatch**: JS uses `execute` for a single call and `executeBatch` for >1, throwing on empty (JS:246-317); Dart identical (DART:205-215). Dart's hand-rolled ABI encoding (DART:217-280) was checked against canonical ABI head/tail layout: `execute` head offset `0x60` (DART:218), `executeBatch` three head offsets with correctly accumulated dynamic tails (DART:236-246), and `bytes[]` element offsets relative to the array data area starting at `n*32` (DART:266-277) — all standard-conformant; missing `value`/`data` defaults (`0`, `0x`) in JS:277-278/316 are non-nullable fields on the Dart `Call` type.
+- **getAddress**: JS counterfactually derives via `getSenderAddress` with factory/factoryData and honors an explicit `address` parameter (JS:96, 210, 233-245); Dart does the same via `publicClient.getSenderAddress(initCode: ...)` or an explicit `address`, caching the result (DART:129-155). Dart throws a descriptive `StateError` when neither is available — JS always has a client, so this branch has no JS analogue but is not a behavioral divergence for valid usage.

--- a/docs/parity-audit/01-account-nexus.md
+++ b/docs/parity-audit/01-account-nexus.md
@@ -1,0 +1,185 @@
+# Parity Audit: Nexus (Biconomy ERC-7579) Smart Account
+
+**Scope**: permissionless.js v0.3.5 `accounts/nexus/toNexusSmartAccount.ts` vs
+permissionless.dart v0.3.0 `lib/src/accounts/nexus/` (`nexus_account.dart`, `constants.dart`, `nexus.dart`).
+
+Paths below are abbreviated:
+
+- **JS** = `/Users/liorag/Documents/development/permissionless/permissionless.js/packages/permissionless`
+- **Dart** = `/Users/liorag/Documents/development/permissionless/permissionless.dart/packages/permissionless`
+
+Helper code compared as part of the behavior chain: JS `utils/encode7579Calls.ts`,
+`actions/erc7579/supportsExecutionMode.ts` (`encodeExecutionMode`), `actions/public/getAccountNonce.ts`;
+Dart `lib/src/utils/erc7579.dart`, `lib/src/utils/message_hash.dart`, `lib/src/accounts/account_owner.dart`,
+`lib/src/clients/public/public_client.dart`, `lib/src/clients/smart_account/smart_account_client.dart`.
+
+## Verdict table
+
+| # | Aspect | Verdict | JS | Dart |
+|---|--------|---------|----|------|
+| 1 | K1ValidatorFactory address `0x00000bb19a3579F4D779215dEf97AFbd0e30DB55` | mirrors | `toNexusSmartAccount.ts:87` | `constants.dart:11-12` |
+| 2 | K1Validator address `0x00000004171351c442B202678c48D8AB5B321E8f` | mirrors | `toNexusSmartAccount.ts:88` | `constants.dart:15-16` |
+| 3 | factoryData: `createAccount(address,uint256,address[],uint8)` encoding (selector `0x0d51f0b7`, arg order, offset, attester sort) | mirrors | `toNexusSmartAccount.ts:151-180` | `nexus_account.dart:197-223`, `constants.dart:25` |
+| 4 | initCode / getFactoryArgs (always factory+factoryData; deployment check external) | mirrors | `toNexusSmartAccount.ts:151-180` | `nexus_account.dart:180-194` |
+| 5 | Counterfactual address derivation | mirrors (different RPC mechanism, same result — see note A) | `toNexusSmartAccount.ts:195-226` | `nexus_account.dart:150-176` |
+| 6 | Nonce key encoding: `key(3 bytes) ++ 0x00 ++ validator(20 bytes)` as uint192 | mirrors (default key = 0) | `toNexusSmartAccount.ts:227-244` | `nexus_account.dart:129-143`, `public_client.dart:164-176` |
+| 7 | Custom nonce key parameter (`args.key % 16777215`) | **missing** | `toNexusSmartAccount.ts:228-229` | `nexus_account.dart:134` (hardcoded `BigInt.zero`) |
+| 8 | Dummy/stub signature (offset word + validator word + fixed 65-byte sig) | mirrors | `toNexusSmartAccount.ts:259-262` | `nexus_account.dart:243-252` |
+| 9 | signUserOperation: userOpHash computation (EP v0.7 packing) | mirrors | `toNexusSmartAccount.ts:336-345` (viem `getUserOperationHash`) | `nexus_account.dart:353-415` |
+| 10 | signUserOperation: returned signature bytes | **diverges** | `toNexusSmartAccount.ts:346-348` (bare 65-byte sig) | `nexus_account.dart:264-275` (validator-prefixed, 85 bytes) |
+| 11 | signMessage: ERC-7739 `PersonalSign(bytes prefixed)` wrapping + personal-sign + `validator ++ sig` packing | mirrors | `toNexusSmartAccount.ts:44-74, 266-283` | `nexus_account.dart:279-289, 306-350` |
+| 12 | signTypedData: same PersonalSign wrapping quirk + `validator ++ sig` packing | mirrors (see note B) | `toNexusSmartAccount.ts:284-329` | `nexus_account.dart:293-303` |
+| 13 | encodeCalls single: `execute(bytes32,bytes)` selector `0xe9ae5c53`, mode byte0=0x00 byte1=0x00, packed `to ++ value(32) ++ data` | mirrors | `encode7579Calls.ts:102-113`, `supportsExecutionMode.ts:46-61` | `erc7579.dart:240-261, 334-349` |
+| 14 | encodeCalls batch: mode byte0=0x01, `abi.encode(Execution[])` (target,value,bytes) | mirrors | `encode7579Calls.ts:55-94` | `erc7579.dart:267-329, 354-377` |
+| 15 | Delegatecall mode from account `encodeCalls` | mirrors (neither side emits it for Nexus; both libs can encode 0xff) | `toNexusSmartAccount.ts:245-255` | `nexus_account.dart:227-239` |
+| 16 | decodeCalls on the account | **missing** | `toNexusSmartAccount.ts:256-258` | no counterpart on `NexusSmartAccount` / `SmartAccount` interface (util `decode7579Calls` exists at `erc7579.dart:756` but is not wired) |
+| 17 | EntryPoint version: v0.7 only | mirrors | `toNexusSmartAccount.ts:143-147` | `nexus_account.dart:112, 123`; `constants/entry_point.dart:21-22` |
+| 18 | Custom EntryPoint address override (`entryPoint: {address, version: "0.7"}`) | **missing** | `toNexusSmartAccount.ts:106-109, 143-147` | `nexus_account.dart:123` (hardcoded `EntryPointAddresses.v07`) |
+| 19 | Module install hooks during setup (none — K1 factory installs the validator) | mirrors | `toNexusSmartAccount.ts` (absent by design) | `nexus_account.dart` (absent by design) |
+| 20 | `computeAccountAddress` selector constant | **dart-only** (dead code, and the value is wrong) | `toNexusSmartAccount.ts:200-214` (uses ABI by name) | `constants.dart:27-28` |
+
+Counts: 14 mirrors, 1 diverges, 3 missing, 1 dart-only (incorrect dead constant), 1 n/a folded into mirrors (#15).
+
+---
+
+## Finding 10 — diverges: `signUserOperation` prepends the validator address (HIGH severity)
+
+**JS** (`toNexusSmartAccount.ts:330-349`) hashes the userOp and returns the owner's bare
+EIP-191 signature — 65 bytes, **no validator prefix**:
+
+```ts
+return await localOwner.signMessage({
+    message: { raw: hash as Hex }
+})
+```
+
+**Dart** (`nexus_account.dart:264-275`) packs the validator address in front, producing an
+85-byte signature:
+
+```dart
+final signature = await _config.owner.signPersonalMessage(userOpHash);
+// Pack: validator address + signature (85 bytes total)
+return Hex.concat([
+  _validatorAddress.hex,
+  Hex.strip0x(signature),
+]);
+```
+
+Why this matters on-chain: for Nexus, the validator module is selected via the **nonce key**
+(aspect #6), and `Nexus.validateUserOp` forwards `userOp.signature` untouched to
+`K1Validator.validateUserOp`, which does an ECDSA recover expecting a 65-byte signature.
+An 85-byte signature fails recovery, so every Dart-signed Nexus UserOperation should be
+rejected with signature-validation failure (AA24). The validator-prefix packing is correct
+for ERC-1271 `signMessage`/`signTypedData` (aspects #11/#12, where JS does the same
+`encodePacked(["address","bytes"])`) — it was incorrectly carried over to the userOp path.
+The doc comment at `nexus_account.dart:258-262` asserts this prefix is expected, which
+contradicts the TS reference.
+
+Fix: return the bare 65-byte `signPersonalMessage(userOpHash)` result.
+
+The hash computed before signing (aspect #9) was verified field-by-field against viem's
+v0.7 `getUserOperationHash` packing (`keccak(abi.encode(sender, nonce, keccak(initCode),
+keccak(callData), accountGasLimits, preVerificationGas, gasFees, keccak(paymasterAndData)))`
+then `keccak(abi.encode(hash, entryPoint, chainId))`) — that part mirrors
+(`nexus_account.dart:353-415`).
+
+## Finding 7 — missing: custom nonce key input
+
+**JS** (`toNexusSmartAccount.ts:227-235`) accepts a caller-supplied key and folds it into the
+top 3 bytes of the 24-byte key:
+
+```ts
+const TIMESTAMP_ADJUSTMENT = 16777215n // max value for size 3
+const defaultedKey = (args?.key ?? 0n) % TIMESTAMP_ADJUSTMENT
+const key = concat([toHex(defaultedKey, { size: 3 }), "0x00", validatorAddress])
+```
+
+**Dart** (`nexus_account.dart:129-143`) exposes `nonceKey` as a getter with the key portion
+hardcoded to zero (`final defaultedKey = BigInt.zero % BigInt.from(timestampAdjustment);`),
+and `smart_account_client.dart:224-229` passes it straight to
+`publicClient.getAccountNonce(..., nonceKey: account.nonceKey)`. There is no way to use a
+parallel nonce lane. The default (key = 0) path is byte-identical to JS:
+`0x000000 ++ 0x00 ++ validator` interpreted as uint192 and passed to
+`EntryPoint.getNonce(address,uint192)` (`public_client.dart:164-176`, selector `0x35567e1a`
+matches JS `getAccountNonce`).
+
+## Finding 16 — missing: `decodeCalls`
+
+**JS** wires `decode7579Calls` into the account (`toNexusSmartAccount.ts:256-258`), used by
+viem's `sendCalls`/debugging paths. **Dart** has an equivalent standalone util
+(`erc7579.dart:756`, `decode7579Calls`) but the `SmartAccount` interface
+(`lib/src/clients/smart_account/smart_account_interface.dart`) has no `decodeCalls` member
+and `NexusSmartAccount` does not expose it. Library-wide interface gap, not Nexus-specific;
+low impact (encode path is what goes on-chain).
+
+## Finding 18 — missing: EntryPoint address override
+
+**JS** allows `entryPoint: { address, version: "0.7" }` (`toNexusSmartAccount.ts:106-109`),
+defaulting to `entryPoint07Address` (`toNexusSmartAccount.ts:143-147`). **Dart** hardcodes
+`EntryPointAddresses.v07` (`nexus_account.dart:123`,
+`constants/entry_point.dart:21-22` = `0x0000000071727De22E5E9d8BAf0edAc6f37da032`, which
+matches viem's `entryPoint07Address`). Only affects users pointing at a non-canonical
+EntryPoint deployment; the default is byte-identical. Note the hardcoded EntryPoint is also
+baked into the manual userOpHash (`nexus_account.dart:359`), so an override would need to
+flow there too.
+
+## Finding 20 — dart-only: incorrect (dead) `computeAccountAddress` selector
+
+**Dart** `constants.dart:27-28` declares:
+
+```dart
+/// computeAccountAddress(address eoaOwner, uint256 index, address[] attesters, uint8 threshold)
+static const String computeAccountAddress = '0x8b97fea1';
+```
+
+The actual selector for `computeAccountAddress(address,uint256,address[],uint8)` is
+**`0x322cc8ca`** (computed with viem `toFunctionSelector`; the `createAccount` selector
+`0x0d51f0b7` at `constants.dart:25` was verified correct the same way). The constant is
+referenced nowhere in `lib/` or `test/`, so there is no behavioral impact today — but if
+anyone wires it up to replicate the JS `getAddress` path (`toNexusSmartAccount.ts:198-223`),
+the eth_call will revert. Recommend fixing the value or deleting the constant.
+
+---
+
+## Note A — address derivation mechanism
+
+JS calls the factory's view function `computeAccountAddress(eoaOwner, index, attesters,
+threshold)` directly (`toNexusSmartAccount.ts:195-226`). Dart instead builds the initCode
+and simulates `EntryPoint.getSenderAddress(initCode)` via `publicClient.getSenderAddress`
+(`nexus_account.dart:161-168`), or accepts a precomputed `address`, and throws a
+`StateError` if neither is available (`nexus_account.dart:171-175`). Since the initCode runs
+the same `createAccount` calldata (verified byte-identical, aspect #3) against the same
+factory, the resulting CREATE2 address is the same — mechanism differs, behavior does not.
+Attester sorting is also equivalent: JS `localeCompare` on lowercased hex
+(`toNexusSmartAccount.ts:173-175`) vs Dart `compareTo` on lowercased hex
+(`nexus_account.dart:199-200`) yield the same lexicographic order for `0x`-prefixed
+hex strings.
+
+## Note B — signTypedData validation and wrapping quirk
+
+Both sides wrap the EIP-712 digest with the ERC-7739 **PersonalSign** typehash
+(`keccak256("PersonalSign(bytes prefixed)")`) inside the Nexus domain
+(`name: "Nexus", version, chainId, verifyingContract`) — JS `toNexusSmartAccount.ts:44-74,
+313-317`; Dart `nexus_account.dart:306-350`. This is arguably a bug upstream (typed data
+"should" use the TypedDataSign wrapper), but the Dart port faithfully reproduces the JS
+bytes, which is what parity requires. Dart's EIP-712 hashing chain
+(`message_hash.dart:52-107` — domain separator with only-present fields, `0x1901` prefix)
+matches viem's `hashTypedData`/`domainSeparator`. The only difference: JS runs
+`validateTypedData` before hashing (`toNexusSmartAccount.ts:299-304`), Dart does not —
+input validation only, no byte difference for valid input. Signing of the wrapped hash uses
+EIP-191 personal-sign on both sides (viem `signMessage({raw})` vs web3dart
+`signPersonalMessageToUint8List`, `account_owner.dart:116-129`), and both pack
+`validator ++ signature` (JS `encodePacked(["address","bytes"])`,
+`toNexusSmartAccount.ts:279-282, 325-328`; Dart `Hex.concat`,
+`nexus_account.dart:285-288, 299-302`).
+
+## Note C — execution mode bytes
+
+JS Nexus passes `revertOnError: false`, which `encodeExecutionMode` maps to execType byte
+`0x00` (`supportsExecutionMode.ts:56` — `revertOnError ? "0x01" : "0x00"`; the JS field is
+confusingly named). Dart `encode7579ExecuteMode` defaults execType to `0x00`
+(`erc7579.dart:240-249`). Resulting 32-byte mode is identical
+(`0x00/0x01` calltype, `0x00` exectype, 30 zero bytes). Beware: Dart's separate
+`ExecutionMode.encode()` class (`erc7579.dart:195-225`) uses the **opposite** boolean
+convention (`revertOnError ? 0x00 : 0x01`) — not used by the Nexus account, so out of
+scope here, but flagged for the ERC-7579 utils audit unit.

--- a/docs/parity-audit/01-account-safe.md
+++ b/docs/parity-audit/01-account-safe.md
@@ -1,0 +1,198 @@
+# Parity Audit: Safe Smart Account
+
+**JS reference:** permissionless.js v0.3.5 — `accounts/safe/toSafeSmartAccount.ts` (2017 lines), `accounts/safe/signUserOperation.ts` (316 lines)
+**Dart port:** permissionless.dart v0.3.0 — `lib/src/accounts/safe/safe_account.dart` (1181 lines), `lib/src/accounts/safe/constants.dart` (226 lines), plus helpers in `lib/src/utils/{encoding,multisend,erc7579,webauthn_encoding}.dart`
+
+Paths below are relative to:
+
+- JS: `/Users/liorag/Documents/development/permissionless/permissionless.js/packages/permissionless/`
+- Dart: `/Users/liorag/Documents/development/permissionless/permissionless.dart/packages/permissionless/`
+
+Scope: behavioral, byte-level comparison of addresses, CREATE2/initcode derivation, setup calldata (incl. `useMultiSendForSetup`), MultiSend usage, dummy signature, `signUserOperation` (incl. V adjustment), EIP-712 SafeOp domain/typehashes, validAfter/validUntil packing, ERC-7579 launchpad path, nonce key handling, and Safe4337 module addresses.
+
+## Verdict table
+
+| # | Aspect | Verdict |
+|---|--------|---------|
+| 1 | Safe v1.4.1 addresses (EP v0.6 + v0.7, all 8 contracts) | mirrors |
+| 2 | Safe v1.5.0 addresses | **diverges** (MULTI_SEND_CALL_ONLY) |
+| 3 | Safe4337 module addresses (0xa581… v0.6 / 0x75cf… v0.7) | mirrors |
+| 4 | CREATE2 salt / deploymentCode / address math | mirrors |
+| 5 | Proxy creation code source (RPC read vs hardcoded constant) | **diverges** (conditional — unverified for v1.5.0 factory) |
+| 6 | factory/factoryData: `createProxyWithNonce` encoding | mirrors |
+| 7 | Setup initializer (enableModules via MultiSend delegatecall, fallbackHandler = 4337 module, payment zeros) | mirrors |
+| 8 | `useMultiSendForSetup: false` fast path (JS 0.3.5 feature) | mirrors |
+| 9 | Default threshold | **diverges** |
+| 10 | `setupTransactions` / `safeModules` / `paymentToken`/`payment`/`paymentReceiver` params | **missing** |
+| 11 | Single-call encoding (`executeUserOpWithErrorString`, operation 0) | mirrors |
+| 12 | Batch-call encoding target contract | **diverges** (MultiSend vs MultiSendCallOnly) |
+| 13 | `onchainIdentifier` calldata suffix | **missing** |
+| 14 | `decodeCalls` | **missing** (introspection only) |
+| 15 | Stub signature — ECDSA dummy bytes | **diverges** |
+| 16 | Stub signature — WebAuthn dummy bytes | **diverges** |
+| 17 | Stub signature — structure (uint48/uint48 prefix + sorted concat) | mirrors |
+| 18 | SafeOp EIP-712 v0.7 typehash, field order, domain (chainId + 4337-module verifyingContract) | mirrors |
+| 19 | SafeOp v0.6 typehash + EP v0.6 signing | **missing** |
+| 20 | Configurable `validAfter`/`validUntil` | **missing** |
+| 21 | Custom EntryPoint address in SafeOp `entryPoint` field | **missing** (hardcoded canonical v0.7) |
+| 22 | Signature concatenation (address sort, 65-byte static, dynamic contract-sig parts, type byte 0x00) | mirrors |
+| 23 | V handling in `signUserOperation` (typed-data path, v = 27/28) | mirrors |
+| 24 | `signMessage` / `signTypedData` (EIP-1271 SafeMessage wrapper, eth_sign +4 adjust, 7579 zero-address prefix) | **diverges** |
+| 25 | Standalone `signUserOperation` (multi-device signature accumulation) | **missing** |
+| 26 | Nonce key handling | **missing** |
+| 27 | 7579: `preValidationSetup` initializer + InitData `initHash` | mirrors |
+| 28 | 7579: `initSafe7579` encoding incl. attester sorting | mirrors |
+| 29 | 7579: safe7579 module address resolution / domain in 7579 mode | **diverges** |
+| 30 | 7579: WebAuthn owner mapping inside InitData owners | **diverges** |
+| 31 | 7579: first-op `setupSafe` wrapping (auto vs manual) | **diverges** |
+| 32 | 7579: call vs batchcall mode selection, revertOnError=false | mirrors |
+| 33 | 7579 + Safe v1.5.0 incompatibility guard | **missing** |
+| 34 | Dart-only additions (Safe7579Addresses defaults, `encodeCallsForDeployment`, hardcoded proxy code constant, unused `publicClient` param) | dart-only |
+
+**Counts: 12 mirrors · 9 diverges · 9 missing · 1 dart-only (grouped).**
+
+Key mirrored details verified byte-by-byte (not just by name):
+
+- All v1.4.1 addresses: JS `accounts/safe/toSafeSmartAccount.ts:472-503` == Dart `lib/src/accounts/safe/constants.dart:131-178`.
+- CREATE2: salt = `keccak256(keccak256(initializer) ++ saltNonce)`, deploymentCode = `proxyCreationCode ++ uint256(singleton|launchpad)` — JS `toSafeSmartAccount.ts:1329-1349` == Dart `safe_account.dart:274-319`.
+- Initializer: `setup(owners, threshold, multiSend, multiSendCallData, safe4337Module, 0, 0, 0)` with `enableModules([safe4337Module])` delegatecalled (operation 1) — JS `toSafeSmartAccount.ts:861-940` == Dart `safe_account.dart:340-428` + `lib/src/utils/encoding.dart:122-186` + `lib/src/utils/multisend.dart:82-115` (MultiSend packing `uint8 ++ address ++ uint256 ++ uint256 len ++ bytes` identical to JS `toSafeSmartAccount.ts:566-588`).
+- `useMultiSendForSetup: false` single-call direct `setup()` branch — JS `toSafeSmartAccount.ts:907-922` == Dart `safe_account.dart:400-414` (the extra `!_hasWebAuthnOwner` guard at `safe_account.dart:402` is redundant, not behavioral: a WebAuthn owner always adds a second MultiSend call, making `length == 1` false in JS too). Dart's CREATE2 outputs for both branches are pinned to JS-0.3.5-generated vectors in `test/accounts/safe/safe_account_test.dart:496-511`.
+- SafeOp v0.7 typehash string — JS `toSafeSmartAccount.ts:430-446` (uint128 verificationGasLimit before callGasLimit, uint128 fee fields, uint48 validity, address entryPoint) == Dart `safe_account.dart:967-968`; all EIP-712 words are 32-byte padded (Dart `lib/src/utils/encoding.dart:21-26`); dynamic fields (`initCode`, `callData`, `paymasterAndData`) are keccak-hashed (`safe_account.dart:979-1013`); `paymasterAndData` reconstruction `paymaster ++ u128 pmVGL ++ u128 pmPoGL ++ pmData` — JS `toSafeSmartAccount.ts:942-966` == Dart `safe_account.dart:985-999`.
+- Domain separator: `EIP712Domain(uint256 chainId,address verifyingContract)` with **verifyingContract = Safe4337Module**, not the account — JS `signUserOperation.ts:279-290` == Dart `safe_account.dart:943-958`.
+- Signature concat: sort by signer address, 65-byte static parts, dynamic position = `n*65 + dynamicBytes/2`, type byte `00`, `{len}{data}` tail — JS `signUserOperation.ts:30-74` == Dart `safe_account.dart:1042-1076`.
+- V values in `signUserOperation`: JS signs SafeOp via `signTypedData` (no +4 adjust, v stays 27/28, `toSafeSmartAccount.ts:1994-2008` → `signUserOperation.ts:279-291`); Dart signs the identical EIP-712 hash via `signRawHash` and normalizes v to 27/28 (`lib/src/accounts/account_owner.dart:132-148`). Same bytes for the same key. The +31 (`27+4`) eth_sign adjustment only exists in the JS *message*-signing path (see finding 24).
+- validAfter/validUntil packing: `encodePacked(uint48, uint48, bytes)` prefix — JS `signUserOperation.ts:312-315` / stub `toSafeSmartAccount.ts:1827-1830` == Dart 6-byte-each prefix `safe_account.dart:790-794, 853-857`.
+- 7579 initializer: `preValidationSetup(initHash, address(0), 0x)` where initHash = keccak of ABI-encoded `(singleton, owners, threshold, setupTo, setupData, safe7579, ModuleInit[] validators)` — JS `toSafeSmartAccount.ts:747-834` == Dart `safe_account.dart:435-568`; `initSafe7579` attesters sorted case-insensitively — JS `toSafeSmartAccount.ts:676-679` == Dart `lib/src/utils/encoding.dart:319-321`.
+- 7579 execution mode: single call → callType 0x00, batch → 0x01, execType 0x00 (revertOnError false) — JS `toSafeSmartAccount.ts:1637-1661` == Dart `lib/src/utils/erc7579.dart:334-377` (Dart `encode7579ExecuteBatch` collapses single-element lists to call mode at `erc7579.dart:360-362`).
+
+---
+
+## Finding 2 — Safe v1.5.0 MULTI_SEND_CALL_ONLY address mismatch (diverges)
+
+- JS: `accounts/safe/toSafeSmartAccount.ts:515-516` — `MULTI_SEND_CALL_ONLY_ADDRESS: "0xA83c336B20401Af773B6219BA5027174338D1836"`
+- Dart: `lib/src/accounts/safe/constants.dart:196-198` — `multiSendCallOnlyAddress: 0x0c28E9886f79618371c5Af86aA7e5Cf62dddd8dC`
+
+Every other address in the v1.5.0 block matches byte-for-byte (proxy factory `0x14F2982D…`, singleton `0xFf51A589…`, multiSend `0x21854328…`, module setup, 4337 module, shared signer, P256 verifier). Today this constant is latent in Dart because the batch path never uses it (see Finding 12), but it is the address JS routes all multi-call executions through on v1.5.0, so fixing Finding 12 without fixing this constant would produce calldata targeting the wrong contract.
+
+## Finding 5 — Proxy creation code: hardcoded constant vs RPC `proxyCreationCode()` (diverges, conditional)
+
+- JS: `accounts/safe/toSafeSmartAccount.ts:1299-1303` — `getAccountAddress` reads `proxyCreationCode()` from the *configured factory* via `readContract`, so the bytecode always matches the factory in use (1.4.1 factory `0x4e1DCf…` or 1.5.0 factory `0x14F2982D…`, or any custom factory).
+- Dart: `lib/src/accounts/safe/safe_account.dart:24-25` — a single hardcoded `_proxyCreationCode` constant used for **all** versions/factories (`safe_account.dart:285-291`).
+
+For Safe v1.4.1 the constant is proven byte-equivalent: the Dart CREATE2 test vectors were generated with permissionless.js 0.3.5 (`test/accounts/safe/safe_account_test.dart:496-511`) and match. For the v1.5.0 factory (and any `customAddresses.safeProxyFactoryAddress`) the constant is **unverified**: if that factory's `proxyCreationCode()` differs even in the metadata hash, `getAddress()` returns a wrong counterfactual address while `getFactoryData()` still deploys to the (different) correct one — a silent, funds-endangering mismatch. Recommend either fetching via the (already accepted but unused) `publicClient`, or adding a pinned per-factory constant verified against the deployed v1.5.0 factory.
+
+## Finding 9 — Default threshold (diverges)
+
+- JS: `accounts/safe/toSafeSmartAccount.ts:1388` — `threshold = BigInt(_owners.length)` (defaults to *all* owners).
+- Dart: `lib/src/accounts/safe/safe_account.dart:58` — `threshold = threshold ?? BigInt.one` (defaults to 1).
+
+For a multi-owner Safe created without an explicit threshold, JS and Dart produce **different initializers → different CREATE2 addresses** and different on-chain signing policies. Single-owner accounts (the common case) are unaffected since both resolve to 1.
+
+## Finding 10 — `setupTransactions`, `safeModules`, `payment*` parameters (missing)
+
+- JS: `toSafeSmartAccount.ts:1135-1140` (`setupTransactions`, `safeModules`), `1204-1206` (`paymentToken`, `payment`, `paymentReceiver`); consumed in `getInitializerCode` at `toSafeSmartAccount.ts:867, 900-905, 917-919, 935-937`.
+- Dart: no equivalents — `SafeSmartAccountConfig` (`safe_account.dart:39-69`) exposes none of these; `_getStandardInitializer` hardcodes exactly one `enableModules([safe4337Module])` call (`safe_account.dart:358-366`) and zero payment fields (`safe_account.dart:410-412, 424-426`).
+
+Behavior matches JS *defaults* exactly (empty setup txs, single enabled module, zero payments), so parity holds for default inputs; the configuration surface is absent. Any JS account created with these params has a CREATE2 address Dart cannot reproduce.
+
+## Finding 12 — Batch execution targets MultiSend instead of MultiSendCallOnly (diverges)
+
+- JS: `accounts/safe/toSafeSmartAccount.ts:1669-1681` — `encodeCalls` for >1 call: `to = multiSendCallOnlyAddress`, `operationType = 1`, inner operations all `0`.
+- Dart: `lib/src/accounts/safe/safe_account.dart:678-687` — `encodeCalls` for >1 call: `to: _addresses.multiSendAddress`, delegatecall, inner operations `0` (`lib/src/utils/multisend.dart:41-77`, default `OperationType.call`).
+
+Byte-level divergence in every batched UserOperation's `callData` (different 20-byte target inside `executeUserOpWithErrorString`). Functionally both execute the batch (inner ops are plain calls, which MultiSendCallOnly also permits), but JS deliberately uses the call-only variant as a safety property — the delegatecalled MultiSend contract Dart uses would also accept inner `delegatecall` operations. Also, Dart short-circuits `calls.length == 1` to a plain single-call encoding (`safe_account.dart:674-676`); JS reaches the same single-call encoding through its `else` branch (`toSafeSmartAccount.ts:1682-1692`) — that part is equivalent.
+
+## Finding 13 — `onchainIdentifier` (missing)
+
+- JS: `toSafeSmartAccount.ts:1207, 1700-1702` — optional hex identifier concatenated after `executeUserOpWithErrorString` calldata.
+- Dart: no parameter, never appended (`safe_account.dart:642-687`).
+
+## Finding 14 — `decodeCalls` (missing)
+
+- JS: `toSafeSmartAccount.ts:1706-1780` — decodes `setupSafe`, 7579, `executeUserOpWithErrorString`, and MultiSend-batched calldata back to call lists.
+- Dart: `SafeSmartAccount` exposes no decode method; a generic `decodeMultiSend` exists in `lib/src/utils/multisend.dart:118-141` but nothing decodes the Safe wrapper. Introspection-only gap; no signing/deployment impact.
+
+## Finding 15 — ECDSA stub signature bytes (diverges)
+
+- JS: `toSafeSmartAccount.ts:1792-1793` — fixed 65-byte dummy per owner: `0xfffffffffffffffffffffffffffffff0000000000000000000000000000000007aaaaaaaa…aaa1c` (r ≈ max, plausible s, v = 0x1c → ecrecover path in `checkSignatures`).
+- Dart: `safe_account.dart:772-784` — r = owner address left-padded, s = 0, v = 0x01. In Safe's `checkSignatures`, v == 1 selects the **approved-hash** branch with r as the approver address, not the ecrecover branch.
+
+Both are 65 bytes and structurally valid stubs, but they exercise different validation code paths during bundler gas estimation (approved-hash storage read vs ecrecover precompile), so estimated `verificationGasLimit` can differ from JS. Not a correctness bug for real signatures, but not byte- or path-parity.
+
+## Finding 16 — WebAuthn stub signature bytes (diverges)
+
+- JS: `toSafeSmartAccount.ts:1796-1810` — authenticatorData `0x49960de5…631d00000000` (37 bytes, realistic rpIdHash), clientDataFields `"origin":"http://somelargdomainheresothatwehaveenoughbytes.com","crossOrigin":false` (deliberately long, 77 chars), specific r/s constants.
+- Dart: `lib/src/utils/webauthn_encoding.dart:211-242` — authenticatorData = 32×0x49 + flags + counter, clientDataFields `"origin":"http://localhost:3000","crossOrigin":false` (53 chars), r = 2²⁵⁶-ish max, s = P-256 half-order value.
+
+Same ABI shape (`(bytes, string, uint256[2])`, matching JS `signUserOperation.ts:100-111` and Dart `webauthn_encoding.dart:165-205`), different content and — importantly — a **shorter** clientDataFields than JS's intentionally oversized one, so calldata/verification gas may be underestimated for real origins longer than localhost.
+
+## Finding 19 — EntryPoint v0.6 SafeOp signing (missing)
+
+- JS: v0.6 typehash `EIP712_SAFE_OPERATION_TYPE_V06` (`toSafeSmartAccount.ts:412-428`, uint256 gas fields, `callGasLimit` before `verificationGasLimit`) selected at `signUserOperation.ts:265-268, 284-287`; v0.6 message uses raw `initCode`/`paymasterAndData` (`signUserOperation.ts:161-175`).
+- Dart: only the v0.7 typehash exists (`safe_account.dart:966-968`); `signUserOperation` accepts only `UserOperationV07` (`safe_account.dart:801`) and `SafeSmartAccount` does not implement the `SmartAccountV06` interface (`lib/src/clients/smart_account/smart_account_interface.dart:120-129`).
+
+Dart *does* carry the full v0.6 address table (`constants.dart:132-151`) and allows `entryPointVersion: v06` in config (`safe_account.dart:43`), so a v0.6-configured account computes a correct counterfactual address but then produces v0.7-typed, v0.7-EntryPoint-addressed signatures (`safe_account.dart:1008-1016`) that can never validate. This half-supported state is worse than rejecting v0.6 outright.
+
+## Finding 20 — Configurable `validAfter` / `validUntil` (missing)
+
+- JS: parameters at `toSafeSmartAccount.ts:1201-1202, 1395-1396`, threaded into both the signed SafeOp message (`signUserOperation.ts:139-140, 168-169`) and the packed signature prefix (`signUserOperation.ts:312-315`).
+- Dart: hardcoded zeros in the struct hash (`safe_account.dart:1014-1015`) and the prefix (`safe_account.dart:853-856`).
+
+Identical bytes for the default (0, 0); time-bounded signatures are impossible in Dart.
+
+## Finding 21 — Custom EntryPoint address in the SafeOp (missing)
+
+- JS: `entryPoint: entryPoint.address` in the signed message (`signUserOperation.ts:170`), honoring `parameters.entryPoint.address` (`toSafeSmartAccount.ts:1458-1465`).
+- Dart: `AbiEncoder.encodeAddress(EntryPointAddresses.v07)` hardcoded (`safe_account.dart:1016`), ignoring even its own `entryPointVersion` config (compounds Finding 19).
+
+## Finding 24 — `signMessage` / `signTypedData`: SafeMessage EIP-1271 flow absent (diverges)
+
+- JS `signMessage`: wraps the message hash in the `SafeMessage(bytes message)` typed struct with domain `{chainId, verifyingContract: safeAddress}` (`toSafeSmartAccount.ts:1846-1858`), each owner signs that hash via **eth_sign** (`localOwner.signMessage({raw})`, `toSafeSmartAccount.ts:1873-1880`), then `adjustVInSignature("eth_sign", …)` normalizes v to 27/28 and adds +4 → v ∈ {31, 32} (`toSafeSmartAccount.ts:525-547`) so Safe's `checkSignatures` re-applies the EIP-191 prefix. Threshold guard at `1836-1840`, v1.5.0+7579 guard at `1842-1844`, and in 7579 mode the result is prefixed with 20 zero bytes (`toSafeSmartAccount.ts:1898-1900`).
+- JS `signTypedData`: same SafeMessage wrapper, signed via `signTypedData` with `adjustVInSignature("eth_signTypedData", …)` (v stays 27/28) (`toSafeSmartAccount.ts:1902-1981`).
+- Dart: `signMessage`/`signTypedData` (`safe_account.dart:865-878`) hash the raw message (EIP-191 / EIP-712) and `_signHash` (`safe_account.dart:881-911`) has each owner `signRawHash` that hash directly — **no SafeMessage wrapper, no Safe domain, no eth_sign +4 adjustment, no zero-address 7579 prefix, no threshold guard**, and signatures are concatenated without the dynamic-part handling used elsewhere (`safe_account.dart:895-910` — plain string concat, so a WebAuthn contract signature would be malformed here too).
+
+Consequence: Dart Safe `signMessage`/`signTypedData` output will **fail on-chain EIP-1271 verification** (`isValidSignature` via CompatibilityFallbackHandler), which is the entire purpose of these methods in the JS reference. This is the largest behavioral gap in the port. (`signUserOperation` is unaffected — see mirrored item 23.)
+
+## Finding 25 — Standalone multi-signer `signUserOperation` helper (missing)
+
+- JS: `accounts/safe/signUserOperation.ts:114-316`, exported via `accounts/safe/index.ts` — supports collecting signatures one owner at a time across devices: intermediate results are ABI-encoded `(address,bytes,bool)[]` tuples (`signUserOperation.ts:295-310`), decoded back on the next call (`213-251`, with legacy 2-field fallback), and only packed into `uint48‖uint48‖sigs` once `signatures.length === owners.length`.
+- Dart: no equivalent; `SafeSmartAccount.signUserOperation` (`safe_account.dart:801-858`) requires every configured owner to sign in one process. Multi-device m-of-n flows cannot be reproduced.
+
+## Finding 26 — Nonce key handling (missing)
+
+- JS: `nonceKey?: bigint` parameter (`toSafeSmartAccount.ts:1203, 1397`); `getNonce` fetches from the EntryPoint with `key: nonceKey ?? args?.key` (`toSafeSmartAccount.ts:1781-1787`).
+- Dart: `nonceKey` is a fixed `BigInt.zero` getter (`safe_account.dart:214-215`) with no configuration path. Parallel nonce lanes (2D nonces) are unusable for Safe in Dart.
+
+## Finding 29 — 7579 module address resolution (diverges)
+
+- JS: in 7579 mode the `safe7579` value in InitData **is** `safe4337ModuleAddress` (`toSafeSmartAccount.ts:663, 682`), which defaults to the standard Safe 4337 module `0x75cf11467937ce3F2f357CE24ffc3DBF8fD5c226` from the address map (`toSafeSmartAccount.ts:489-490, 1097-1098`) unless the caller overrides `safe4337ModuleAddress` with the Safe7579 adapter. The signing domain uses that same address (`signUserOperation.ts:149-155, 262-263`).
+- Dart: 7579 mode force-substitutes `Safe7579Addresses.safe7579ModuleAddress = 0x7579EE8307284F293B1927136486880611F20002` (`safe_account.dart:236-238`, constant at `constants.dart:74-75`) for both InitData (`safe_account.dart:475, 583, 732`) and the EIP-712 domain (`safe_account.dart:953-955`). `customAddresses.safe4337ModuleAddress` is ignored in 7579 mode.
+
+Dart's default is the one that actually works with the canonical Rhinestone launchpad (JS callers must pass the 7579 adapter explicitly — the JS default would produce a broken 7579 account), so Dart is arguably *more* correct — but it is not the reference behavior, cannot be overridden, and a JS config using a nonstandard adapter address is unreproducible in Dart.
+
+## Finding 30 — 7579 InitData owners: WebAuthn mapping (diverges)
+
+- JS: `get7579LaunchPadInitData` maps WebAuthn owners to `safeWebAuthnSharedSignerAddress` (`toSafeSmartAccount.ts:639-652`), same as the standard initializer.
+- Dart: `_computeInitHash` and `_encodeSetupSafe` use `o.address` for every owner unconditionally (`safe_account.dart:461, 719`), unlike Dart's own standard-mode initializer which does map WebAuthn owners (`safe_account.dart:343-355`).
+
+A 7579 Safe with a WebAuthn owner gets a different (wrong) initHash → different address and failed `setupSafe` validation versus JS. Edge case (WebAuthn + 7579), but byte-level divergence.
+
+## Finding 31 — 7579 first-op `setupSafe` wrapping (diverges)
+
+- JS: `encodeCalls` checks deployment status via `isSmartAccountDeployed` and, when counterfactual, automatically wraps user calls into `setupSafe(InitData{…, callData: encode7579Calls(...)})` (`toSafeSmartAccount.ts:1603-1651`); after deployment it emits plain 7579 calls (`1653-1661`).
+- Dart: `encodeCalls` always emits plain 7579 calls (`safe_account.dart:669-671`); the caller must know to invoke the Dart-only `encodeCallsForDeployment` for the first op (`safe_account.dart:700-715`), which then produces the same `setupSafe` encoding (`encodeSetupSafe`, `lib/src/utils/encoding.dart:427-485` — tuple head offsets match JS ABI output).
+
+The encodings agree; the *selection* is manual in Dart. A caller porting JS code 1:1 will deploy a 7579 Safe whose first UserOp reverts (launchpad expects `setupSafe`).
+
+## Finding 33 — 7579 + Safe v1.5.0 guard (missing)
+
+- JS: throws `"Safe 7579 & version 1.5.0 are not compatible"` in `signMessage`/`signTypedData` (`toSafeSmartAccount.ts:1842-1844, 1909-1911`).
+- Dart: no such check anywhere in `safe_account.dart`; a 1.5.0 + launchpad config is silently accepted.
+
+## Finding 34 — Dart-only surface (dart-only)
+
+- `Safe7579Addresses` canonical constants: launchpad `0x7579011aB74c46090561ea277Ba79D510c6C00ff` and Rhinestone attester `0x000000333034E9f539ce08819E12c1b8Cb29084d` (`constants.dart:67-91`). JS ships no launchpad/attester defaults; callers supply them. Values match the canonical Rhinestone deployments.
+- `encodeCallsForDeployment` (`safe_account.dart:700-715`) — see Finding 31.
+- Hardcoded `_proxyCreationCode` (`safe_account.dart:24-25`) — see Finding 5.
+- `publicClient` config field (`safe_account.dart:47, 92-93`) is accepted but never used (address derivation is fully local); its doc comment ("computed automatically via RPC") is stale.
+- Ergonomic stub choice: approved-hash-style ECDSA stub (Finding 15) is a deliberate Dart design, not an accident, per the r=owner construction.

--- a/docs/parity-audit/01-account-simple.md
+++ b/docs/parity-audit/01-account-simple.md
@@ -1,0 +1,122 @@
+# Parity Audit 01 — Simple Smart Account (incl. EIP-7702 variant)
+
+**Reference:** permissionless.js v0.3.5 — `accounts/simple/toSimpleSmartAccount.ts`, `accounts/simple/to7702SimpleSmartAccount.ts`
+**Port:** permissionless.dart v0.3.0 — `lib/src/accounts/simple/simple_account.dart`, `eip7702_simple_account.dart`, `constants.dart`, `simple.dart`
+
+Paths below are abbreviated:
+
+- `JS` = `/Users/liorag/Documents/development/permissionless/permissionless.js/packages/permissionless/accounts/simple/toSimpleSmartAccount.ts`
+- `JS-7702` = `.../accounts/simple/to7702SimpleSmartAccount.ts`
+- `DART` = `/Users/liorag/Documents/development/permissionless/permissionless.dart/packages/permissionless/lib/src/accounts/simple/simple_account.dart`
+- `DART-7702` = `.../lib/src/accounts/simple/eip7702_simple_account.dart`
+- `DART-CONST` = `.../lib/src/accounts/simple/constants.dart`
+- `VIEM` = `/Users/liorag/Documents/development/permissionless/viem/src/account-abstraction/` (permissionless.js delegates hashing/typed-data to viem)
+- `DART-CLIENT` = `.../lib/src/clients/smart_account/smart_account_client.dart` (cited where account-level signing behavior depends on what the client feeds it)
+
+The JS account is a single implementation parameterized by EP version + `eip7702` flag; the Dart port splits it into `SimpleSmartAccount` (v0.6/v0.7/v0.8 selectable) and `Eip7702SimpleSmartAccount` (v0.8 only). Behavior was compared byte-for-byte for constants, calldata, and signed payloads. Selectors independently verified via viem `toFunctionSelector`: `execute(address,uint256,bytes)` = `0xb61d27f6`, `executeBatch(address[],uint256[],bytes[])` = `0x47e1da2a`, `executeBatch(address[],bytes[])` = `0x18dfb3c7`, `executeBatch((address,uint256,bytes)[])` = `0x34fcd5be`, `createAccount(address,uint256)` = `0x5fbfb9cf`.
+
+## Verdict table
+
+| # | Aspect | Verdict | JS | Dart |
+|---|--------|---------|----|------|
+| 1 | Factory address v0.6 `0x9406Cc6185a346906296840746125a0E44976454` | mirrors | JS:127 | DART-CONST:12-13 |
+| 2 | Factory address v0.7 `0x91E60e0613810449d098b0b5Ec8b51A0FE8c8985` | mirrors | JS:125 | DART-CONST:16-17 |
+| 3 | Factory address v0.8 `0x13E9ed32155810FDbd067D4522C492D6f68E5944` | mirrors | JS:123 | DART-CONST:20-21 |
+| 4 | Custom factory override | mirrors | JS:119 | DART:85-88 |
+| 5 | factoryData = `createAccount(owner, salt)` (`0x5fbfb9cf`), salt/index default 0 | mirrors | JS:37-73, 186 | DART:210-214, 31; DART-CONST:62 |
+| 6 | Default EP version (v0.7 non-7702, v0.8 for 7702); EP addresses | mirrors | JS:198-218; VIEM constants/address.ts:1-6 | DART:26; DART-7702:198-206; `constants/entry_point.dart:14-28` |
+| 7 | Sender address via EP `getSenderAddress` simulation; explicit `address` override | mirrors | JS:257-269 | DART:123-149 |
+| 8 | Dummy/stub signature (`0xfff...aaa1c`, both variants) | mirrors | JS:430-432 | DART:322-325; DART-7702:366-367 |
+| 9 | `execute` single-call calldata (`0xb61d27f6`, all EP versions) | mirrors | JS:334-339, 481-505 | DART:239-252; DART-7702:280-292 |
+| 10 | `executeBatch` v0.7 calldata (`0x47e1da2a`, 3 parallel arrays) | mirrors | JS:306-315, 528-552 | DART:255-315 |
+| 11 | `executeBatch` v0.6 calldata | **diverges** | JS:318-325, 507-526 | DART:225-236 |
+| 12 | `executeBatch` v0.8 calldata — non-7702 account | **diverges** | JS:291-304, 554-585 | DART:225-236 |
+| 13 | `executeBatch` v0.8 calldata — 7702 variant (`0x34fcd5be`, `Call[]` tuple array) | mirrors | JS:291-304, 554-585 | DART-7702:266-362; DART-CONST:59 |
+| 14 | `signUserOperation` v0.7 (EIP-191 personal-sign of packed v0.7 userOpHash) | mirrors | JS:460-477; VIEM getUserOperationHash.ts:90-124 | DART:331-334, 355-425; `accounts/account_owner.dart:116-129` |
+| 15 | `signUserOperation` v0.6 (v0.6 hash format) | **missing** | JS:460-477; VIEM getUserOperationHash.ts:54-88 | DART:331-334 (v0.7 format only) |
+| 16 | `signUserOperation` v0.8 — non-7702 account (EIP-712 typed data) | **diverges** | JS:446-457 | DART:331-334 |
+| 17 | `signUserOperation` v0.8 — 7702 variant: typed-data domain/types/message shape | mirrors | JS:447-457; VIEM getUserOperationTypedData.ts:18-48 | DART-7702:373-377, 431-513 |
+| 18 | 7702 typed-data `initCode` value pre-delegation | **diverges** | JS:246-251; VIEM getInitCode.ts:10-21 | DART-7702:464-472; DART-CLIENT:236-239 |
+| 19 | `signMessage` / `signTypedData` — non-7702 (ERC-1271) | **diverges** | JS:433-441 | DART:340-350 |
+| 20 | `signMessage` / `signTypedData` — 7702 variant | **dart-only** | JS:436-441 (throws) | DART-7702:393-425 |
+| 21 | `decodeCalls` | **missing** | JS:341-422 | — |
+| 22 | `nonceKey` parameter | **missing** | JS:189, 423-429 | DART:113-114 (fixed `0`) |
+| 23 | 7702: account address = owner EOA; no factory/initCode | mirrors | JS:188, 243-252 | DART-7702:219-233 |
+| 24 | 7702: delegation target default `0xe6Cae83BdE06E4c305530e199D7217f42808555B`; override param | mirrors | JS:190, 281-286 | DART-CONST:41-42; DART-7702:131-133 |
+| 25 | 7702: authorization construction (EIP-7702 auth over `accountLogicAddress`) | mirrors | JS:281-286 (viem signs `keccak256(0x05‖rlp([chainId,addr,nonce]))`) | DART-7702:248-253; `types/eip7702.dart:97-140` |
+| 26 | Empty-calls error | mirrors | JS:328-332 | DART:226-228; DART-7702:267-269 |
+
+**Counts: 15 mirrors · 5 diverges · 3 missing · 1 dart-only** (rows 11/12 and 15/16 are distinct behavioral defects even though they share a root cause: the Dart account is version-configurable but hardcodes v0.7 behavior).
+
+---
+
+## Finding 11 — diverges: v0.6 `executeBatch` uses the wrong function signature
+
+JS selects `executeBatch(address[] dest, bytes[] func)` (selector `0x18dfb3c7`) for EP v0.6, because the v0.6 SimpleAccount contract has no `value` array:
+
+- `JS:318-325` — falls through to `executeBatch06Abi` when version is neither 0.8 nor 0.7
+- `JS:507-526` — `executeBatch06Abi`: two params, `address[]` + `bytes[]`
+
+Dart `SimpleSmartAccount.encodeCalls` unconditionally encodes the three-array v0.7 form `executeBatch(address[],uint256[],bytes[])` (`0x47e1da2a`) regardless of `entryPointVersion`:
+
+- `DART:225-236` — `encodeCalls` always calls `_encodeExecuteBatch`
+- `DART:255-280` — `_encodeExecuteBatch` emits `SimpleAccountSelectors.executeBatch` (`0x47e1da2a`, DART-CONST:55) with dest/values/func arrays
+
+A `SimpleSmartAccount` configured with `EntryPointVersion.v06` (allowed by `DART:26` + factory constant `DART-CONST:12-13`) produces batch calldata for a function that does not exist on the v0.6 SimpleAccount contract. Dart has no `0x18dfb3c7` selector anywhere in the simple/ directory.
+
+## Finding 12 — diverges: v0.8 `executeBatch` on the non-7702 account uses the v0.7 array form
+
+JS uses the tuple-array form `executeBatch((address,uint256,bytes)[])` (`0x34fcd5be`) whenever `entryPoint.version === "0.8"`, for both plain and 7702 accounts:
+
+- `JS:291-304` — v0.8 branch using `executeBatch08Abi`
+- `JS:554-585` — `executeBatch08Abi` (`struct BaseAccount.Call[]`)
+
+Dart implements the tuple encoding only in the 7702 class (`DART-7702:298-362`, selector `DART-CONST:59` — verified `0x34fcd5be`, byte-layout of the manual tuple-array encoding checked and correct). The plain `SimpleSmartAccount`, which accepts `EntryPointVersion.v08` (`DART-CONST:24-29`), still emits the three-array v0.7 form (`DART:225-236`). Batch calldata from a Dart v0.8 non-7702 Simple account therefore does not match JS (and would not decode on the v0.8 SimpleAccount contract).
+
+## Finding 15 — missing: v0.6 userOpHash / signing path
+
+JS computes the version-correct hash via viem (`VIEM utils/userOperation/getUserOperationHash.ts:54-88` — v0.6 packs `callGasLimit`, `verificationGasLimit`, `maxFeePerGas`, `maxPriorityFeePerGas` as separate uint256 fields) and signs it (`JS:460-477`).
+
+Dart `SimpleSmartAccount.signUserOperation` accepts only `UserOperationV07` and always packs the v0.7 format (`DART:331-334`, `_packUserOpForHash` at `DART:370-425`: `accountGasLimits`/`gasFees` as packed bytes32). There is no v0.6 hash path. Additionally, the class implements `SmartAccount` but not `SmartAccountV06` (`clients/smart_account/smart_account_interface.dart:120-129`), and the v0.6 client flow does `account as SmartAccountV06` (`DART-CLIENT:549` region, `signUserOperationV06`), so a v0.6-configured Simple account cannot be driven through the v0.6 pipeline at all — v0.6 support is config-visible (factory constant, enum) but non-functional. JS fully supports v0.6.
+
+## Finding 16 — diverges: v0.8 non-7702 signing uses raw-hash personal-sign instead of EIP-712 typed data
+
+JS switches to EIP-712 typed-data signing for any account whose EP version is 0.8 — including a plain (non-7702) v0.8 Simple account:
+
+- `JS:446-457` — `if (entryPoint.version === "0.8") { ... getUserOperationTypedData ... localOwner.signTypedData(typedData) }`
+
+Dart implements typed-data signing only in `Eip7702SimpleSmartAccount` (`DART-7702:373-377`). The plain `SimpleSmartAccount` with `entryPointVersion: v08` falls into the personal-sign-of-v0.7-hash path (`DART:331-334`), producing a signature over the wrong payload for EP v0.8. (The v0.7 path itself mirrors: EIP-191 prefix applied by `PrivateKeyOwner.signPersonalMessage`, `accounts/account_owner.dart:116-129`, matching JS `signMessage(client, { message: { raw: hash } })` at `JS:460-476`; the Dart hand-rolled v0.7 hash at `DART:355-425` matches viem's `getUserOperationHash.ts:90-124` field-for-field.)
+
+## Finding 18 — diverges: 7702 signed `initCode` differs pre-delegation
+
+Both sides agree on the v0.8 typed-data envelope (domain `{name: 'ERC4337', version: '1', chainId, verifyingContract: entryPoint}` and the 8-field `PackedUserOperation` type — `VIEM getUserOperationTypedData.ts:18-48` vs `DART-7702:476-512`), and both pack `accountGasLimits`/`gasFees`/`paymasterAndData` identically. The divergence is the `initCode` message field for the *first* (delegating) UserOperation:
+
+- JS: the permissionless.js 7702 account returns `factory: undefined, factoryData: undefined` (`JS:243-252`), so viem's `getInitCode` yields `'0x'` (`VIEM utils/userOperation/getInitCode.ts:19`). The signed `initCode` is `0x` both pre- and post-delegation. (Note: viem's own `toSimple7702SmartAccount` instead uses factory `'0x7702'`, which `getInitCode.ts:11-17` expands to the delegation address when an authorization is attached — permissionless.js deliberately differs from viem here; the Dart port matches neither.)
+- Dart: the client marks pending delegation with factory = `0x7702000000000000000000000000000000000000` and factoryData `'0x'` (`DART-CLIENT:236-239`, marker defined at `DART-CLIENT:130-131`), and `_getUserOperationTypedData` naively concatenates `factory‖factoryData` whenever `factory != null` (`DART-7702:464-472`). The signed `initCode` is therefore the 20-byte `0x7702…0000` marker pre-delegation.
+
+Result: for the first 7702 UserOperation, the EIP-712 digest signed by Dart is byte-for-byte different from what JS signs for the same operation. Post-delegation (factory null) both sign `initCode = 0x` and mirror. Note EntryPoint v0.8 substitutes the account's actual delegate address into the hash when the `0x7702…` marker is used, so the two libraries cannot both be producing on-chain-valid first-op signatures — this row is flagged on JS-vs-Dart bytes; on-chain validity should be settled by the live-test follow-up.
+
+## Finding 19 — diverges: non-7702 `signMessage`/`signTypedData` sign instead of throwing
+
+JS deliberately rejects ERC-1271 flows because SimpleAccount (v0.6/v0.7) does not implement `isValidSignature`:
+
+- `JS:436-441` — both `signMessage` and `signTypedData` throw `"Simple account isn't 1271 compliant"`; `sign({hash})` (`JS:433-435`) routes into the same throw.
+
+Dart `SimpleSmartAccount` happily produces owner-EOA signatures:
+
+- `DART:340-343` — `signMessage` returns `owner.signPersonalMessage(hashMessage(message))`
+- `DART:349-350` — `signTypedData` returns `owner.signTypedData(typedData)`
+
+These signatures are EOA signatures that no contract will validate for the smart-account address — JS's throw is the safer, reference behavior.
+
+## Finding 20 — dart-only: 7702 `signMessage`/`signTypedData` with delegation guard
+
+JS throws for `signMessage`/`signTypedData` even in 7702 mode (same implementation object, `JS:436-441`; `JS-7702:47-50` merely forwards to `toSimpleSmartAccount` with `eip7702: true`). Dart's 7702 variant implements them: it checks the EOA has been delegated (has code) via `_ensureDeployedForEip1271` and then signs with the owner key (`DART-7702:393-425`). Since the `Simple7702Account` implementation contract is ERC-1271-capable, this is a functional extension rather than a bug, but it is behavior the reference does not have.
+
+## Finding 21 — missing: `decodeCalls`
+
+JS implements `decodeCalls` for all three EP versions (tuple array for 0.8, three arrays for 0.7, two arrays with `value: 0n` for 0.6, single-`execute` fallback) at `JS:341-422`. Neither Dart class has any decode capability (`DART`, `DART-7702` — no counterpart; `SmartAccount` interface has none). API-surface gap, no wire impact.
+
+## Finding 22 — missing: `nonceKey` parameter
+
+JS accepts a `nonceKey` construction parameter used in `getNonce` (`JS:189`, `JS:423-429`, `nonceKey ?? args?.key`). Dart hardcodes `nonceKey => BigInt.zero` with no config field (`DART:113-114`; `SimpleSmartAccountConfig` at `DART:16-59` has no such option). Parallel-nonce (2D nonce) usage is not reachable for Dart Simple accounts.

--- a/docs/parity-audit/01-account-thirdweb.md
+++ b/docs/parity-audit/01-account-thirdweb.md
@@ -1,0 +1,141 @@
+# Parity Audit: Thirdweb Smart Account
+
+**Scope**: permissionless.js v0.3.5 `accounts/thirdweb/` vs permissionless.dart v0.3.0 `lib/src/accounts/thirdweb/`
+
+**JS files**:
+- `permissionless.js/packages/permissionless/accounts/thirdweb/toThirdwebSmartAccount.ts`
+- `permissionless.js/packages/permissionless/accounts/thirdweb/utils/{getFactoryData,getAccountAddress,encodeCallData,decodeCallData,signMessage,signTypedData}.ts`
+
+**Dart files**:
+- `permissionless.dart/packages/permissionless/lib/src/accounts/thirdweb/thirdweb_account.dart`
+- `permissionless.dart/packages/permissionless/lib/src/accounts/thirdweb/constants.dart`
+- `permissionless.dart/packages/permissionless/lib/src/accounts/thirdweb/thirdweb.dart` (barrel)
+
+Selectors were independently verified with `cast sig`: `createAccount(address,bytes)` = `0xd8fd8f44`, `execute(address,uint256,bytes)` = `0xb61d27f6`, `executeBatch(address[],uint256[],bytes[])` = `0x47e1da2a`, `getAddress(address,bytes)` = `0x8878ed33` — all match the Dart constants.
+
+## Verdict Table
+
+| # | Aspect | Verdict |
+|---|--------|---------|
+| 1 | Factory address, EP v0.6 (`0x85e23b94e7F5E9cC1fF78BCe78cfb15B81f0DF00`) | mirrors |
+| 2 | Factory address, EP v0.7 (`0x4be0ddfebca9a5a4a617dee4dece99e7c862dceb`) | mirrors |
+| 3 | factoryData / initCode encoding (`createAccount(address,bytes)`) | mirrors |
+| 4 | Salt interpretation (string -> bytes) | **diverges** |
+| 5 | Counterfactual address derivation | mirrors (different mechanism, same result) |
+| 6 | Stub / dummy signature | mirrors (byte-identical) |
+| 7 | `execute` single-call calldata | mirrors |
+| 8 | `executeBatch` calldata | mirrors |
+| 9 | `decodeCalls` | **missing** |
+| 10 | `signUserOperation`, EP v0.7 (EIP-191 over userOpHash) | mirrors |
+| 11 | `signUserOperation`, EP v0.6 | **missing** |
+| 12 | `signMessage` ERC-1271 `AccountMessage` wrapping | **diverges** |
+| 13 | `signTypedData` ERC-1271 wrapping | **diverges** |
+| 14 | `signTypedData` self-verifying-contract detection | **diverges** |
+| 15 | `sign({ hash })` | missing (minor) |
+| 16 | `getNonce` / nonceKey plumbing | mirrors |
+
+Summary: 9 mirrors, 4 diverges, 3 missing.
+
+### Notes on "mirrors" rows
+
+- **1–2 (factory addresses)**: JS `toThirdwebSmartAccount.ts:39-52` (`THIRDWEB_ADDRESSES["0.6"]["1.5.20"]` / `["0.7"]["1.5.20"]`) vs Dart `constants.dart:10-15` (`factoryV06` / `factoryV07`), selected per EP version at `thirdweb_account.dart:85-89` matching JS `toThirdwebSmartAccount.ts:120-123`. Byte-identical (case differs, addresses equal). The JS `version: "1.5.20"` parameter has exactly one value, so Dart omitting it is non-behavioral.
+- **3 (factoryData)**: JS `utils/getFactoryData.ts:11-39` encodes `createAccount(address _admin, bytes _salt)`; Dart `thirdweb_account.dart:171-189` hand-encodes selector `0xd8fd8f44` + admin address + dynamic-bytes head at offset 64 + length + right-padded data — standard ABI, identical output for the same salt bytes. Both sides use it for v0.6 initCode (`thirdweb_account.dart:154-160`) and v0.7 factory/factoryData (`thirdweb_account.dart:164-168`), matching JS `getFactoryArgs` (`toThirdwebSmartAccount.ts:139-147`).
+- **5 (address)**: JS calls the factory's on-chain `getAddress(_adminSigner, _data)` view (`utils/getAccountAddress.ts:11-47`); Dart uses a pre-supplied `address` or `EntryPoint.getSenderAddress` simulation with the initCode (`thirdweb_account.dart:124-150`), and throws a `StateError` if neither is available (`thirdweb_account.dart:146-149`). Both produce the counterfactual `createAccount` deployment address, so results agree given the same salt bytes (see finding 4 for when salt bytes differ). Dart's unused `ThirdwebSelectors.getAddress` constant (`constants.dart:33`) suggests a local factory-call path was planned but not built.
+- **6 (stub signature)**: JS `toThirdwebSmartAccount.ts:177-179` and Dart `thirdweb_account.dart:301-302` — verified byte-identical by string comparison.
+- **7–8 (execute/executeBatch)**: JS `utils/encodeCallData.ts:10-80` — batch iff `calls.length > 1`, else single `execute`, throw on empty. Dart `thirdweb_account.dart:215-225` implements the same dispatch. Single-call encoding (`thirdweb_account.dart:193-211`): selector `0xb61d27f6`, address, value, bytes head at offset 96 — correct. Batch encoding (`thirdweb_account.dart:228-297`): three heads at 0x60, array lengths, per-element `bytes[]` offsets relative to the array data area — hand-checked against canonical ABI encoding, matches `encodeFunctionData` output including empty-`data` elements (JS defaults `value ?? 0n`, `data ?? "0x"`; Dart `Call` carries concrete values).
+- **10 (v0.7 signUserOperation)**: JS `toThirdwebSmartAccount.ts:199-219` — `admin.signMessage({ raw: getUserOperationHash(...) })`, i.e. EIP-191 `personal_sign` over the raw 32-byte v0.7 userOpHash with empty signature field. Dart `thirdweb_account.dart:306-309` calls `owner.signPersonalMessage(userOpHash)` (EIP-191 prefix `\x19Ethereum Signed Message:\n32`, `account_owner.dart:116-129`), with the hash computed locally in `_computeUserOpHash`/`_packUserOpForHash` (`thirdweb_account.dart:379-441`). The packing (sender, nonce, keccak(initCode), keccak(callData), accountGasLimits as 16+16 bytes, preVerificationGas, gasFees as 16+16 bytes, keccak(paymasterAndData); then keccak(hash ++ entryPoint ++ chainId)) matches viem's v0.7 `getUserOperationHash` exactly.
+- **16 (nonce)**: JS `toThirdwebSmartAccount.ts:170-176` (`parameters.nonceKey ?? args.key`); Dart exposes `nonceKey` (default 0) at `thirdweb_account.dart:113-114` for the client to use. Same effective behavior.
+
+---
+
+## Finding 4 — Salt interpretation (diverges)
+
+**JS**: the `salt` string is converted with viem's `toHex`, which UTF-8-encodes the string into bytes:
+
+- `toThirdwebSmartAccount.ts:144` — `salt: salt ? toHex(salt) : "0x"` (factoryData)
+- `toThirdwebSmartAccount.ts:159` — `salt: salt ? toHex(salt) : "0x"` (getAddress)
+
+So JS `salt: "1234"` produces salt bytes `0x31323334` (ASCII), and even an explicit `salt: "0x"` is truthy and becomes `0x3078`.
+
+**Dart**: the `salt` string is parsed as a hex string:
+
+- `thirdweb_account.dart:173-174` — `final salt = _config.salt.isEmpty ? '0x' : _config.salt; final saltBytes = Hex.decode(salt);` (`Hex.decode` strips `0x` and hex-decodes, `types/hex.dart:17-22`)
+
+So Dart `salt: '1234'` produces salt bytes `0x1234`.
+
+**Impact**: the two implementations agree only for the default (JS `salt` omitted -> `"0x"`; Dart default `'0x'` -> empty bytes). For any user-supplied salt they produce different `createAccount` calldata and therefore **different counterfactual account addresses**. A user porting `salt: "my-salt"` from JS to Dart (or passing a hex salt in either direction) lands on a different account. Dart would need to UTF-8-encode non-hex salts (and hex-encode the literal characters of `0x…` strings) to match JS byte-for-byte.
+
+---
+
+## Finding 9 — decodeCalls (missing)
+
+**JS**: `utils/decodeCallData.ts:3-87` decodes calldata back to a call list — tries `executeBatch(address[],uint256[],bytes[])` first, falls back to `execute(address,uint256,bytes)` — and is wired into the account at `toThirdwebSmartAccount.ts:167-169`.
+
+**Dart**: no decode API exists on `ThirdwebSmartAccount` or on the `SmartAccount` interface (`lib/src/clients/smart_account/smart_account_interface.dart:20-114` has only `encodeCall`/`encodeCalls`). This is a library-wide gap, not thirdweb-specific, but it is part of the JS thirdweb surface.
+
+**Impact**: functionality absent; no wrong bytes produced.
+
+---
+
+## Finding 11 — signUserOperation for EntryPoint v0.6 (missing)
+
+**JS**: fully supports EP v0.6 — the entryPoint version flows into `getUserOperationHash` (`toThirdwebSmartAccount.ts:199-219`, version at `toThirdwebSmartAccount.ts:105-112`), which uses the v0.6 packing (initCode/paymasterAndData as flat fields, separate gas fields).
+
+**Dart**: the account advertises v0.6 support — `entryPointVersion` config defaults to v0.7 but accepts v0.6 (`thirdweb_account.dart:34,51`), `factoryV06` is selected (`thirdweb_account.dart:86-89`), `entryPoint` returns `EntryPointAddresses.v06` (`thirdweb_account.dart:107-110`), and `getInitCode()` exists (`thirdweb_account.dart:154-160`) — **but there is no v0.6 signing path**:
+
+- `ThirdwebSmartAccount implements SmartAccount` only (`thirdweb_account.dart:80`); it does not implement `SmartAccountV06` (`smart_account_interface.dart:120-130`), unlike `BiconomySmartAccount` (`biconomy/biconomy_account.dart:81`) and `TrustSmartAccount` (`trust/trust_account.dart:81`).
+- `SmartAccountClient.signUserOperationV06` therefore throws `StateError('Account does not support v0.6 signing...')` (`smart_account_client.dart:541-547`).
+- `signUserOperation` takes a `UserOperationV07` and `_computeUserOpHash` packs only the v0.7 format (`thirdweb_account.dart:306-309, 379-441`); there is no v0.6 hash computation.
+
+**Impact**: a Thirdweb account configured with `EntryPointVersion.v06` can build init code and encode calls but cannot sign — the v0.6 half of the account is a trap. JS handles both versions end-to-end.
+
+---
+
+## Finding 12 — signMessage ERC-1271 wrapping (diverges)
+
+Both sides build the same `AccountMessage` EIP-712 wrapper (domain `{name: "Account", version: "1", chainId, verifyingContract: accountAddress}`, type `AccountMessage(bytes message)`, message = EIP-191 hash of the input):
+
+- JS: `utils/signMessage.ts:20-32`
+- Dart: `thirdweb_account.dart:313-332`
+
+**But the final signing step differs:**
+
+- **JS** (`signMessage.ts:22`): `admin.signTypedData(...)` — the owner signs the **EIP-712 digest directly** (`keccak256("\x19\x01" ++ domainSeparator ++ structHash)`), no EIP-191 prefix.
+- **Dart** (`thirdweb_account.dart:334-336`): `final wrappedHash = hashTypedData(wrappedTypedData); return _config.owner.signPersonalMessage(wrappedHash);` — the EIP-712 digest is **re-wrapped with the EIP-191 prefix** (`"\x19Ethereum Signed Message:\n32" ++ digest`, `account_owner.dart:116-129`) before signing.
+
+**Impact**: the Dart signature is over a different final digest and will **fail ERC-1271 `isValidSignature` verification** on the Thirdweb account contract, which recovers against the EIP-712 digest. Dart's `AccountOwner.signTypedData` (`account_owner.dart:151-168`) signs the EIP-712 hash directly and is what should be called here (the in-code comment "Thirdweb signs typed data with personal message prefix" at `thirdweb_account.dart:334` does not match the JS reference).
+
+Secondary scope note: JS accepts `SignableMessage` (UTF-8 string or `{ raw: hex }`); Dart `signMessage(String)` UTF-8-encodes only (`utils/message_hash.dart:22-36`), so raw-bytes messages cannot be expressed.
+
+---
+
+## Finding 13 — signTypedData ERC-1271 wrapping (diverges)
+
+Same root cause as Finding 12, in both branches:
+
+- **Wrapping branch** — JS `utils/signTypedData.ts:50-66`: hashes the caller's typed data, ABI-encodes the hash as `bytes32`, and signs the `AccountMessage` wrapper via `admin.signTypedData` (direct EIP-712 digest signature). Dart `thirdweb_account.dart:351-375`: builds the identical wrapper (the `encodeUint256(BigInt.parse(typedHash))` at `thirdweb_account.dart:353-355` is equivalent to JS's `encodeAbiParameters([{type:"bytes32"}], [typedHash])` at `signTypedData.ts:51-54`), but then signs `signPersonalMessage(hashTypedData(wrapper))` (`thirdweb_account.dart:374-375`) — EIP-191 prefix added on top of the EIP-712 digest.
+- **Self-verifying branch** — JS `signTypedData.ts:27-31`: `admin.signTypedData(typedData)` (direct). Dart `thirdweb_account.dart:344-349`: `signPersonalMessage(hashTypedData(typedData))` (prefixed).
+
+**Impact**: as with Finding 12, Dart signatures are over `keccak256("\x19Ethereum Signed Message:\n32" ++ eip712Digest)` instead of the EIP-712 digest itself, and will not verify via ERC-1271. Fix is to route both branches through `owner.signTypedData` / a raw-digest sign of the EIP-712 hash.
+
+---
+
+## Finding 14 — signTypedData self-verifying-contract detection (diverges)
+
+- **JS** (`utils/signTypedData.ts:21-24`):
+  ```ts
+  const isSelfVerifyingContract =
+      (typedData.domain as TypedDataDomain)?.verifyingContract?.toLowerCase() === accountAddress
+  ```
+  Only the left side is lowercased; `accountAddress` (from `this.getAddress()`, an EIP-55 checksummed address) almost always contains uppercase characters, so this comparison is effectively **always false** — JS in practice always takes the wrapping branch. (This is a known-looking case-sensitivity bug in the reference.)
+- **Dart** (`thirdweb_account.dart:345-346`): lowercases **both** sides, so the check works as intended and the self-verifying branch is actually reachable.
+
+**Impact**: for typed data whose `verifyingContract` equals the account address, JS wraps it in `AccountMessage` while Dart signs it directly — different signatures for the same input. Dart implements the intended semantics; JS exhibits the buggy ones. Flagged because the audit criterion is behavioral parity with the reference: if byte-parity with permissionless.js is the goal, Dart differs here; if correctness is the goal, Dart is right and the JS bug should be documented instead.
+
+---
+
+## Finding 15 — `sign({ hash })` (missing, minor)
+
+**JS** (`toThirdwebSmartAccount.ts:180-182`): exposes `sign({ hash })`, delegating to `signMessage({ message: hash })` (viem treats the hex string as a raw-hash message). Used by viem tooling (e.g. ERC-6492 flows).
+
+**Dart**: no `sign` method on `ThirdwebSmartAccount` or the `SmartAccount` interface (`smart_account_interface.dart:20-114`). Interface-wide gap; and since Dart's `signMessage` UTF-8-encodes its input, the JS behavior (`{ raw: hash }`) cannot currently be reproduced through it.

--- a/docs/parity-audit/01-account-trust.md
+++ b/docs/parity-audit/01-account-trust.md
@@ -1,0 +1,89 @@
+# Parity Audit: Trust Wallet (Barz) Smart Account
+
+**Scope**: permissionless.js v0.3.5 `accounts/trust/` vs permissionless.dart v0.3.0 `lib/src/accounts/trust/`
+
+**JS files**:
+- `/Users/liorag/Documents/development/permissionless/permissionless.js/packages/permissionless/accounts/trust/toTrustSmartAccount.ts`
+- `.../accounts/trust/utils/getFactoryData.ts`, `encodeCallData.ts`, `decodeCallData.ts`
+
+**Dart files**:
+- `/Users/liorag/Documents/development/permissionless/permissionless.dart/packages/permissionless/lib/src/accounts/trust/trust_account.dart`
+- `.../trust/constants.dart`, `.../trust/trust.dart` (barrel)
+
+**Method**: Side-by-side source reading, plus byte-for-byte cross-execution: viem (`encodeFunctionData`, `getUserOperationHash`, `signMessage`, `signTypedData`) vs the Dart implementation run against the same inputs and private key. Calldata (factoryData, execute, executeBatch), stub signature, and userOp signatures were compared as raw hex.
+
+## Verdict Table
+
+| # | Aspect | Verdict | JS | Dart |
+|---|--------|---------|----|------|
+| 1 | Factory address `0x729c310186a57833f622630a16d13f710b83272a` | mirrors | toTrustSmartAccount.ts:67 | constants.dart:11 |
+| 2 | Secp256k1 verification facet `0x81b9E3689390C7e74cF526594A105Dea21a8cdD5` | mirrors | toTrustSmartAccount.ts:66 | constants.dart:15 |
+| 3 | factoryData: `createAccount(address,bytes,uint256)` selector `0x296601cd`, owner = 20-byte EOA address as `bytes`, salt = index (verified byte-identical) | mirrors | utils/getFactoryData.ts:16-49, toTrustSmartAccount.ts:145-154 | trust_account.dart:172-192, constants.dart:29 |
+| 4 | initCode = factory ++ factoryData / getFactoryArgs tuple | mirrors | toTrustSmartAccount.ts:145-154 | trust_account.dart:153-169 |
+| 5 | getAddress via `getSenderAddress` (EntryPoint simulation), with optional pre-set `address` | mirrors | toTrustSmartAccount.ts:160-173 (address param :87,127) | trust_account.dart:123-149 |
+| 6 | Dummy/stub signature (identical 65-byte string, v=0x1c) | mirrors | toTrustSmartAccount.ts:187-189 | trust_account.dart:298-299 |
+| 7 | Single call: `execute(address,uint256,bytes)` selector `0xb61d27f6` (verified byte-identical incl. empty-data case) | mirrors | utils/encodeCallData.ts:52-77 | trust_account.dart:196-214, constants.dart:23 |
+| 8 | Batch: `executeBatch(address[],uint256[],bytes[])` selector `0x47e1da2a`, used when calls > 1 (verified byte-identical) | mirrors | utils/encodeCallData.ts:11-44 | trust_account.dart:218-294, constants.dart:26 |
+| 9 | signUserOperation: v0.6 userOpHash then EIP-191 personal-sign of the raw hash (verified: identical signature for identical userOp/key) | mirrors | toTrustSmartAccount.ts:209-230 | trust_account.dart:313-316, 359-390 |
+| 10 | EP version support: v0.6 only, v0.7 path rejected | mirrors | toTrustSmartAccount.ts:82-85 (type-level `"0.6"`) | trust_account.dart:109, 305-309 (`UnsupportedError`) |
+| 11 | Custom EntryPoint address override (JS `entryPoint.address` param) | diverges (minor) | toTrustSmartAccount.ts:82-85, 129-133 | trust_account.dart:109 (hardcoded) |
+| 12 | signMessage: Barz EIP-712 wrapper (`BarzMessage`, domain name "Barz", version "v0.2.0") | **diverges** | toTrustSmartAccount.ts:35-56, 193-200 | trust_account.dart:320-323, 333-356 |
+| 13 | signTypedData: same Barz EIP-712 wrapper over `hashTypedData` | **diverges** (same root cause as 12) | toTrustSmartAccount.ts:201-208 | trust_account.dart:327-330, 333-356 |
+| 14 | `sign({ hash })` (raw sign entry point, delegates to signMessage) | missing | toTrustSmartAccount.ts:190-192 | no counterpart (interface: smart_account_interface.dart:36-129) |
+| 15 | decodeCalls (executeBatch/execute calldata decoding) | missing | utils/decodeCallData.ts:3-88, toTrustSmartAccount.ts:177-179 | no counterpart in trust/ or interface |
+| 16 | nonceKey passthrough for getNonce | mirrors | toTrustSmartAccount.ts:180-186 | trust_account.dart:112-113 |
+
+Counts: **10 mirrors, 3 diverges (2 of them one root cause, 1 minor), 2 missing, 0 dart-only.**
+
+---
+
+## Finding 1 (diverges, HIGH): signMessage / signTypedData sign the wrong digest
+
+**JS behavior** (`toTrustSmartAccount.ts:35-56`): both `signMessage` and `signTypedData` funnel into `_signTypedData`, which calls `signer.signTypedData({...})` with the Barz domain. viem's `signTypedData` signs the **EIP-712 digest directly** — `sign(keccak256("\x19\x01" ‖ domainSeparator ‖ structHash))` — with no EIP-191 personal-message prefix.
+
+```ts
+// toTrustSmartAccount.ts:41-55
+return signer.signTypedData({
+    domain: { chainId, name: "Barz", verifyingContract: accountAddress, version: "v0.2.0" },
+    types: { BarzMessage: [{ name: "message", type: "bytes" }] },
+    message: { message: hashedMessage },
+    primaryType: "BarzMessage"
+})
+```
+
+**Dart behavior** (`trust_account.dart:333-356`): `_signWithBarzWrapper` builds the identical Barz `TypedData`, but then computes `hashTypedData(wrappedTypedData)` itself and passes the digest to `owner.signPersonalMessage(hash)`:
+
+```dart
+// trust_account.dart:353-355
+// Trust signs typed data with personal message prefix
+final hash = hashTypedData(wrappedTypedData);
+return _config.owner.signPersonalMessage(hash);
+```
+
+`PrivateKeyOwner.signPersonalMessage` (`account_owner.dart:116-129`) prepends `"\x19Ethereum Signed Message:\n32"` and re-hashes before signing. So Dart signs `keccak256(EIP-191 prefix ‖ eip712Digest)` while JS signs `eip712Digest`. The comment in the Dart code asserting "Trust signs typed data with personal message prefix" contradicts the JS reference.
+
+**Empirical proof** (same key `0x59c6...690d`, message `'hello'`, account `0x4444...4444`, chainId 11155111):
+- JS `signTypedData` (Barz wrapper): `0x461b0fe38f4c33023993a07c4f39f9957295250657ad5d9332c8cab134e276344d5c0308b8971abf79cb4ea4980c581ad1b44f4a862ff2be9854a57ac3db7f841c`
+- Dart `signMessage('hello')`: `0xa1f5e89edd8c0a1579b16ae14430b7af78a85935870d39d1746aceabb1a57ec61864a2379ce16baaf495463c054962a08e04df27a1b1e3342686c297305d01131c`
+
+**Impact**: signatures produced by Dart `signMessage`/`signTypedData` will fail Barz's ERC-1271 on-chain verification (which expects the EIP-712 digest signature per the reference). `signUserOperation` is unaffected (verified identical, Finding table row 9).
+
+**Fix**: `_signWithBarzWrapper` should call `_config.owner.signTypedData(wrappedTypedData)` — that method already exists and signs the EIP-712 digest raw (`account_owner.dart:151-169`) — instead of `hashTypedData` + `signPersonalMessage`.
+
+## Finding 2 (diverges, minor): custom EntryPoint address not configurable
+
+JS accepts `entryPoint: { address, version: "0.6" }` and uses `parameters.entryPoint?.address ?? entryPoint06Address` (`toTrustSmartAccount.ts:82-85, 129-133`), so a nonstandard v0.6 EntryPoint deployment can be targeted. Dart hardcodes `EntryPointAddresses.v06` (`trust_account.dart:109`) with no config parameter (`TrustSmartAccountConfig`, `trust_account.dart:30-64`). Behavior is identical for the canonical EntryPoint; only the override capability is absent.
+
+## Finding 3 (missing): `sign({ hash })`
+
+JS exposes `sign` (`toTrustSmartAccount.ts:190-192`), delegating to `signMessage({ message: hash })` — used by viem infrastructure (e.g., ERC-1271 flows). The Dart `SmartAccountV06` interface (`smart_account_interface.dart:36-129`) has no raw `sign` method and `TrustSmartAccount` provides none. Callers can approximate via `signMessage`, but note viem's `sign` treats the hash hex string as a UTF-8 message (`hashMessage(hexString)`), which Dart's `signMessage(String)` (`trust_account.dart:320-323`, `message_hash.dart:22-36`) would reproduce if called with the hash string — so the gap is API surface, not a conflicting encoding.
+
+## Finding 4 (missing): `decodeCalls`
+
+JS implements `decodeCallData` (`utils/decodeCallData.ts:3-88`) wired as `decodeCalls` (`toTrustSmartAccount.ts:177-179`): tries `executeBatch(address[],uint256[],bytes[])` first, falls back to `execute(address,uint256,bytes)`. Dart has no decode counterpart anywhere in `lib/src/accounts/trust/` and the interface defines none. This appears to be a library-wide omission in the Dart port (no account exposes decode), not Trust-specific.
+
+## Notes (non-behavioral)
+
+- `PrivateKeyOwner.publicKey` (`account_owner.dart:104-113`) is documented as "Required by TrustAccount for the Barz factory" but is never used — the factory owner bytes are the 20-byte EOA address on both sides (matching JS `localOwner.address`, `toTrustSmartAccount.ts:149`). The doc comment is stale, the behavior is correct.
+- Dart `getAddress` throws `StateError` when neither `address` nor `publicClient` is supplied (`trust_account.dart:144-148`); JS always has a client by construction. Equivalent when used as documented.
+- Byte-for-byte verified vectors: `createAccount` factoryData, initCode, `execute` (with and without calldata), `executeBatch` (2 calls, mixed empty data), stub signature, and v0.6 userOp signature all match viem output exactly.

--- a/docs/parity-audit/02-userop-encoding.md
+++ b/docs/parity-audit/02-userop-encoding.md
@@ -1,0 +1,171 @@
+# Parity Audit 02 — UserOperation Core Types, Packing, Hashing & Serialization
+
+**Reference:** permissionless.js v0.3.5 (`permissionless.js/packages/permissionless`) + viem account-abstraction utils (`viem/src/account-abstraction`)
+**Port:** permissionless.dart v0.3.0 (`permissionless.dart/packages/permissionless`)
+
+## Scope
+
+UserOperation v0.6 / v0.7 field sets, the `PackedUserOperation` layout (`accountGasLimits`, `gasFees`,
+`initCode`, `paymasterAndData`), `userOpHash` computation per EntryPoint version, JSON-RPC hex serialization
+rules (deepHexlify / formatUserOperationRequest parity), and EntryPoint address constants.
+
+Note on structure: permissionless.js/viem expose **one** shared `getUserOperationHash` (viem
+`account-abstraction/utils/userOperation/getUserOperationHash.ts`) that branches on EP version. The Dart port
+has **no shared hash function** — every account re-implements `_computeUserOpHash` / `_packUserOp` inline.
+Byte layouts below were verified against the actual Dart packing code in each account plus the shared
+`packed_user_operation.dart`, not against names.
+
+## Verdict Table
+
+| # | Aspect | Verdict | JS/viem | Dart |
+|---|--------|---------|---------|------|
+| 1 | `getPackedUserOperation` top-level (v0.7) | **mirrors** | `utils/getPackedUserOperation.ts:108` | `utils/packed_user_operation.dart:99` |
+| 2 | `initCode` = factory ‖ factoryData | **mirrors** | `getPackedUserOperation.ts:7` | `packed_user_operation.dart:123` |
+| 3 | `accountGasLimits` = verificationGasLimit(16) ‖ callGasLimit(16) | **mirrors** | `getPackedUserOperation.ts:29` | `packed_user_operation.dart:142` |
+| 4 | `gasFees` = maxPriorityFee(16) ‖ maxFee(16) | **mirrors** | `getPackedUserOperation.ts:47` | `packed_user_operation.dart:155` |
+| 5 | `paymasterAndData` = paymaster(20) ‖ pmVerGas(16) ‖ pmPostOpGas(16) ‖ pmData | **mirrors** | `getPackedUserOperation.ts:63` | `packed_user_operation.dart:171` |
+| 6 | Unpack helpers (initCode/gasLimits/gasFees/paymaster) | **mirrors** | `getPackedUserOperation.ts:16,40,56,91` | `packed_user_operation.dart:220,262,301,348` |
+| 7 | v0.6 field set (initCode, paymasterAndData, split gas) | **mirrors** | viem `types/userOperation.ts:210` | `types/user_operation.dart:111` |
+| 8 | v0.7 field set (factory/factoryData, split paymaster fields) | **mirrors** | viem `types/userOperation.ts:99` | `types/user_operation.dart:247` |
+| 9 | v0.6 userOpHash (10-field abi.encode + keccak, then EP+chainId) | **mirrors** | `getUserOperationHash.ts:54` | `biconomy_account.dart:382`, `kernel_account.dart:616`, `trust_account.dart:359` |
+| 10 | v0.7 userOpHash (8-field packed abi.encode + keccak, then EP+chainId) | **mirrors** | `getUserOperationHash.ts:90` | `simple_account.dart:355`, `kernel_account.dart:692`, others |
+| 11 | v0.8 userOpHash (EIP-712 typed data, `ERC4337` domain) | **mirrors** | `getUserOperationHash.ts:44` + `getUserOperationTypedData.ts` | `eip7702_simple_account.dart:431` |
+| 12 | EntryPoint v0.6 / v0.7 addresses | **mirrors** | viem `constants/address.ts:1,3` | `constants/entry_point.dart:14,21` |
+| 13 | EntryPoint v0.8 address | **mirrors** (case only) | viem `constants/address.ts:5` | `constants/entry_point.dart:27` |
+| 14 | JSON-RPC quantity encoding (minimal hex) | **mirrors** | viem `numberToHex` / `deepHexlify.ts:17` | `hex.dart:82` (`fromBigInt`) |
+| 15 | v0.7 optional paymaster/factory fields omitted when null | **mirrors** | `formatUserOperationRequest.ts:20` | `user_operation.dart:380` |
+| 16 | EntryPoint v0.9 support | **missing** | viem `constants/address.ts:7`, `getUserOperationHash.ts:44` | absent |
+| 17 | `0x7702` factory sentinel in `getInitCode` | **missing** | viem `getInitCode.ts:10` | `packed_user_operation.dart:123` / per-account packers |
+| 18 | `paymasterSignature` append in packed `paymasterAndData` (v0.9) | **missing** | viem `toPackedUserOperation.ts:50` | absent |
+| 19 | Shared `getUserOperationHash` util | **diverges** | single `getUserOperationHash.ts` | duplicated per-account, no shared util |
+| 20 | Pad/quantity overflow guard (size exceeded) | **diverges** | viem `pad` throws `SizeExceedsPaddingSizeError` | `hex.dart:41` silently returns oversize |
+| 21 | Address casing in RPC output | **diverges** (cosmetic) | viem emits EIP-55 checksummed | Dart emits lowercase (`address.dart:15`) |
+| 22 | `AbiEncoder.encodeUint128` naming vs behavior | **dart-only** (mislabel, correct output) | n/a | `encoding.dart:21` |
+
+**Counts:** mirrors 15, diverges 4, missing 3, dart-only 1.
+
+---
+
+## Finding 16 — EntryPoint v0.9 not supported (missing)
+
+viem defines `entryPoint09Address` (`viem/src/account-abstraction/constants/address.ts:7`) and
+`getUserOperationHash` routes both `'0.8'` and `'0.9'` through the EIP-712 typed-data path
+(`getUserOperationHash.ts:44`). The Dart `EntryPointVersion` enum stops at `v08`
+(`types/user_operation.dart:14-32`) and `EntryPointAddresses` has no v0.9 entry
+(`constants/entry_point.dart:8-37`).
+
+Impact: **low for this reference version.** permissionless.js v0.3.5 itself uses no `"0.9"` string in its
+non-test source (grep over `packages/permissionless` returns nothing); v0.9 exists only in the underlying
+viem. So this is a viem-level capability the Dart port has not pulled forward, not a v0.3.5 feature gap.
+
+## Finding 17 — `0x7702` factory sentinel not handled in initCode packing (missing)
+
+viem's `getInitCode` treats a factory value of `0x7702` (or the padded
+`0x7702000000000000000000000000000000000000`) specially: it substitutes the EIP-7702 authorization's
+delegation address, or emits the sentinel unchanged when no authorization is present
+(`viem/src/account-abstraction/utils/userOperation/getInitCode.ts:10-21`).
+
+The Dart packers — both the shared `getInitCode` (`packed_user_operation.dart:123-131`) and every
+per-account `_packUserOp` (e.g. `kernel_account.dart:709`, `simple_account.dart:373`) — implement only the
+plain branch:
+
+```dart
+if (userOperation.factory == null) return '0x';
+return Hex.concat([userOperation.factory!.hex, userOperation.factoryData ?? '0x']);
+```
+
+Impact: **low.** The Dart EIP-7702 accounts (`eip7702_simple_account.dart`, `eip7702_kernel_account.dart`)
+never set `factory` to the sentinel — they return a `null` factory (`eip7702_simple_account.dart:230-233`)
+and sign via EntryPoint v0.8 EIP-712 typed data, which does not route through the sentinel logic. So no
+current Dart code path needs it. It only diverges if a caller manually constructs a UserOperation with
+`factory = 0x7702`, which the port never does.
+
+## Finding 18 — `paymasterSignature` not appended to packed `paymasterAndData` (missing)
+
+viem's `toPackedUserOperation` appends an optional `paymasterSignature` after `paymasterData` inside
+`paymasterAndData` (`viem/src/account-abstraction/utils/userOperation/toPackedUserOperation.ts:50`). Neither
+the Dart `UserOperationV07` type (`types/user_operation.dart:247`) nor `getPaymasterAndData`
+(`packed_user_operation.dart:171`) has a `paymasterSignature` field/branch.
+
+Impact: **low.** `paymasterSignature` is a v0.9-only concern; permissionless.js v0.3.5's own
+`getPackedUserOperation.ts` (the direct reference for this scope) does not emit it either — it is present
+only in viem's newer packer. Ties to Finding 16.
+
+## Finding 19 — Hash computation duplicated per account instead of a shared util (diverges)
+
+viem centralizes all hashing in one `getUserOperationHash` that branches on EP version
+(`getUserOperationHash.ts:24`). The Dart port has no equivalent shared function; each account carries its own
+copy: `_computeUserOpHash` / `_packUserOp` in `simple_account.dart:355`, `nexus_account.dart:353`,
+`light_account.dart:396`, `thirdweb_account.dart:379`, `kernel_account.dart:692`,
+`eip7702_kernel_account.dart:362`, `etherspot_account.dart:448`, and the v0.6 variants
+`_computeUserOpHashV06` in `biconomy_account.dart:382`, `kernel_account.dart:616`, `trust_account.dart:359`.
+
+Behavior verified identical across all copies (byte-for-byte same packing: `keccak256` of
+`abi.encode(sender, nonce, keccak(initCode), keccak(callData), accountGasLimits, preVerificationGas, gasFees,
+keccak(paymasterAndData))` then `keccak256(abi.encode(innerHash, entryPoint, chainId))`). This is a
+**structural / maintainability** divergence, not a behavioral one — but the duplication is a drift risk: a
+future fix must be applied in ~11 places. Recommend extracting a shared `getUserOperationHash(userOp,
+entryPoint, chainId, version)` mirroring viem.
+
+## Finding 20 — No pad/quantity overflow guard (diverges)
+
+viem's `pad` throws `SizeExceedsPaddingSizeError` when a value is wider than the requested size (used for the
+16-byte gas fields). Dart's `Hex.padLeft` (`hex.dart:41-49`) and `Hex.fromBigInt(..., byteLength:)`
+(`hex.dart:82-89`) instead return the value **unchanged** when it already exceeds the target width — no throw,
+no truncation. A `verificationGasLimit`/`callGasLimit`/fee that overflows uint128 would silently produce a
+mis-sized `accountGasLimits`/`gasFees` blob (and a wrong hash) rather than failing fast.
+
+Impact: **low in practice** (gas values never approach 2^128) but it is a correctness guard viem has and the
+port lacks.
+
+## Finding 21 — RPC address casing differs (diverges, cosmetic)
+
+viem formatters emit EIP-55 checksummed addresses in RPC payloads. Dart `toJson` uses `sender.hex` /
+`factory!.hex` / `paymaster!.hex`, and the `hex` getter returns the **lowercase** form (`with0x`,
+`types/address.dart:15`). Bundlers accept both, and hashing is case-insensitive (addresses are keccak-hashed
+as bytes), so this is cosmetic. A checksummed getter (`checksummed`, `address.dart:18`) exists but is not used
+in serialization.
+
+## Finding 22 — `encodeUint128` mislabeled but behaviorally correct (dart-only)
+
+`AbiEncoder.encodeUint128` (`encoding.dart:21`) is documented "16 bytes, left-padded to 32 bytes" and
+`encodeUint48` similarly, but both call `Hex.fromBigInt(value, byteLength: 32)`, producing a full 32-byte
+ABI word. That is the **correct** ABI encoding for any `uintN` (all integers pad to 32 bytes), so output is
+right; only the doc/name is misleading. Not used in the packed-userop 16-byte fields (those use
+`padLeft(..., 16)` / `byteLength: 16` directly), so no impact on packing.
+
+---
+
+## Confirmed mirrors (evidence)
+
+- **Packing byte layout** (Findings 2–5): field widths and concatenation order match viem exactly —
+  `initCode` = factory(20)‖factoryData; `accountGasLimits` = verificationGasLimit(16)‖callGasLimit(16);
+  `gasFees` = maxPriorityFeePerGas(16)‖maxFeePerGas(16); `paymasterAndData` =
+  paymaster(20)‖pmVerGas(16)‖pmPostOpGas(16)‖pmData. `'0x'` returned when factory/paymaster absent, matching
+  viem's ternaries. Defaults for missing paymaster gas fields are `BigInt.zero` on both sides
+  (`packed_user_operation.dart:179,184` vs `getPackedUserOperation.ts:71,80`).
+- **v0.6 hash** (Finding 9): 10-field `abi.encode` with `keccak(initCode)`, `keccak(callData)`,
+  `keccak(paymasterAndData)` and the un-packed gas fields as separate uint256s, exactly per
+  `getUserOperationHash.ts:62-87`. Verified in `biconomy_account.dart:396`, `kernel_account.dart:630`,
+  `trust_account.dart` packers.
+- **v0.7 hash** (Finding 10): 8-field packed `abi.encode` with `accountGasLimits`/`gasFees` as `bytes32`
+  and `keccak` of initCode/callData/paymasterAndData, per `getUserOperationHash.ts:90-113`. Verified across
+  `simple/nexus/light/thirdweb/kernel/etherspot`. Final wrapper
+  `keccak256(abi.encode(hash, entryPoint, chainId))` matches `getUserOperationHash.ts:119`.
+- **v0.8 typed-data hash** (Finding 11): Dart's `_getUserOperationTypedData`
+  (`eip7702_simple_account.dart:431-512`) reproduces viem's `getUserOperationTypedData` field-for-field —
+  domain `{ name: 'ERC4337', version: '1', chainId, verifyingContract: entryPoint }`, primaryType
+  `PackedUserOperation`, and the same 8 typed fields (`initCode`/`callData`/`paymasterAndData` as `bytes`,
+  `accountGasLimits`/`gasFees` as `bytes32`). Matches `getUserOperationTypedData.ts:18-48`.
+- **EntryPoint addresses** (Findings 12–13): v0.6 `0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789` and v0.7
+  `0x0000000071727De22E5E9d8BAf0edAc6f37da032` are byte-identical to viem. v0.8
+  `0x4337084d9e255ff0702461cf8895ce9e3b5ff108` matches viem's `0x4337084D9E255Ff0702461CF8895CE9E3b5Ff108`
+  up to EIP-55 casing only (both parse to the same address).
+- **Quantity serialization** (Finding 14): `Hex.fromBigInt` with no `byteLength` emits minimal hex
+  (`value.toRadixString(16)`), e.g. `0x186a0`, `0x0` for zero — matching viem `numberToHex` minimal
+  quantities and `deepHexlify`'s bigint branch. Dart has no `deepHexlify` helper but achieves equivalent
+  output field-by-field in each `toJson` and in the pimlico/bundler client serializers
+  (`pimlico_client.dart:342`).
+- **Optional-field omission** (Finding 15): `UserOperationV07.toJson` omits `factory`, `factoryData`,
+  `paymaster`, `paymasterVerificationGasLimit`, `paymasterPostOpGasLimit`, `paymasterData` when null
+  (`user_operation.dart:393-412`), matching `formatUserOperationRequest`'s `typeof !== 'undefined'` guards.

--- a/docs/parity-audit/03-actions.md
+++ b/docs/parity-audit/03-actions.md
@@ -1,0 +1,191 @@
+# Parity Audit 03 — Smart-Account Actions & ERC-7579 Actions
+
+**Scope**: `actions/smartAccount/` (sendTransaction, sendCalls, getCallsStatus, signMessage, signTypedData, writeContract) and `actions/erc7579/` (installModule(s), uninstallModule(s), isModuleInstalled, supportsModule, supportsExecutionMode, accountId), permissionless.js v0.3.5 vs permissionless.dart v0.3.0.
+
+**JS root**: `/Users/liorag/Documents/development/permissionless/permissionless.js/packages/permissionless`
+**Dart root**: `/Users/liorag/Documents/development/permissionless/permissionless.dart/packages/permissionless`
+
+Key Dart files:
+- `lib/src/actions/smart_account/smart_account_actions.dart`
+- `lib/src/actions/erc7579/erc7579_actions.dart`
+- `lib/src/actions/erc7579/module_queries.dart`
+- `lib/src/utils/erc7579.dart` (encoding backend, equivalent to JS `utils/encodeInstallModule.ts` / `utils/encodeUninstallModule.ts` and the inline ABIs in the JS actions)
+
+**Headline finding**: 4 of the 7 hard-coded ERC-7579 function selectors in the Dart port are **wrong** (`uninstallModule`, `isModuleInstalled`, `supportsModule`, `accountId`). Every Dart action built on them produces calldata that no ERC-7579 account will recognize. The unit tests assert the same wrong constants, so they pass while the on-chain behavior is broken.
+
+---
+
+## Verdict table
+
+| # | Aspect | Verdict | Notes |
+|---|--------|---------|-------|
+| 1 | sendTransaction → userop conversion (value/data defaults, single-call wrapping) | mirrors | `value ?? 0`, `data = '0x'` on both sides |
+| 2 | sendTransaction receipt wait / return value on timeout | **diverges** | JS throws on timeout; Dart silently returns the userop hash as if it were a tx hash |
+| 3 | sendTransaction userop-params passthrough form (batch `calls`) | **diverges** (minor) | JS accepts `SendUserOperationParameters`; Dart only single `to/value/data` |
+| 4 | sendCalls (EIP-5792 submit, no wait) | mirrors | Both return the userop hash as the call-bundle id, no receipt wait |
+| 5 | getCallsStatus (EIP-5792 status + receipt mapping) | mirrors | pending=100 / success=200 / failure=500, `version '1.0'`, `atomic: true`, spec-shaped receipt |
+| 6 | signMessage delegation | **diverges** (minor) | Delegation to account mirrors; Dart accepts `String` only, JS also accepts raw bytes/hex. No ERC-6492 wrapping in either (JS does none at the action layer) |
+| 7 | signTypedData delegation | mirrors | Dart auto-adds `EIP712Domain` type like JS; JS additionally runs `validateTypedData` pre-flight (Dart relies on hashing to fail) — cosmetic, not encoded output |
+| 8 | writeContract ABI encoding path | **diverges** (major) | Dart uses a hand-rolled signature-string encoder: dynamic `bytes` args are mis-encoded (no offset head), `string`/arrays/tuples/`int` unsupported, no `dataSuffix` |
+| 9 | Module type id mapping (validator=1, executor=2, fallback=3, hook=4) | mirrors | |
+| 10 | installModule / installModules calldata + batching | mirrors | Selector `0x9517e29f` correct; one call per module to the account address, value 0 |
+| 11 | install/uninstall parameter surface (paymaster override, authorization, appended `calls`) | **diverges** (minor) | JS supports per-op paymaster/paymasterContext/authorization/extra calls; Dart has none of these |
+| 12 | uninstallModule / uninstallModules calldata | **diverges (CRITICAL)** | Wrong selector `0xa4d6f1d2` (actual: `0xa71763a8`) |
+| 13 | isModuleInstalled read call | **diverges (CRITICAL)** | Wrong selector `0x6d61fe70` (that is `onInstall(bytes)`; actual: `0x112d3a7d`); also errors swallowed → `false`, no counterfactual fallback |
+| 14 | supportsModule read call | **diverges (CRITICAL)** | Wrong selector `0x12d79da3` (actual: `0xf2dc691d`) |
+| 15 | accountId read call | **diverges (CRITICAL)** | Wrong selector `0x7b60424a` (actual: `0x9cfd7cff`); errors swallowed → `''` |
+| 16 | supportsExecutionMode mode encoding (callType/execType/selector/payload packing) | **diverges** | Layout and selector `0xd03c7914` mirror; but the `revertOnError` → execType byte is **inverted** relative to JS when set explicitly (defaults happen to coincide) |
+| 17 | Counterfactual (undeployed account) fallback for all four query actions | **diverges** | JS retries via `call` with `factory`/`factoryData`; Dart has no equivalent |
+| 18 | Fallback-module selector special-casing in install initData | mirrors | Neither side special-cases module type 3; init/context bytes passed through verbatim |
+| 19 | installModuleAndWait / uninstallModuleAndWait / getInstalledModulesOfType / standalone `module_queries.dart` functions | dart-only | Convenience additions, no JS counterpart |
+
+**Counts**: mirrors 8 · diverges 10 (4 critical) · missing 0 · dart-only 1 group (4 helpers).
+
+---
+
+## Critical: 4 wrong hard-coded ERC-7579 selectors (rows 12–15)
+
+JS never hard-codes selectors — every action/util builds calldata from an inline ABI via viem's `encodeFunctionData`:
+
+- `utils/encodeUninstallModule.ts:58` (`name: "uninstallModule"`, encoded at `utils/encodeUninstallModule.ts:80-85`)
+- `actions/erc7579/isModuleInstalled.ts:60-77` (ABI) and `:87-95` (readContract args, `context ?? additionalContext` at `:92`)
+- `actions/erc7579/supportsModule.ts:59-77` (ABI), invoked at `:79-87`
+- `actions/erc7579/accountId.ts:37-50` (ABI), invoked at `:52-58`
+
+Dart hard-codes the selectors in `Erc7579Selectors` and four of them do not match `keccak256(signature)[0:4]`:
+
+| Function | Dart constant (`lib/src/utils/erc7579.dart`) | Actual selector | Status |
+|---|---|---|---|
+| `installModule(uint256,address,bytes)` | `0x9517e29f` (`erc7579.dart:77`) | `0x9517e29f` | correct |
+| `uninstallModule(uint256,address,bytes)` | `0xa4d6f1d2` (`erc7579.dart:81`) | `0xa71763a8` | **WRONG** |
+| `isModuleInstalled(uint256,address,bytes)` | `0x6d61fe70` (`erc7579.dart:85`) | `0x112d3a7d` | **WRONG** |
+| `supportsModule(uint256)` | `0x12d79da3` (`erc7579.dart:89`) | `0xf2dc691d` | **WRONG** |
+| `accountId()` | `0x7b60424a` (`erc7579.dart:93`) | `0x9cfd7cff` | **WRONG** |
+| `supportsExecutionMode(bytes32)` | `0xd03c7914` (`erc7579.dart:97`) | `0xd03c7914` | correct |
+| `execute(bytes32,bytes)` | `0xe9ae5c53` (`erc7579.dart:73`) | `0xe9ae5c53` | correct |
+
+Selectors verified with `cast sig` / `cast keccak` (e.g. `keccak256("uninstallModule(uint256,address,bytes)") = 0xa71763a8...`).
+
+Notably, `0x6d61fe70` is the selector of **`onInstall(bytes)`** — the Dart codebase even uses that same constant correctly under that name at `lib/src/accounts/etherspot/constants.dart:46` — so `isModuleInstalled` was evidently copy-pasted from the wrong signature.
+
+Consequences (all calldata built in `lib/src/utils/erc7579.dart` and consumed by `lib/src/actions/erc7579/erc7579_actions.dart` and `lib/src/actions/erc7579/module_queries.dart`):
+
+- `uninstallModule` / `uninstallModules` (`erc7579_actions.dart:142-164`, `:189-216` → `encode7579UninstallModule`, `erc7579.dart:432-448`): the userop executes a call to the account with an unknown selector — at best reverts, at worst hits a fallback handler. **Module uninstallation cannot work.**
+- `isModuleInstalled` (`erc7579_actions.dart:370-390`; `module_queries.dart:26-41` → `encode7579IsModuleInstalled`, `erc7579.dart:470-486`): eth_call reverts or returns garbage; combined with the catch-all (`erc7579_actions.dart:387-389`) the method **always returns `false`**.
+- `supportsModule` (`erc7579_actions.dart:341-355`; `module_queries.dart:64-72` → `erc7579.dart:501-504`): same failure mode, always `false`.
+- `getAccountId` (`erc7579_actions.dart:402-415`; `module_queries.dart:88-95` → `erc7579.dart:541`): always returns `''` (catch at `erc7579_actions.dart:412-414`).
+- The Dart-only `getInstalledModulesOfType` (`module_queries.dart:116-138`) is built on the broken `isModuleInstalled`, so it always returns an empty list.
+
+The unit tests lock in the wrong values instead of catching them: `test/utils/erc7579_test.dart:327-343` asserts `0xa4d6f1d2`, `0x6d61fe70`, `0x12d79da3`, `0x7b60424a` with comments claiming they are the keccak prefixes.
+
+Everything else about the calldata layout mirrors JS: `uint256 moduleTypeId` + `address module` + dynamic `bytes` at offset `0x60` (`erc7579.dart:398-448, 470-486` vs the viem-encoded ABIs above), and the module type ids match (`Erc7579ModuleType` 1/2/3/4 at `erc7579.dart:15-38` vs `parseModuleTypeId` at `actions/erc7579/supportsModule.ts:25-36`).
+
+---
+
+## supportsExecutionMode: execType bit inverted vs JS (row 16)
+
+JS (`actions/erc7579/supportsExecutionMode.ts:46-61`) packs `bytes1 callType | bytes1 execType | bytes4 unused | bytes4 selector | bytes22 payload` and sets:
+
+```ts
+toHex(toBytes(revertOnError ? "0x01" : "0x00", { size: 1 }))   // :56
+```
+
+i.e. `revertOnError: true` → execType `0x01`.
+
+Dart (`lib/src/utils/erc7579.dart:195-225`, `ExecutionMode.encode`):
+
+```dart
+mode[1] = revertOnError ? 0x00 : 0x01;   // erc7579.dart:202
+```
+
+i.e. `revertOnError: true` → execType `0x00` — the opposite bit for the same flag value.
+
+Per ERC-7579 the Dart semantics are the correct ones (`0x00` = default/revert, `0x01` = try), and the JS mapping is arguably a reference bug; but as a parity matter the two SDKs disagree whenever the caller sets `revertOnError` explicitly. They coincide only by accident on defaults: JS `revertOnError` is optional (`supportsExecutionMode.ts:24-29`, undefined → falsy → `0x00`) and Dart defaults `revertOnError = true` → `0x00` (`erc7579.dart:161`).
+
+Everything else mirrors: callType byte 0x00/0x01/0xff (`getCallType`, `supportsExecutionMode.ts:35-44` vs `Erc7579CallKind`, `erc7579.dart:103-131`), selector right-padded into bytes 6–9, context into bytes 10–31 (`supportsExecutionMode.ts:57-60` vs `erc7579.dart:206-222`), selector `0xd03c7914`, and a plain `bytes32` argument (`erc7579.dart:523-526`).
+
+Error handling diverges as described in the next section: Dart returns `false` on any call failure (`erc7579_actions.dart:320-323`).
+
+---
+
+## Query actions: no counterfactual fallback, errors swallowed (rows 13–15, 17)
+
+All four JS read actions (`accountId`, `isModuleInstalled`, `supportsModule`, `supportsExecutionMode`) share a pattern: try `readContract` against the deployed account; on `ContractFunctionExecutionError`, retry as an `eth_call` with `factory`/`factoryData` so the query works for **undeployed (counterfactual) accounts**, and rethrow anything else:
+
+- `actions/erc7579/accountId.ts:62-91` (fallback at `:63-64`)
+- `actions/erc7579/isModuleInstalled.ts:97-131`
+- `actions/erc7579/supportsModule.ts:88-118` (fallback at `:89-90`)
+- `actions/erc7579/supportsExecutionMode.ts:126-156` (fallback at `:127-128`)
+
+Dart performs a single `publicClient.call` and converts **any** exception into a benign answer:
+
+- `supportsExecutionMode` → `false` (`erc7579_actions.dart:316-323`)
+- `supportsModule` → `false` (`erc7579_actions.dart:348-354`)
+- `isModuleInstalled` → `false` (`erc7579_actions.dart:383-389`)
+- `getAccountId` → `''` (`erc7579_actions.dart:408-414`)
+
+(The standalone versions in `module_queries.dart:26-95` don't catch, but also have no counterfactual fallback.)
+
+Behavioral differences: (a) queries against not-yet-deployed accounts return `false`/`''` in Dart but real answers in JS; (b) transport/RPC failures are indistinguishable from "not supported" in Dart, whereas JS propagates them. Also minor: JS `isModuleInstalled` accepts `context ?? additionalContext` (`isModuleInstalled.ts:92`); Dart exposes only `additionalContext` (`erc7579_actions.dart:374`) — same wire bytes, narrower input surface.
+
+---
+
+## writeContract: hand-rolled encoder, dynamic `bytes` mis-encoded (row 8)
+
+JS delegates encoding entirely to viem's `encodeFunctionData` with a full ABI and supports `dataSuffix` concatenation (`actions/smartAccount/writeContract.ts:50-53`, `:61`), then routes through `sendTransaction`.
+
+Dart (`smart_account_actions.dart:122-143`) parses a signature string and encodes each argument independently (`_encodeFunction`, `:268-300`; `_encodeArg`, `:303-338`), then flat-concatenates: `AbiEncoder.encodeFunctionCall` is `selector + concat(params)` (`lib/src/utils/encoding.dart:54-58`).
+
+Divergences:
+
+1. **Dynamic `bytes` produces invalid ABI encoding.** `_encodeArg('bytes', v)` returns `AbiEncoder.encodeBytes(v)` (`smart_account_actions.dart:333-335`), which is the *tail* (length word + padded data, `encoding.dart:33-42`). `_encodeFunction` inlines that tail into the head positions with no offset pointer, so any signature containing a `bytes` parameter (e.g. `execute(address,uint256,bytes)`) yields calldata the contract cannot decode. The codebase has a correct helper for this (`AbiEncoder.encodeWithDynamics`, `encoding.dart:64+`) but `writeContract` does not use it. JS handles all of this via viem.
+2. **Type coverage.** Only `address`, `uint*`, `bool`, `bytes32`, `bytes` are supported; `string`, arrays, tuples, `int*`, fixed-size arrays throw `ArgumentError` (`smart_account_actions.dart:337`). JS supports the full ABI.
+3. **No `dataSuffix`** equivalent (JS: `writeContract.ts:61`).
+4. `uint*` widths are all encoded as full 32-byte words (`smart_account_actions.dart:313-323`) — this is actually correct ABI behavior, noted only because the doc comment implies width-awareness.
+
+---
+
+## sendTransaction: timeout fallback returns the wrong kind of hash (rows 2–3)
+
+Both sides convert a `{to, value, data}` triple to a single-call userop with identical defaults — JS `value || BigInt(0)`, `data || "0x"` (`actions/smartAccount/sendTransaction.ts:107-108`), Dart `value` defaulting to 0 via `Call` (`lib/src/types/user_operation.dart:450-454`) and `data = '0x'` (`smart_account_actions.dart:78, 85`) — then wait for the receipt and return `receipt.transactionHash` (`sendTransaction.ts:124-132` vs `smart_account_actions.dart:91-94`).
+
+Divergences:
+
+1. **Timeout semantics.** JS `waitForUserOperationReceipt` throws (`WaitForUserOperationReceiptTimeoutError`) if the op is not included, so a returned hash is always a transaction hash. Dart's `waitForReceipt` returns `null` on timeout (`lib/src/clients/bundler/bundler_client.dart:208-224`) and `sendTransaction` then falls back to returning the **UserOperation hash** (`smart_account_actions.dart:94`: `receipt?.receipt?.transactionHash ?? hash`). The caller receives a value that looks like a tx hash but will never resolve via `eth_getTransactionReceipt`.
+2. **No userop-params form.** JS `sendTransaction` also accepts full `SendUserOperationParameters` (multiple `calls`, paymaster override, etc.) when no `to` field is present (`sendTransaction.ts:78, 117-121`); Dart supports only the single-call named-parameter form (`smart_account_actions.dart:75-83`). Batch senders must drop to `sendUserOperation`. Minor, since the capability exists elsewhere.
+3. Cross-cutting API note (applies to all send-type actions in this scope): Dart requires explicit `maxFeePerGas`/`maxPriorityFeePerGas` (`smart_account_actions.dart:79-80`); JS treats them as optional overrides resolved by the client's gas estimation.
+
+---
+
+## signMessage: string-only input (row 6)
+
+JS accepts viem's `SignMessageParameters`, i.e. `message: string | { raw: Hex | ByteArray }`, and delegates to `account.signMessage({ message })` (`actions/smartAccount/signMessage.ts:62, 72`). Dart accepts `String message` only and delegates to `account.signMessage(message)` (`smart_account_actions.dart:39`). Raw-bytes payloads (e.g. signing a 32-byte hash under EIP-191) cannot be expressed through the Dart action. Delegation itself mirrors; neither side applies ERC-6492 wrapping at the action layer (in JS that lives on the account implementations, out of this unit's scope).
+
+---
+
+## install/uninstall parameter surface (row 11)
+
+JS `installModule`/`installModules`/`uninstallModule`/`uninstallModules` accept per-operation `paymaster` / `paymasterContext` overrides, EIP-7702 `authorization`, and **extra `calls` appended after the module-management calls** in the same userop (`actions/erc7579/installModule.ts:16, 66-67, 83-97` — `...(calls ?? [])` at `:89`; same shape in `installModules.ts:57-96`, `uninstallModule.ts:76-98`, `uninstallModules.ts:44-87`). JS also accepts `context` as an alias for `initData`/`deInitData` (`utils/encodeInstallModule.ts:86`, `utils/encodeUninstallModule.ts:84`).
+
+Dart exposes only `type`/`address`/`initData|deInitData`/gas fees/`nonce` (`erc7579_actions.dart:47-54, 96-101, 142-149, 189-194`); paymaster behavior comes solely from client construction, and there is no way to piggyback additional calls or an authorization onto the module-management userop. Batching of the module list itself mirrors (one `Call` per module targeting the account address, `erc7579_actions.dart:108-115, 201-208` vs `encodeInstallModule.ts:50-56` map). Two trivial extras: Dart rejects empty module lists (`erc7579_actions.dart:102-104, 195-197`) where JS would submit an empty-call userop, and Dart's `Call` defaults `value` to 0 exactly like JS's explicit `BigInt(0)` (`encodeInstallModule.ts:55` vs `user_operation.dart:454`).
+
+---
+
+## Dart-only additions (row 19)
+
+Not divergences — additive convenience APIs with no JS counterpart:
+
+- `installModuleAndWait` (`erc7579_actions.dart:223-247`) and `uninstallModuleAndWait` (`erc7579_actions.dart:254-278`): compose the send action with `waitForReceipt`.
+- `getInstalledModulesOfType` (`module_queries.dart:116-138`): sequentially probes candidate module addresses via `isModuleInstalled` (currently non-functional due to the selector bug above).
+- Standalone address-based query functions in `module_queries.dart:26-95` (`isModuleInstalled`, `supportsModule`, `getAccountId` taking an explicit account address rather than a client) — parallel to but distinct from the client-extension versions.
+
+---
+
+## Mirrors (verified, no section needed)
+
+- **sendCalls** (`actions/smartAccount/sendCalls.ts:27-37` vs `smart_account_actions.dart:173-184`): both submit a userop and return the hash as the EIP-5792 bundle id without waiting (JS wraps it as `{ id }`, Dart returns the `String` — same information).
+- **getCallsStatus** (`actions/smartAccount/getCallsStatus.ts:52-90` vs `smart_account_actions.dart:210-241`): identical mapping — receipt found → `success`/`failure` with statusCode 200/500 from `receipt.success`; not found (throw in JS, `null`/throw in Dart) → `pending`/100; `version: '1.0'`, `atomic: true`; receipt projected to `{status, logs(address/topics/data), blockHash, blockNumber, gasUsed, transactionHash}` (`getCallsStatus.ts:68-78` vs `smart_account_actions.dart:244-259`; Dart's `status == 1 → 'success' : 'reverted'` matches viem's hex-status semantics).
+- **signTypedData** (`actions/smartAccount/signTypedData.ts:136-156` vs `smart_account_actions.dart:47-48`): both delegate to the account; the `EIP712Domain` type JS injects via `getTypesForEIP712Domain` (`signTypedData.ts:138`) is auto-derived inside Dart's `TypedData` hashing (`lib/src/types/typed_data.dart:143`). JS's extra `validateTypedData` pre-flight (`signTypedData.ts:144`) only changes *which* error malformed input throws, not any signature bytes.
+- **Module type id mapping**: `parseModuleTypeId` 1/2/3/4 (`actions/erc7579/supportsModule.ts:25-36`) ≡ `Erc7579ModuleType` enum ids (`lib/src/utils/erc7579.dart:15-38`).
+- **installModule calldata**: selector `0x9517e29f` + `(uint256, address, bytes@0x60)` (`utils/encodeInstallModule.ts:56-88` vs `erc7579.dart:398-415`).
+- **Fallback-module handling**: neither implementation special-cases module type 3 (no selector packed into initData) — the caller supplies the fully-formed context bytes on both sides.

--- a/docs/parity-audit/04a-clients-pimlico-etherspot.md
+++ b/docs/parity-audit/04a-clients-pimlico-etherspot.md
@@ -1,0 +1,156 @@
+# Parity Audit 04a — Pimlico and Etherspot Client Extensions
+
+Scope: permissionless.js v0.3.5 `actions/pimlico/*`, `actions/etherspot/*`, `clients/pimlico.ts`, `clients/decorators/pimlico.ts`, `types/pimlico.ts`, `types/etherspot.ts` vs permissionless.dart v0.3.0 `lib/src/clients/pimlico/`, `lib/src/clients/etherspot/`, `lib/src/clients/paymaster/` (plus `lib/src/experimental/pimlico/erc20_paymaster.dart` where it overlaps).
+
+Paths below are abbreviated:
+
+- JS = `/Users/liorag/Documents/development/permissionless/permissionless.js/packages/permissionless`
+- Dart = `/Users/liorag/Documents/development/permissionless/permissionless.dart/packages/permissionless/lib/src`
+
+## Priority question (answered)
+
+**Does Dart implement `validateSponsorshipPolicies`, `estimateErc20PaymasterCost`, and `getTokenQuotes`?** Yes — all three exist on `PimlicoClient`:
+
+- `getTokenQuotes` — Dart `clients/pimlico/pimlico_client.dart:160-182` — **mirrors** the JS action.
+- `validateSponsorshipPolicies` — Dart `clients/pimlico/pimlico_client.dart:286-309` — exists but **diverges**: it sends RPC method `pimlico_validateSponsorshipPolicies` while JS/Pimlico use `pm_validateSponsorshipPolicies`.
+- `estimateErc20PaymasterCost` — Dart `clients/pimlico/pimlico_client.dart:239-255` — exists but **diverges**: it calls a nonexistent RPC method `pimlico_estimateErc20PaymasterCost`, while JS computes the cost locally from `getTokenQuotes` + `getRequiredPrefund`. A correct local-computation variant exists at Dart `experimental/pimlico/erc20_paymaster.dart:312-345`, but it omits `costInUsd`.
+
+## Verdict table
+
+| # | Action | JS | Dart | Verdict |
+|---|--------|----|------|---------|
+| 1 | `getUserOperationGasPrice` (Pimlico) | `actions/pimlico/getUserOperationGasPrice.ts:49` | `clients/pimlico/pimlico_client.dart:74-77`, `clients/pimlico/types.dart:103-136` | mirrors |
+| 2 | `getUserOperationStatus` | `actions/pimlico/getUserOperationStatus.ts:46`, enum `types/pimlico.ts:20-28` | `clients/pimlico/pimlico_client.dart:57-65`, `clients/pimlico/types.dart:9-65` | mirrors |
+| 3 | `sendCompressedUserOperation` | `actions/pimlico/sendCompressedUserOperation.ts:56-58`, schema `types/pimlico.ts:57-64` | `clients/pimlico/pimlico_client.dart:90-107` | **diverges** |
+| 4 | `sponsorUserOperation` (`pm_sponsorUserOperation`) | `actions/pimlico/sponsorUserOperation.ts:88-151` | `clients/paymaster/paymaster_client.dart:99-113`, `clients/paymaster/types.dart:99-242` | mirrors (see notes) |
+| 5 | `validateSponsorshipPolicies` | `actions/pimlico/validateSponsorshipPolicies.ts:67-74` | `clients/pimlico/pimlico_client.dart:286-309` | **diverges** |
+| 6 | `getTokenQuotes` | `actions/pimlico/getTokenQuotes.ts:57-77` | `clients/pimlico/pimlico_client.dart:160-182`, `clients/pimlico/types.dart:152-225` | mirrors |
+| 7 | `estimateErc20PaymasterCost` | `actions/pimlico/estimateErc20PaymasterCost.ts:60-102` | `clients/pimlico/pimlico_client.dart:239-255` (+ `experimental/pimlico/erc20_paymaster.dart:312-345`) | **diverges** |
+| 8 | Etherspot `getUserOperationGasPrice` (`skandha_getGasPrice`) | `actions/etherspot/getUserOperationGasPrice.ts:24-26` | `clients/etherspot/etherspot_client.dart:57-60`, `clients/etherspot/types.dart:24-28` | mirrors |
+| 9 | `getSupportedTokens` (`pimlico_getSupportedTokens`) | — (not in JS v0.3.5) | `clients/pimlico/pimlico_client.dart:196-218` | dart-only |
+| 10 | `waitForUserOperationStatus` | — | `clients/pimlico/pimlico_client.dart:113-136` | dart-only |
+
+Counts: 5 mirrors, 3 diverges, 0 missing, 2 dart-only.
+
+Architecture note (not a verdict): JS `createPimlicoClient` (`clients/pimlico.ts:96-124`) composes bundler + paymaster + pimlico actions on one client. Dart splits this: `PimlicoClient extends BundlerClient` (`clients/pimlico/pimlico_client.dart:34`) carries the `pimlico_*` methods, while `pm_*` sponsorship methods live on the separate `PaymasterClient` (`clients/paymaster/paymaster_client.dart:35`). Behavior per method is what is audited below.
+
+---
+
+## Finding 3: `sendCompressedUserOperation` — diverges (wrong param shape, would fail at runtime)
+
+**JS** sends exactly 3 params, first being the pre-compressed calldata hex blob:
+
+- `actions/pimlico/sendCompressedUserOperation.ts:56-58`:
+  `params: [compressedUserOperation, inflatorAddress, entryPointAddress]`
+- Schema confirms: `types/pimlico.ts:57-64` — `Parameters: [compressedUserOperation: Hex, inflatorAddress: Address, entryPoint: Address]`.
+- JS also marks the action `@deprecated` (`sendCompressedUserOperation.ts:20`, `clients/decorators/pimlico.ts:86`) since EIP-4844.
+
+**Dart** sends 4 params in a different order, with a full user-operation JSON map first (`clients/pimlico/pimlico_client.dart:97-105`):
+
+```dart
+final result = await rpcClient.call(
+  'pimlico_sendCompressedUserOperation',
+  [
+    packedUserOp,          // <-- not in the JS/Pimlico API at all
+    entryPoint.hex,
+    compressedCalldata,
+    inflator.hex,
+  ],
+);
+```
+
+Impact:
+
+- Param 1 should be the compressed hex string, param 2 the inflator address, param 3 the entryPoint. Dart's call does not match the API and would be rejected by Pimlico's bundler.
+- Dart's signature also demands the uncompressed `UserOperationV07` (`pimlico_client.dart:90-94`), which the RPC method never receives in JS.
+- No deprecation notice on the Dart side.
+
+Suggested fix: change the Dart method to `sendCompressedUserOperation(String compressedUserOperation, EthereumAddress inflator)` sending `[compressedUserOperation, inflator.hex, entryPoint.hex]`, and mark it deprecated.
+
+## Finding 5: `validateSponsorshipPolicies` — diverges (wrong RPC method name; v0.7-only; unpacked vs packed userop)
+
+**JS** (`actions/pimlico/validateSponsorshipPolicies.ts:67-73`):
+
+```ts
+method: "pm_validateSponsorshipPolicies",
+params: [deepHexlify(args.userOperation), args.entryPointAddress, args.sponsorshipPolicyIds]
+```
+
+Schema: `types/pimlico.ts:126-131` — method is `pm_validateSponsorshipPolicies` and the userOperation may be any entry-point version.
+
+**Dart** (`clients/pimlico/pimlico_client.dart:296-303`):
+
+```dart
+final result = await rpcClient.call(
+  'pimlico_validateSponsorshipPolicies',   // wrong prefix: should be pm_
+  [ packedUserOp, entryPoint.hex, sponsorshipPolicyIds ],
+);
+```
+
+Divergences:
+
+1. **RPC method name**: `pimlico_validateSponsorshipPolicies` vs JS `pm_validateSponsorshipPolicies`. Pimlico's endpoint is `pm_`-prefixed; the Dart call will get "method not found".
+2. **v0.7 only**: Dart takes `required UserOperationV07 userOperation` (`pimlico_client.dart:287`); JS accepts any `UserOperation` (v0.6 included).
+3. Param 1 serialization: both send the unpacked v0.7 shape with hex fields (Dart `_packUserOperationV07`, `pimlico_client.dart:339-369`, matches JS `deepHexlify` output for v0.7, modulo Dart omitting `factory`/`paymaster` groups when absent, which JS also effectively does since undefined keys are dropped in JSON). This part is fine.
+4. Minor: Dart short-circuits to `[]` on empty `sponsorshipPolicyIds` (`pimlico_client.dart:290-292`); JS always issues the request. Harmless.
+5. Response parsing: Dart `PimlicoSponsorshipPolicyData.fromJson` (`clients/pimlico/types.dart:295-301`) casts `name`/`author` with `as String` (non-null), but the JS type declares them `string | null` (`validateSponsorshipPolicies.ts:15-19`). A null `name`/`author` would throw a cast error in Dart.
+
+Suggested fix: rename the RPC string to `pm_validateSponsorshipPolicies`, accept both entry-point versions, and make `name`/`author`/`icon`/`description` nullable in parsing.
+
+## Finding 7: `estimateErc20PaymasterCost` — diverges (RPC call to a method that does not exist; JS computes locally)
+
+**JS** performs no dedicated RPC call. `actions/pimlico/estimateErc20PaymasterCost.ts:60-102` fetches quotes via `getTokenQuotes` and computes:
+
+```ts
+const userOperationMaxCost = getRequiredPrefund({ userOperation, entryPointVersion })   // :83
+const maxCostInWei = userOperationMaxCost + postOpGas * userOperation.maxFeePerGas      // :89
+const costInToken = (maxCostInWei * exchangeRate) / BigInt(1e18)                        // :93
+const costInUsd = (maxCostInWei * exchangeRateNativeToUsd) / 10n ** 18n                 // :96
+```
+
+There is no `pimlico_estimateErc20PaymasterCost` entry anywhere in the JS RPC schema (`types/pimlico.ts`).
+
+**Dart** `PimlicoClient.estimateErc20PaymasterCost` (`clients/pimlico/pimlico_client.dart:245-252`) instead issues:
+
+```dart
+final result = await rpcClient.call(
+  'pimlico_estimateErc20PaymasterCost',
+  [ packedUserOp, entryPoint.hex, token.hex ],
+);
+```
+
+This RPC method is not part of Pimlico's API (per the JS reference schema), so the client method will fail with "method not found" against a real endpoint. Its return type `PimlicoErc20PaymasterCost` (`clients/pimlico/types.dart:366-399`) also documents `costInUsd` as 8-decimal, whereas JS documents 6 decimals (`estimateErc20PaymasterCost.ts:19` "10^6 decimals"; the code divides by 10^18 with `exchangeRateNativeToUsd` being 6-decimal per `getTokenQuotes`).
+
+Dart does have a behaviorally correct local-computation counterpart at `experimental/pimlico/erc20_paymaster.dart:312-345`:
+
+- Gas sum (`erc20_paymaster.dart:326-332`) matches JS `getRequiredPrefund` for v0.7 (`utils/getRequiredPrefund.ts:36-45`): preVerificationGas + callGasLimit + verificationGasLimit + paymasterVerificationGasLimit + paymasterPostOpGasLimit, times maxFeePerGas.
+- `maxCostInToken` formula (`erc20_paymaster.dart:334-337`) matches JS `costInToken` (`estimateErc20PaymasterCost.ts:89-93`).
+- However it returns `Erc20CostEstimate` with **no `costInUsd`** (`erc20_paymaster.dart:339-344`), it is v0.7-only, and it lives under `experimental/` rather than on the client where JS exposes it (`clients/decorators/pimlico.ts:140-152, 186-191`).
+
+Suggested fix: reimplement `PimlicoClient.estimateErc20PaymasterCost` as a local computation delegating to `getTokenQuotes` (like the experimental helper), add `costInUsd = maxCostInWei * exchangeRateNativeToUsd / 1e18`, support v0.6 via the prefund multiplier rule (`getRequiredPrefund.ts:20-33`), and remove the fictitious RPC method string.
+
+---
+
+## Mirrors — supporting evidence
+
+**1. Pimlico `getUserOperationGasPrice`.** JS `pimlico_getUserOperationGasPrice` with `params: []`, mapping slow/standard/fast `{maxFeePerGas, maxPriorityFeePerGas}` to bigint (`actions/pimlico/getUserOperationGasPrice.ts:48-66`). Dart identical: method at `clients/pimlico/pimlico_client.dart:75` (the RPC client defaults `params` to `[]`, `clients/bundler/rpc_client.dart:43-51`), three tiers parsed to `BigInt` at `clients/pimlico/types.dart:82-86, 116-122`.
+
+**2. Pimlico `getUserOperationStatus`.** JS `pimlico_getUserOperationStatus` with `params: [hash]` (`actions/pimlico/getUserOperationStatus.ts:46-48`); status enum `not_found | not_submitted | submitted | rejected | reverted | included | failed` (`types/pimlico.ts:20-28`). Dart identical method/params (`clients/pimlico/pimlico_client.dart:60-63`) and the same seven documented status strings (`clients/pimlico/types.dart:36-44`); status is kept as `String` rather than an enum, so unknown values pass through (lenient superset). Dart additionally parses an optional `receipt` field (`types.dart:23-31`) not present in the JS type — harmless extra.
+
+**4. `pm_sponsorUserOperation`.** JS params: `[deepHexlify(userOperation), entryPoint.address, finalPaymasterContext?]` where `sponsorshipPolicyId` is merged into the paymaster context (`actions/pimlico/sponsorUserOperation.ts:91-107`). Dart `PaymasterClient.sponsorUserOperation` sends `[userOp.toJson(), entryPoint.hex, context?]` (`clients/paymaster/paymaster_client.dart:105-111`); `PaymasterContext.toJson` emits `sponsorshipPolicyId`, `token`, and arbitrary extras (`clients/paymaster/types.dart:236-241`), and `UserOperationV07.toJson` hexlifies BigInts identically to `deepHexlify` (`types/user_operation.dart:380-415`). Response: JS branches on entry-point version, BigInt-converting gas fields and returning `paymasterAndData` (v0.6) or `paymaster/paymasterData/...` (v0.7) (`sponsorUserOperation.ts:109-151`); Dart `SponsorUserOperationResult.fromJson` key-sniffs `paymasterAndData` vs `paymaster` and BigInt-converts the same fields (`clients/paymaster/types.dart:117-162`), and `withSponsorshipV06` re-concatenates paymaster+data back into `paymasterAndData` (`paymaster_client.dart:201-211`) — behaviorally equivalent. Notes (not verdict-changing):
+
+- JS allows the userOperation's gas fields to be absent (`PartialBy<...>`; `sponsorUserOperation.ts:27-43`) so the paymaster can estimate; Dart `UserOperationV07` requires all gas fields (`types/user_operation.dart:250-258`), forcing callers to send explicit zeros instead of omitting the keys.
+- Dart's method lives on `PaymasterClient`, not `PimlicoClient`; a `PimlicoClient` instance cannot sponsor directly, unlike JS `createPimlicoClient` output.
+- `PaymasterRpcError` (`clients/paymaster/types.dart:245-269`) is declared but never thrown; errors surface as `BundlerRpcError` from `clients/bundler/rpc_client.dart:74-82` with the same code/message/data fields.
+
+**6. `pimlico_getTokenQuotes`.** JS params `[{ tokens }, entryPointAddress, numberToHex(chainId)]`, response `{ quotes: [...] }` with `postOpGas/exchangeRate/exchangeRateNativeToUsd` hex-to-BigInt and optional `balanceSlot/allowanceSlot` (`actions/pimlico/getTokenQuotes.ts:57-77`). Dart identical param shape and order (`clients/pimlico/pimlico_client.dart:164-173`), unwraps `quotes` (`:177`), same BigInt conversions with optional slots (`clients/pimlico/types.dart:169-184`). Two benign differences: Dart resolves chainId via an `eth_chainId` RPC round-trip (`pimlico_client.dart:163`) instead of client config (JS throws `ChainNotFoundError` when unset, `getTokenQuotes.ts:53-55`); and Dart treats `exchangeRateNativeToUsd` as nullable (`types.dart:175-177`) where JS assumes it present — Dart is the lenient side.
+
+**8. Etherspot `skandha_getGasPrice`.** JS: method with `params: []`, both fields `BigInt(...)` (`actions/etherspot/getUserOperationGasPrice.ts:24-31`). Dart identical (`clients/etherspot/etherspot_client.dart:58-59`, `clients/etherspot/types.dart:24-28`; `parseBigInt` accepts hex or decimal strings, matching `BigInt(string)` behavior). JS has no dedicated Etherspot client/decorator in v0.3.5 (only the barrel `actions/etherspot.ts`); Dart's `EtherspotClient extends BundlerClient` (`etherspot_client.dart:29`) is a reasonable structural equivalent and adds nothing beyond this one method.
+
+## Dart-only items
+
+**9. `getSupportedTokens` (`pimlico_getSupportedTokens`)** — `clients/pimlico/pimlico_client.dart:196-218`, types at `clients/pimlico/types.dart:239-275`. No counterpart anywhere in permissionless.js v0.3.5 (grep for `getSupportedTokens` returns nothing). Useful extension; flag as intentional dart-only surface.
+
+**10. `waitForUserOperationStatus`** — polling helper over `getUserOperationStatus` with terminal-state detection (`clients/pimlico/pimlico_client.dart:113-136`). No JS counterpart (JS relies on viem's `waitForUserOperationReceipt`). Dart-only convenience.
+
+Also noted: `experimental/pimlico/erc20_paymaster.dart` (`prepareUserOperationForErc20Paymaster`, lines 103-294) parallels JS `experimental/pimlico/` — that surface belongs to the experimental audit unit; here it was only consulted for Finding 7.

--- a/docs/parity-audit/04b-clients-core.md
+++ b/docs/parity-audit/04b-clients-core.md
@@ -1,0 +1,158 @@
+# Parity Audit 04b — Smart-Account Client Pipeline & Native Bundler/Paymaster/Public Clients
+
+**Reference:** permissionless.js v0.3.5 (`createSmartAccountClient.ts`, `clients/decorators/smartAccount.ts`, `actions/public/*`), which delegates the UserOperation pipeline to **viem**'s account-abstraction actions. viem is therefore the behavioral reference for `prepareUserOperation`, `estimateUserOperationGas`, `sendUserOperation`, `waitForUserOperationReceipt`, `getPaymasterData`/`getPaymasterStubData`.
+
+**Port:** permissionless.dart v0.3.0 (`lib/src/clients/smart_account/`, `lib/src/clients/bundler/`, `lib/src/clients/paymaster/`, `lib/src/clients/public/`).
+
+The Dart port does **not** wrap viem; it re-implements the whole middleware pipeline natively inside `SmartAccountClient.prepareUserOperationWithAuth`, plus hand-rolled bundler/paymaster/public JSON-RPC clients. This audit compares behavior, not shape.
+
+## Scope note
+
+permissionless.js itself is thin here: `createSmartAccountClient` just assembles a viem client, attaches `bundlerActions` + `smartAccountActions`, and stores `paymaster` / `paymasterContext` / `userOperation` config. All the pipeline logic lives in viem `prepareUserOperation.ts`. The Dart `SmartAccountClient` collapses viem's `createBundlerClient` + `prepareUserOperation` + `sendUserOperation` + `waitForUserOperationReceipt` into one class. So "JS side" citations point to viem where the logic actually is.
+
+---
+
+## Verdict table
+
+| # | Aspect | Verdict |
+|---|--------|---------|
+| 1 | prepareUserOperation middleware order (sender/nonce/factory → stub sig → paymaster stub → gas est → paymaster final → sign) | **mirrors** |
+| 2 | UserOperation partial-override semantics (override any field: callData, gas, signature, paymaster, factory) | **diverges** |
+| 3 | Fee estimation (`userOperation.estimateFeesPerGas` hook / `estimateFeesPerGas` 2× buffer fallback) | **missing** |
+| 4 | Gas-limit multipliers / defaults applied after estimation | **dart-only** |
+| 5 | eth_estimateUserOperationGas params + state-override support | **mirrors** |
+| 6 | Gas-estimation "estimate only if a field is missing" + preserve populated values | **diverges** |
+| 7 | pm_getPaymasterStubData / pm_getPaymasterData param arity & context | **diverges** |
+| 8 | Paymaster `isFinal` short-circuit | **mirrors** |
+| 9 | pm_sponsorUserOperation (v0.6 combined path) param arity | **mirrors** |
+| 10 | getAccountNonce (EntryPoint.getNonce encoding + key) | **mirrors** |
+| 11 | getSenderAddress (helper-bytecode deploy trick vs. revert-decode) | **diverges** |
+| 12 | waitForUserOperationReceipt (timeout default, throw-vs-null, error classification) | **diverges** |
+| 13 | sendUserOperation (retryCount:0, no client retry) | **mirrors** |
+| 14 | getChainId / eth_supportedEntryPoints | **mirrors** |
+| 15 | Client-level `paymasterContext` default fallback | **missing** |
+| 16 | Default nonce key source (viem `nonceKeyManager` timestamp vs. fixed `nonceKey`) | **diverges** (benign for Safe) |
+| 17 | eip7702 authorization insertion into prepare pipeline | **mirrors** (dart-only marker mechanics) |
+
+Counts: **mirrors 7**, **diverges 6**, **missing 2**, **dart-only 1** (plus one mirrors-with-caveat on 17).
+
+---
+
+## 1. Middleware order — mirrors
+
+viem `prepareUserOperation.ts:419-705` runs: concurrently fill `callData` / `factory` (or `initCode` for 0.6) / `fees` / `nonce` / `authorization` (`:419-535`) → fill stub `signature` (`:553-560`) → paymaster **stub** for estimation (`:585-607`) → gas estimation (`:621-679`) → paymaster **final** for sending (`:687-705`).
+
+Dart `smart_account_client.dart:201-323` runs the same sequence: resolve `sender`/`authorization` (`:210-214`), `isDeployed` + nonce (`:216-230`), factory/initCode (`:232-247`), build UserOp with stub signature (`:261-273`), paymaster stub (`:276-285`), gas estimate (`:293-306`), paymaster final gated on `!stubData.isFinal` (`:309-317`). Signing is a separate step (`signUserOperation`, `:328-331`), matching viem where `sendUserOperation.ts:137-138` signs after `prepareUserOperation`.
+
+Order verdict: mirrors. The remaining findings are about *what happens inside* each step.
+
+## 2. UserOperation partial-override semantics — diverges
+
+viem accepts a partially- or fully-formed UserOperation and only fills what is missing. Every step guards on the caller-supplied value:
+- `callData`: uses `parameters.callData` if `calls` absent (`prepareUserOperation.ts:420-435`).
+- `factory`/`initCode`: honors `parameters.initCode` / `parameters.factory`+`factoryData` before calling `account.getFactoryArgs()` (`:436-457`).
+- `nonce`: `if (typeof parameters.nonce === 'bigint') return parameters.nonce` (`:513-514`).
+- `signature`: `if (parameters.signature !== undefined) request.signature = parameters.signature` (`:553-555`).
+- gas fields: each is `request.x ?? gas.x` (`:665-677`); if all gas fields are pre-supplied, the estimate RPC is skipped entirely (`:636-644`).
+
+Dart exposes only `nonce` and `sender` as overrides (`smart_account_client.dart:153-160`, `201-208`). `callData` is always computed from `calls` (`:249-258`), `signature` is always the stub then re-signed, gas limits are always estimated and overwritten (`:293-306`, `_applyGasEstimate` `:632-674`), and factory is always derived from the account. There is no way to pass a pre-formed UserOp or pin an individual gas field. Divergence: the Dart pipeline is prescriptive, not fill-the-gaps.
+
+## 3. Fee estimation hook / fallback — missing
+
+viem fills fees inside prepare (`prepareUserOperation.ts:458-511`):
+1. If both `maxFeePerGas` and `maxPriorityFeePerGas` are supplied, keep them.
+2. Else if `bundlerClient.userOperation.estimateFeesPerGas` hook exists, call it (`:469-479`). This is exactly the seam permissionless.js exposes in `createSmartAccountClient.ts:97-119` (`userOperation.estimateFeesPerGas`) and how a Pimlico gas-price oracle is injected.
+3. Else fall back to viem `estimateFeesPerGas` and apply a **2× buffer** on both fields (`:482-507`): `2n * fees.maxFeePerGas`.
+
+Dart makes `maxFeePerGas` and `maxPriorityFeePerGas` **required parameters** on every entry point (`smart_account_client.dart:155-156`, `202-206`, `394-402`, `483-490`). There is no in-pipeline fee hook and no 2× buffer. Fee estimation exists only as *standalone helpers* the caller must invoke and pass in manually: `estimateFees` (`utils/gas.dart:272-291`, 1.1× default) and `estimateFeesFromPimlico` (`utils/gas.dart:305-321`, no buffer). So the automatic "estimateFeesPerGas hook" middleware step is missing, and the 2×-buffer fallback behavior is absent. Practical consequence: a caller who forwards raw `eth_maxPriorityFeePerGas` without buffering will be under viem's effective floor and may be rejected by strict bundlers.
+
+## 4. Gas-limit multipliers / post-estimation defaults — dart-only
+
+viem returns **raw bundler gas estimates** from prepare — it applies no multiplier to `callGasLimit` / `verificationGasLimit` / `preVerificationGas` (`prepareUserOperation.ts:665-677` just does `request.x ?? gas.x`). The only buffer viem applies anywhere is the 2× on *fees* (see #3), not on gas limits.
+
+Dart applies a whole buffering layer that has no counterpart in viem/permissionless.js:
+- `GasMultipliers.standard` = 1.1× on verification/call/paymaster limits, 1.0× on preVerification (`utils/gas.dart:34-71`), applied in `_applyGasEstimate` (`smart_account_client.dart:636`) and `_applyGasEstimateV06` (`:681`).
+- WebAuthn floor: `withMinimumVerificationGas()` forces `verificationGasLimit ≥ 900_000` for `account.isWebAuthn` (`smart_account_client.dart:640-642`, `utils/gas.dart:165-182`).
+- Paymaster gas-limit floor/keep logic: keeps stub values, only takes bundler values `≥ 10_000`, discards sub-10k values (`smart_account_client.dart:648-665`).
+
+These are dart-only. They are defensible (bundlers do sometimes underestimate), but they mean an identical UserOp will carry different gas limits than the viem reference, which can matter for prefund math and paymaster budgeting.
+
+## 5. eth_estimateUserOperationGas params + state override — mirrors
+
+viem `estimateUserOperationGas.ts:187-196`: params are `[formatUserOperationRequest(request), entryPointAddress]`, with `serializeStateOverride(stateOverride)` appended as an optional 3rd element only when present.
+
+Dart `bundler_client.dart:100-114`: params are `[userOp.toJson(), entryPoint.hex]`, appending `stateOverride` as a 3rd element only when non-null. The smart-account client serializes overrides via `stateOverridesToJson` and passes `null` when empty (`smart_account_client.dart:289-305`). Same shape and same conditional-append behavior. Mirrors.
+
+## 6. "Estimate only if missing" + preserve populated fields — diverges
+
+viem only calls `eth_estimateUserOperationGas` when at least one gas field is undefined (`prepareUserOperation.ts:636-644`), and even then merges with `??` so any pre-populated field survives (`:665-677`). It also injects zeroish defaults for the RPC call (`callGasLimit: 0n, preVerificationGas: 0n, verificationGasLimit: 0n`, plus paymaster zeros when a paymaster is set) but lets the spread of `request` override them (`:650-664`).
+
+Dart always calls estimation and always overwrites the three core gas fields from the buffered estimate (`smart_account_client.dart:293-306`, `_applyGasEstimate:667-673`). It builds the UserOp with `BigInt.zero` gas fields up front (`:267-269`) which matches viem's zeroish-default intent, but there is no "skip if already filled" and no `??`-preserve for the core limits (only paymaster limits get keep-logic, #4). Given #2 there is also no way to pre-fill a gas field to preserve. Minor behavioral divergence in the same direction; flagged because a caller cannot opt out of re-estimation.
+
+## 7. Paymaster stub/data param arity & context — diverges
+
+viem `getPaymasterStubData.ts:114-128` and `getPaymasterData.ts:137-151` send **4 positional params**: `[{...request, callGasLimit:'0x0', verificationGasLimit:'0x0', preVerificationGas:'0x0'}, entryPointAddress, numberToHex(chainId), context]`. The `context` slot is **always present** (4th arg), even when `undefined`. viem also force-defaults the three gas fields to `'0x0'` inside the paymaster request, and strips `sponsor` / hoists `paymasterPostOpGasLimit`/`paymasterVerificationGasLimit` to bigint in the return.
+
+Dart `paymaster_client.dart:54-90` sends `[userOp.toJson(), entryPoint.hex, '0x<chainId>', if (context != null) context.toJson()]` — the context slot is **omitted** when null, so the request has only 3 elements. It also does not force `callGasLimit`/`verificationGasLimit`/`preVerificationGas` to `'0x0'` in the paymaster payload (it forwards whatever the UserOp currently holds — zeros at stub time, which happens to coincide, but not guaranteed at final-data time). Divergences:
+- Positional context omission can shift a server that reads params by index (viem guarantees chainId at index 2, context at index 3 always).
+- No explicit `'0x0'` gas defaulting in the paymaster request body.
+
+## 8. Paymaster `isFinal` short-circuit — mirrors
+
+viem sets `isPaymasterPopulated = isFinal` from stub (`prepareUserOperation.ts:592-602`) and skips `getPaymasterData` when true (`:687-692`). Dart mirrors: `PaymasterStubData.isFinal` (`paymaster/types.dart:34,49-50`) gates the final call via `!stubData.isFinal` (`smart_account_client.dart:309`). Mirrors.
+
+## 9. pm_sponsorUserOperation (v0.6 combined path) — mirrors
+
+permissionless.js `actions/pimlico/sponsorUserOperation.ts:100-107` sends `[deepHexlify(userOp), entryPoint.address, context?]` (2 or 3 params) and branches the response on entryPoint version (v0.6 returns combined `paymasterAndData` + gas, v0.7 returns split fields). Dart `paymaster_client.dart:99-113` sends `[userOp.toJson(), entryPoint.hex, if (context != null) context.toJson()]` and `SponsorUserOperationResult.fromJson` (`paymaster/types.dart:117-162`) branches on presence of `paymasterAndData` to handle both versions. Arity and version-branching match. Mirrors. (Note this is a Pimlico extension used only on the Dart v0.6 path in `prepareUserOperationV06:517-531`; viem's core prepare does not use it.)
+
+## 10. getAccountNonce — mirrors
+
+permissionless.js `actions/public/getAccountNonce.ts:37-74` calls `EntryPoint.getNonce(address sender, uint192 key)` via `readContract`, default `key = 0n`. Dart `public_client.dart:164-180` hand-encodes selector `0x35567e1a` (= `getNonce(address,uint192)`) + left-padded address + `key` padded to 32 bytes, default `key = 0` (`:169`), via `eth_call`, then `parseBigInt`. Selector, argument order, and default key all match; uint192 ABI-encodes into a 32-byte word so the padding is correct. Mirrors.
+
+## 11. getSenderAddress — diverges
+
+permissionless.js `actions/public/getSenderAddress.ts:97-129` uses the **Pimlico `GetSenderAddressHelper` deploy-bytecode trick**: it `encodeDeployData(helperByteCode, [entryPoint, initCode])` and `eth_call`s it *with no `to`* (`:112-122`). The helper contract internally calls `EntryPoint.getSenderAddress`, catches the `SenderAddressResult` revert, and **returns the address as normal return data**, which viem decodes with `decodeAbiParameters([{type:'address'}], data)` (`:128`). If the helper does not produce data, it throws `InvalidEntryPointError` (`:54-70,124-126`).
+
+Dart `public_client.dart:202-258` takes the **opposite mechanism**: it calls `EntryPoint.getSenderAddress(bytes initCode)` directly (selector `0x9b249f69`, `:206-218`), expects it to **revert**, and decodes the address out of the revert error payload by matching the `SenderAddressResult` selector `0x6ca7b806` in `BundlerRpcError.data` (`:229-249`). This depends on the RPC node surfacing revert data inside the JSON-RPC error `data` field (and on the node not swallowing it). It also hand-encodes the `bytes` calldata (offset `0x20`, length, word-padded initCode) rather than using an ABI encoder. Divergence: same goal, structurally different and less node-robust than the helper-bytecode approach permissionless.js uses; nodes that return a bare `execution reverted` without data will fail the Dart path where the JS helper still works.
+
+## 12. waitForUserOperationReceipt — diverges
+
+viem `waitForUserOperationReceipt.ts:69-144`:
+- Default **timeout 120_000 ms** (`:77`); polling at `client.pollingInterval` (`:75`).
+- On timeout, **throws** `WaitForUserOperationReceiptTimeoutError` (`:99-104,111-115`).
+- Error classification while polling: `getUserOperationReceipt` **throws** `UserOperationReceiptNotFoundError` when the receipt is absent (`getUserOperationReceipt.ts:60-61`); wait ignores only that error name and **rejects on any other error** (`:125-128`).
+
+Dart `bundler_client.dart:208-224`:
+- Default **timeout 60 s**, polling **2 s** (`:210-211`) — both hard-coded, not derived from a client `pollingInterval`.
+- On timeout, **returns `null`** (`:223`) instead of throwing. The whole client API returns `UserOperationReceipt?` (`smart_account_client.dart:428-468`), so a timeout is indistinguishable from any other null.
+- `getUserOperationReceipt` returns `null` on absent receipt (`bundler_client.dart:176-185`) rather than throwing, so there is **no not-found-vs-other-error classification** — any RPC exception raised mid-poll propagates directly out of the loop (it is not caught).
+
+Divergences: (a) 60 s vs 120 s default; (b) null-on-timeout vs throw; (c) no distinction between "not found yet" and a real RPC error (viem keeps polling on not-found but rejects on real errors; Dart never sees a not-found error because it maps absence to null, and lets real errors escape unpolled).
+
+## 13. sendUserOperation — mirrors
+
+viem `sendUserOperation.ts:145-155` sends `eth_sendUserOperation` with `{ retryCount: 0 }` so the transport does not retry a broadcast. Dart `bundler_client.dart:55-61` posts once through `JsonRpcClient.call` which has no retry logic at all (`rpc_client.dart:43-84`). Effective behavior matches (single attempt). viem additionally re-wraps failures via `getUserOperationError` for nicer messages (`:156-163`); Dart surfaces a raw `BundlerRpcError` with an `aaErrorCode` extractor (`bundler/types.dart:293-327`) — different error ergonomics, same broadcast semantics. Mirrors.
+
+## 14. getChainId / eth_supportedEntryPoints — mirrors
+
+viem `getSupportedEntryPoints.ts:31-33` → `eth_supportedEntryPoints`. Dart `bundler_client.dart:188-193` calls the same and maps to `EthereumAddress`. viem chain id comes from `client.chain.id` or `getChainId` (`prepareUserOperation.ts:575-581`); Dart `bundler_client.dart:196-200` and `public_client.dart:127-130` call `eth_chainId` and parse. Mirrors.
+
+## 15. Client-level paymasterContext default — missing
+
+viem/permissionless.js let you set `paymasterContext` once on the client (`createSmartAccountClient.ts:94-95,160`) and prepare falls back to it: `parameters.paymasterContext ?? bundlerClient?.paymasterContext` (`prepareUserOperation.ts:401-403`). Dart's `SmartAccountClient` stores no `paymasterContext` field; context must be passed on every `prepareUserOperation`/`sendUserOperation` call (`smart_account_client.dart:158,399,433`). The per-call convenience of a client default is missing.
+
+## 16. Default nonce-key source — diverges (benign for Safe)
+
+viem's generic account `getNonce` defaults the 192-bit key from a **timestamp-based `nonceKeyManager`** (`toSmartAccount.ts:36-43,60-72`) to enable parallel nonces. permissionless.js Safe overrides `getNonce` to use `nonceKey ?? args?.key` (`accounts/safe/toSafeSmartAccount.ts:1780-1786`), which — when unset — bottoms out at `getAccountNonce`'s `key = 0n`, bypassing the timestamp manager. Dart uses a fixed `account.nonceKey` getter defaulting to `BigInt.zero` (`smart_account_interface.dart:100-103`; used at `smart_account_client.dart:225-229`) and has **no `nonceKeyManager`**. For Safe (and any account that fixes its key) the effective default is identical (0). For accounts that rely on viem's timestamp-parallel-nonce default, Dart diverges: it cannot auto-generate distinct parallel nonce keys.
+
+## 17. EIP-7702 authorization in prepare — mirrors (dart-only mechanics)
+
+viem inserts the authorization during the concurrent prepare phase (`prepareUserOperation.ts:517-534`) with a dummy signed authorization (`r/s/yParity` stubbed) for estimation, formatting it as `eip7702Auth` in the RPC request (`userOperationRequest.ts:55-56,61-75`). Dart mirrors the intent: `_createAuthorizationIfNeeded` (`smart_account_client.dart:110-124`) builds it before estimation, estimation and send both attach `eip7702Auth = authorization.toRpcFormat()` (`bundler_client.dart:74-91,122-145`). Dart adds a proprietary `0x7702…0000` factory **marker** normalized to `0x7702` for Pimlico (`smart_account_client.dart:130-131,236-239`; `bundler_client.dart:147-156`) — a dart-only mechanism with no viem equivalent, but the overall behavior (authorization filled pre-estimation, sent alongside the UserOp) mirrors. Note this path targets EntryPoint v0.8, outside viem 0.3.5's default 0.6/0.7 flow.
+
+---
+
+## Summary of actionable gaps
+
+- **Missing fee middleware (#3)** and **missing client paymasterContext (#15)** are the two capability gaps versus permissionless.js: callers must supply fees (and per-call context) themselves, and there is no 2×-buffer fee fallback.
+- **getSenderAddress (#11)** and **waitForUserOperationReceipt (#12)** are the two behavioral divergences most likely to bite in production: the revert-decode approach is node-dependent, and null-on-timeout hides failures that viem would throw.
+- **Gas multipliers (#4)** and **prescriptive overrides (#2/#6)** mean Dart-produced UserOps will not be byte-identical to viem's for the same inputs; intentional, but worth documenting for anyone cross-checking gas/prefund.

--- a/docs/parity-audit/05-utils.md
+++ b/docs/parity-audit/05-utils.md
@@ -1,0 +1,136 @@
+# Parity Audit — Unit 05: Utility Functions
+
+**Scope:** `permissionless.js` v0.3.5 `utils/` vs `permissionless.dart` v0.3.0 `lib/src/utils/` (plus `accounts/account_owner.dart` for `toOwner`, and Safe MultiSend which lives in the JS Safe account file). `getPackedUserOperation` / `packed_user_operation.dart` are covered by another unit and skipped here.
+
+**Roots:**
+- JS: `/Users/liorag/Documents/development/permissionless/permissionless.js/packages/permissionless`
+- Dart: `/Users/liorag/Documents/development/permissionless/permissionless.dart/packages/permissionless`
+
+**Headline finding:** four of the seven hardcoded ERC-7579 function selectors in `lib/src/utils/erc7579.dart` are **wrong** (`uninstallModule`, `isModuleInstalled`, `supportsModule`, `accountId`). They are consumed by the ERC-7579 actions layer, so module uninstallation and all module/account queries produce calldata that no ERC-7579 account will recognize. The unit tests assert the wrong values, so they pass. Additionally, the `revertOnError` execution-mode bit is encoded with **opposite polarity** in Dart vs JS.
+
+## Verdict table
+
+| # | Utility (JS) | JS location | Dart equivalent | Dart location | Verdict |
+|---|---|---|---|---|---|
+| 1 | `encode7579Calls` | `utils/encode7579Calls.ts:24` | `encode7579Execute` / `encode7579ExecuteBatch` / `ExecutionMode.encode` | `lib/src/utils/erc7579.dart:334,354,195` | **diverges** |
+| 2 | `decode7579Calls` | `utils/decode7579Calls.ts:24` | `decode7579Calls` | `lib/src/utils/erc7579.dart:756` | **diverges** |
+| 3 | `encodeInstallModule` | `utils/encodeInstallModule.ts:36` | `encode7579InstallModule` | `lib/src/utils/erc7579.dart:398` | mirrors |
+| 4 | `encodeUninstallModule` | `utils/encodeUninstallModule.ts:36` | `encode7579UninstallModule` | `lib/src/utils/erc7579.dart:432` | **diverges (broken)** |
+| 5 | `encodeNonce` | `utils/encodeNonce.ts:3` | `encodeNonce` | `lib/src/utils/erc7579.dart:703` | mirrors |
+| 6 | `decodeNonce` | `utils/decodeNonce.ts:3` | `decodeNonce` | `lib/src/utils/erc7579.dart:684` | mirrors |
+| 7 | `deepHexlify` | `utils/deepHexlify.ts:9` | — (typed `toJson()` per model) | `lib/src/types/user_operation.dart:205,380` | **missing** (by design) |
+| 8 | `erc20AllowanceOverride` | `utils/erc20AllowanceOverride.ts:17` | `erc20AllowanceOverride` | `lib/src/utils/erc20.dart:340` | mirrors |
+| 9 | `erc20BalanceOverride` | `utils/erc20BalanceOverride.ts:16` | `erc20BalanceOverride` | `lib/src/utils/erc20.dart:411` | mirrors |
+| 10 | `getRequiredPrefund` | `utils/getRequiredPrefund.ts:24` | `getRequiredPrefund` (v0.7) + `getRequiredPrefundV06` | `lib/src/utils/gas.dart:358,390` | mirrors |
+| 11 | `isSmartAccountDeployed` | `utils/isSmartAccountDeployed.ts:4` | `PublicClient.isDeployed` | `lib/src/clients/public/public_client.dart:60` | mirrors |
+| 12 | `toOwner` | `utils/toOwner.ts:22` | `AccountOwner` / `PrivateKeyOwner` | `lib/src/accounts/account_owner.dart:31,88` | **diverges** (architectural) |
+| 13 | `getAddressFromInitCodeOrPaymasterAndData` | `utils/getAddressFromInitCodeOrPaymasterAndData.ts:3` | same name | `lib/src/utils/gas.dart:432` | mirrors |
+| 14 | `getPimlicoEstimationCallData` | `utils/getEstimationCallData.ts:259` | — | — | **missing** |
+| 15 | `ox` shim (`getOxExports`/`hasOxModule`) | `utils/ox.ts:18,34` | native WebAuthn impl | `lib/src/utils/webauthn_encoding.dart`, `lib/src/utils/rip7212.dart` | mirrors (intent; JS-specific shim not needed) |
+| 16 | MultiSend encoding (JS: Safe account internal) | `accounts/safe/toSafeSmartAccount.ts:566,590` | `encodeMultiSend` / `encodeMultiSendWithOperations` | `lib/src/utils/multisend.dart:41,82` | mirrors |
+| 17 | — | — | `decodeMultiSend` | `lib/src/utils/multisend.dart:118` | dart-only |
+| 18 | — (JS equivalents are actions, correct there) | `actions/erc7579/supportsModule.ts:25` etc. | `encode7579IsModuleInstalled` / `encode7579SupportsModule` / `encode7579AccountId` | `lib/src/utils/erc7579.dart:470,501,541` | **dart-only (broken selectors)** |
+| 19 | — | — | `GasMultipliers`, `FeeEstimate`, `estimateFees*` | `lib/src/utils/gas.dart:29,188,272` | dart-only |
+| 20 | — | — | `erc20PaymasterOverride`, `mergeStateOverrides`, `Erc20StorageSlots` | `lib/src/utils/erc20.dart:527,455,568` | dart-only |
+| 21 | — | — | `units.dart`, `parsing.dart`, `message_hash.dart`, `erc20_paymaster.dart` | `lib/src/utils/` | dart-only (viem-builtin equivalents in JS) |
+
+**Counts:** 9 mirrors · 4 diverges · 2 missing · 5 dart-only rows (one of which is broken).
+
+---
+
+## Finding 1 — `encode7579UninstallModule` and 3 query encoders use wrong function selectors (diverges — broken)
+
+The Dart file hardcodes ERC-7579 selectors at `lib/src/utils/erc7579.dart:68-98`. Verified against `cast sig`:
+
+| Function | Dart constant (`erc7579.dart` line) | Actual selector | Status |
+|---|---|---|---|
+| `execute(bytes32,bytes)` | `0xe9ae5c53` (:73) | `0xe9ae5c53` | correct |
+| `installModule(uint256,address,bytes)` | `0x9517e29f` (:77) | `0x9517e29f` | correct |
+| `uninstallModule(uint256,address,bytes)` | **`0xa4d6f1d2`** (:81) | **`0xa71763a8`** | **WRONG** |
+| `isModuleInstalled(uint256,address,bytes)` | **`0x6d61fe70`** (:85) | **`0x112d3a7d`** | **WRONG** |
+| `supportsModule(uint256)` | **`0x12d79da3`** (:89) | **`0xf2dc691d`** | **WRONG** |
+| `accountId()` | **`0x7b60424a`** (:93) | **`0x9cfd7cff`** | **WRONG** |
+| `supportsExecutionMode(bytes32)` | `0xd03c7914` (:97) | `0xd03c7914` | correct |
+
+JS never hardcodes these: it derives selectors via `encodeFunctionData` from the ABI (`utils/encodeUninstallModule.ts:54-86`, `actions/erc7579/supportsModule.ts`, `actions/erc7579/isModuleInstalled.ts`, `actions/erc7579/accountId.ts`), so JS is correct.
+
+**Impact.** The wrong selectors are consumed by the public actions layer:
+- `lib/src/actions/erc7579/erc7579_actions.dart:152,202` (uninstall), `:346` (supportsModule), `:377` (isModuleInstalled), `:406` (accountId)
+- `lib/src/actions/erc7579/module_queries.dart:33,69,92`
+
+Any `uninstallModule` UserOperation reverts on-chain (or hits an unintended fallback handler), and all module/account queries return garbage or revert. Argument layout after the selector is otherwise correct (uint256, address, bytes-offset, bytes — matches JS).
+
+**Tests are self-referential** and assert the wrong values, e.g. `test/utils/erc7579_test.dart:328` (`expect(... uninstallModule, equals('0xa4d6f1d2'))`), `:333`, `:338`, `:343` — so the suite passes despite the bug.
+
+## Finding 2 — `encode7579Calls`: `revertOnError` wire polarity is inverted vs JS (diverges)
+
+Per ERC-7579 the execType byte is `0x00` = default (revert on failure), `0x01` = try.
+
+- **JS** `encodeExecutionMode` — `actions/erc7579/supportsExecutionMode.ts:56`:
+  ```ts
+  toHex(toBytes(revertOnError ? "0x01" : "0x00", { size: 1 }))
+  ```
+  i.e. `revertOnError: true` → byte `0x01` ("try" mode — arguably a JS naming bug, but it is the reference behavior, and `decode7579Calls.ts:76` round-trips it: `revertOnError: BigInt(revertOnError) === BigInt(1)`).
+- **Dart** `ExecutionMode.encode` — `lib/src/utils/erc7579.dart:202`:
+  ```dart
+  mode[1] = revertOnError ? 0x00 : 0x01;
+  ```
+  i.e. `revertOnError: true` → byte `0x00` (spec-correct), decoded consistently at `erc7579.dart:778` (`revertOnError = modeBytes[1] == 0x00`).
+
+Both libraries are internally self-consistent, and the *defaults* happen to produce identical wire bytes (JS default `revertOnError: undefined` → `0x00`; Dart default `true` → `0x00`). But any caller porting JS code that explicitly sets `revertOnError: true` gets the opposite execType byte in Dart. Dart matches the ERC-7579 spec semantics; JS does not. Document the intentional deviation (or rename the Dart field) — otherwise cross-port test vectors will mismatch.
+
+## Finding 3 — `decode7579Calls`: mode selector/context byte offsets differ from JS (diverges — Dart is the correct one)
+
+Mode layout (ERC-7579): `callType(1) | execType(1) | unused(4) | modeSelector(4 @ bytes 6-9) | payload(22 @ bytes 10-31)`.
+
+- **JS decode** — `utils/decode7579Calls.ts:56-57` reads `selector = slice(mode, 3, 7)` (bytes 3-6) and `context = slice(mode, 7)` (bytes 7-31). This does **not** match JS's own encoder (`supportsExecutionMode.ts:53-60` places the selector at bytes 6-9), so a JS encode→decode round trip of a non-zero selector is lossy. Known upstream inconsistency.
+- **Dart decode** — `lib/src/utils/erc7579.dart:780-799` reads selector at bytes 6-10 and context at bytes 10-32, matching both the Dart and JS encoders and the spec.
+
+Deliberate, correct deviation — but note it when comparing decoded structures across the two libraries.
+
+Two secondary decode differences:
+- Dart assumes the `bytes executionCalldata` head offset is the standard `0x40` and ignores the actual offset word (`erc7579.dart:809-815`); JS uses viem's full ABI decoder. Nonstandard-but-valid ABI encodings would decode incorrectly in Dart. Low risk in practice.
+- Single-call batch: JS `encode7579Calls` with 1 call keeps the *supplied* mode byte (e.g. `batchcall` `0x01` or `delegatecall` `0xff`) while packing single-call calldata (`encode7579Calls.ts:96-113`); Dart `encode7579ExecuteBatch` silently downgrades a 1-element batch to a plain `call` (`0x00`) encoding (`erc7579.dart:360-362`). Also, Dart has no public helper to encode a `delegatecall` execution (constants exist at `erc7579.dart:53,111`, but `encode7579Execute` hardcodes `Erc7579CallType.call` at `:335`). Batch tuple ABI layout itself (`(address,uint256,bytes)[]`, packed single call `to ++ value32 ++ data`) mirrors JS exactly (`encode7579Calls.ts:61-91,107-111` vs `erc7579.dart:254-329`).
+
+## Finding 4 — `toOwner` (diverges — architectural)
+
+JS `toOwner` (`utils/toOwner.ts:22-89`) normalizes any of {EIP-1193 provider, viem `WalletClient`, `LocalAccount`} into a `LocalAccount`, including `eth_requestAccounts`/`eth_accounts` address discovery for providers.
+
+Dart replaces this with an abstract `AccountOwner` (`lib/src/accounts/account_owner.dart:31`) exposing `signPersonalMessage` / `signRawHash` / `signTypedData`, with two concrete implementations: `PrivateKeyOwner` (`account_owner.dart:88`) and `WebAuthnOwner` (`lib/src/accounts/webauthn_owner.dart`). There is no injected-provider / wallet-client owner, so browser-wallet-owned smart accounts have no Dart path. The three signing modes cover the same account needs as JS's `LocalAccount` surface (signMessage / signTypedData / raw). Reasonable platform adaptation; flagging so the gap (external signer / EIP-1193 owner) is a conscious decision.
+
+## Finding 5 — `deepHexlify` (missing — by design)
+
+JS uses `deepHexlify` (`utils/deepHexlify.ts:9-35`) to recursively convert arbitrary objects' bigints to minimal hex before RPC submission. Dart has no generic equivalent; each type serializes itself (`UserOperationV06.toJson` at `lib/src/types/user_operation.dart:205`, `UserOperationV07.toJson` at `:380`, using `Hex.fromBigInt` which produces minimal hex like JS `toHex`). Functionally equivalent for the RPC payloads that matter; the JS `transactionReceiptStatus` map (`deepHexlify.ts:3-6`) also has no Dart counterpart (receipt status handled in client parsing). No action needed unless arbitrary passthrough params must be hexlified.
+
+## Finding 6 — `getPimlicoEstimationCallData` (missing)
+
+JS ships `getPimlicoEstimationCallData` (`utils/getEstimationCallData.ts:259-297`): builds `simulateHandleOp` (EP v0.6) or `PimlicoSimulations.simulateEntryPoint`→`simulateHandleOpLast` (EP v0.7/0.8, estimation contract `0x949CeCa936909f75E5A40bD285d9985eFBb9B0D3`, `getEstimationCallData.ts:174`) calldata for client-side gas simulation. No Dart equivalent exists anywhere in `lib/` (`grep simulateEntryPoint|simulateHandleOp` returns nothing) — Dart relies entirely on bundler `eth_estimateUserOperationGas`. Note: this util is internal in JS (not exported from `utils/index.ts`), so the gap is low-priority unless local simulation is planned.
+
+---
+
+## Mirrors — verification notes
+
+- **`encodeInstallModule`** — selector `0x9517e29f` correct; arg layout `uint256 moduleType, address module, bytes initData` with offset `0x60` matches JS ABI encoding (`encodeInstallModule.ts:56-88` vs `erc7579.dart:398-415`). Module type IDs match (JS `parseModuleTypeId` validator=1/executor=2/fallback=3/hook=4, `actions/erc7579/supportsModule.ts:25-38`; Dart `Erc7579ModuleType` `erc7579.dart:19-34`). API-shape difference only: JS binds to an account and returns `{to, value, data}[]` (and accepts `context ?? initData`); Dart returns bare calldata for a single module and the caller supplies `to`. Neither library applies per-module-type initData transformation — raw bytes pass through in both.
+- **`encodeNonce`/`decodeNonce`** — settled: Dart **has** both, in `lib/src/utils/erc7579.dart:703` and `:684`, publicly exported via `lib/permissionless.dart:61`. Same math (`(key << 64) + sequence`; decode masks low 64 bits / shifts 64). One edge difference: JS `toHex(key, {size: 24})` **throws** if key ≥ 2^192 or sequence ≥ 2^64 (`encodeNonce.ts:4-5`), Dart silently masks to 192/64 bits (`erc7579.dart:705-710`).
+- **`erc20AllowanceOverride`** — identical slot math: `keccak256(abi.encode(spender, keccak256(abi.encode(owner, slot))))` (`erc20AllowanceOverride.ts:26-53` vs `erc20.dart:353-369`); identical default amount `0x7FFF…FFFF` (max int256) (`erc20AllowanceOverride.ts:22-24` vs `erc20.dart:298-301`). Cosmetic: JS emits minimal-hex value (`toHex(amount)`), Dart 32-byte padded — both accepted by RPC state-override.
+- **`erc20BalanceOverride`** — identical slot math `keccak256(abi.encode(owner, slot))` and identical default balance constant `0x1000…FFFF` (`erc20BalanceOverride.ts:20-36` vs `erc20.dart:304-307,420-427`). Token-specific slot knowledge is dart-only convenience (`Erc20StorageSlots`, `erc20.dart:568-596`) — JS makes the caller supply the slot; Dart does too but documents/provides common values.
+- **`getRequiredPrefund`** — formulas identical. v0.6: `callGas + verificationGas * (paymasterAndData.length > 2 ? 3 : 1) + preVerificationGas` × `maxFeePerGas` (`getRequiredPrefund.ts:30-43` vs `gas.dart:390-401`). v0.7: sum of five gas fields (paymaster fields defaulting to 0) × `maxFeePerGas` (`getRequiredPrefund.ts:46-55` vs `gas.dart:358-372`). Dart splits into two typed functions instead of a version parameter — equivalent behavior.
+- **`isSmartAccountDeployed`** — JS `Boolean(getCode(...))` (`isSmartAccountDeployed.ts:8-12`); Dart `code != '0x' && code.length > 2` after `eth_getCode` (`public_client.dart:46-63`). Equivalent (viem `getCode` returns `undefined` for `0x`).
+- **`getAddressFromInitCodeOrPaymasterAndData`** — same 42-char threshold and first-20-bytes extraction (`getAddressFromInitCodeOrPaymasterAndData.ts:3-13` vs `gas.dart:432-452`). Edge: JS `getAddress` throws on malformed hex; Dart catches and returns `null`.
+- **MultiSend** — packed layout identical: `uint8 operation | address to | uint256 value | uint256 dataLength | bytes data`, wrapped in `multiSend(bytes)` (JS `accounts/safe/toSafeSmartAccount.ts:566-607`; Dart `lib/src/utils/multisend.dart:41-115`, selector derived from signature at `lib/src/utils/encoding.dart:118-119`). Dart adds per-call operation control (`encodeMultiSendWithOperations`, `multisend.dart:82`) and a decoder (`decodeMultiSend`, `multisend.dart:118` — drops the operation byte when reconstructing `Call`s, `multisend.dart:148-149`).
+- **ox shim** — `utils/ox.ts` exists only to make `ox` an optional JS dependency for WebAuthn. Dart implements WebAuthn encoding natively (`webauthn_encoding.dart`, `rip7212.dart`), so no counterpart is needed.
+
+## Dart-only inventory (no JS counterpart in `utils/`)
+
+- `lib/src/utils/gas.dart:29-183` — `GasMultipliers` presets (incl. `webAuthn` 3x verification buffer), `withMinimumVerificationGas`, `FeeEstimate`, `estimateFees`/`estimateFeesFromPimlico`, `GasCostEstimate`.
+- `lib/src/utils/erc20.dart:64-160` — `encodeErc20Approve/Transfer/AllowanceCall/BalanceOfCall`, `decodeUint256Result`; `:455-596` — `mergeStateOverrides`, `erc20PaymasterOverride`, `Erc20StorageSlots`.
+- `lib/src/utils/erc20_paymaster.dart` — allowance checking + `erc20PaymasterGasBuffer` helper.
+- `lib/src/utils/units.dart`, `lib/src/utils/parsing.dart`, `lib/src/utils/message_hash.dart` — replacements for viem built-ins (`parseUnits`, `hashMessage`, `hashTypedData`).
+- `lib/src/utils/rip7212.dart`, `lib/src/utils/webauthn_encoding.dart` — P256 precompile detection and validator-specific signature encodings.
+- `lib/src/utils/erc7579.dart:470-595` — eth_call query encoders + `decode7579BoolResult`/`decode7579StringResult` (JS does this via viem `readContract` in actions). **Three of these are broken — see Finding 1.**
+
+## Recommended fixes (priority order)
+
+1. Fix the four wrong selectors in `lib/src/utils/erc7579.dart:81,85,89,93` (or derive them via `AbiEncoder.functionSelector` like `encoding.dart` does for Safe) and correct the assertions in `test/utils/erc7579_test.dart:328-343`; add a cross-check test that computes selectors from signatures.
+2. Decide and document the `revertOnError` polarity (Finding 2); if JS-compat is the goal, flip `erc7579.dart:202` and `:778` together.
+3. Consider an EIP-1193/external-signer `AccountOwner` implementation (Finding 4) if wallet-owned accounts are on the roadmap.

--- a/docs/parity-audit/06-experimental-errors-types.md
+++ b/docs/parity-audit/06-experimental-errors-types.md
@@ -1,0 +1,292 @@
+# Parity Audit 06 — Experimental APIs, Error Taxonomy, Primitive Types
+
+Unit scope: `experimental/` (Pimlico ERC-20 paymaster), `errors/`, and `types/`
+(pimlico, etherspot, passkeyServer on the JS side; address, hex, calls_status,
+typed_data, eip7702 on the Dart side — `user_operation.dart` excluded, covered
+by another unit).
+
+- JS reference: `permissionless.js` v0.3.5 —
+  `/Users/liorag/Documents/development/permissionless/permissionless.js/packages/permissionless`
+- Dart port: `permissionless.dart` v0.3.0 —
+  `/Users/liorag/Documents/development/permissionless/permissionless.dart/packages/permissionless`
+- Behavioral reference for viem primitives:
+  `/Users/liorag/Documents/development/permissionless/viem`
+
+Method: behavior comparison, not surface comparison. Where the JS side gets a
+primitive from viem (hashTypedData, hashAuthorization, hexToBytes, AA error
+mapping, EIP-5792 statuses), the viem source was used as the reference.
+
+## Verdict table
+
+| # | Aspect | Verdict |
+|---|--------|---------|
+| 1 | ERC-20 paymaster: token quote fetch + empty-quote error | mirrors |
+| 2 | ERC-20 paymaster: dummy max-approval injection + USDT zero-approval (estimation round) | mirrors |
+| 3 | ERC-20 paymaster: balance state override (default balance, slot fallback, missing-slot error) | mirrors |
+| 4 | ERC-20 paymaster: paymaster **stub** substitution during estimation round | **diverges** |
+| 5 | ERC-20 paymaster: `maxCostInToken` formula | mirrors |
+| 6 | ERC-20 paymaster: allowance read + conditional exact-amount approval + USDT reset (final round) | mirrors |
+| 7 | ERC-20 paymaster: final calldata re-encode + fresh paymaster data with context | mirrors |
+| 8 | ERC-20 paymaster: API shape (decorator, `decodeCalls`, non-token passthrough, stateOverride merge) | **diverges** |
+| 9 | `estimateErc20PaymasterCost` / `Erc20CostEstimate` | **dart-only** |
+| 10 | Errors: `AccountNotFoundError` | **missing** |
+| 11 | Errors: AA## bundler error mapping / revert-reason parsing | **diverges** |
+| 12 | Errors: `PermissionlessException` taxonomy (`InvalidAddress`, `UnsupportedVersion`, `Rpc`, `Signature`, `BundlerRpcError`) | **dart-only** |
+| 13 | Address: EIP-55 checksum validation/formatting | mirrors |
+| 14 | Hex: validation, padding, concat, slice, BigInt round-trip | mirrors |
+| 15 | EIP-712: hashStruct / domain separator / type encoding / array & nested-struct hashing | mirrors |
+| 16 | EIP-712: edge cases (custom `EIP712Domain` type, value validation, non-ASCII type names) | **diverges** |
+| 17 | calls_status: core EIP-5792 mapping (100/200/500, `version`, `atomic`, receipt shape) | mirrors |
+| 18 | calls_status: legacy status strings + out-of-range code classification | **diverges** (minor) |
+| 19 | EIP-7702: authorization hash + RPC tuple shape vs viem | mirrors |
+| 20 | passkeyServer (types + client) | **missing** |
+| 21 | types/pimlico.ts RPC surface (gas price tiers, op status strings, token quote fields) | mirrors |
+| 22 | types/etherspot.ts (`skandha_getGasPrice`) | mirrors |
+
+**Totals: 12 mirrors, 5 diverges, 2 missing, 2 dart-only** (verdict rows 1–22;
+tallied by row).
+
+Mirrors evidence (abbreviated citations, JS → Dart):
+
+- (1) `experimental/pimlico/utils/prepareUserOperationForErc20Paymaster.ts:103-119` → `lib/src/experimental/pimlico/erc20_paymaster.dart:115-120` (error class differs: viem `RpcError` vs Dart `ArgumentError`, but both throw on empty quotes and use `quotes[0]`).
+- (2) JS `...ts:134-152` (max-uint dummy approve prepended, USDT `0` approve unshifted first) → Dart `...erc20_paymaster.dart:127-149` (same ordering; same mainnet USDT constant, JS `...ts:31-33` vs Dart `...:19-20`).
+- (3) JS `...ts:158-174` + `utils/erc20BalanceOverride.ts:20-48` (default balance `0x100...FFF...F`, `keccak256(abi.encode(owner, slot))`) → Dart `...erc20_paymaster.dart:152-166` + `lib/src/utils/erc20.dart:305-308,411-440` (identical constant and slot derivation); missing-slot error JS `...ts:161-165` → Dart `...:155-160`.
+- (5) JS `...ts:223-238` → Dart `...erc20_paymaster.dart:181-194` — identical gas sum (preVerification + call + verification + postOp + paymasterVerification), identical singleton-paymaster formula `((maxCost + postOpGas*maxFeePerGas) * exchangeRate) / 1e18` with floor division.
+- (6) JS `...ts:247-279` (on-chain `allowance(owner, paymaster)` read; skip if `allowance >= maxCostInToken`; else unshift exact-amount approve, USDT zero-approve first) → Dart `...erc20_paymaster.dart:197-236` (same reads, same threshold, same ordering).
+- (7) JS `...ts:281-346` (re-`encodeCalls` final calls, re-fetch paymaster data with `context: paymasterContext` and estimated gas fields, merge into returned op) → Dart `...erc20_paymaster.dart:239-286` (same: final callData, `getPaymasterData(... context: paymasterContext)`, gas limits carried from the dummy-approval estimation).
+- (13) Dart `lib/src/types/address.dart:13-36` delegates to `wallet` 0.0.18 (`~/.pub-cache/hosted/pub.dev/wallet-0.0.18/lib/src/ethereum/ethereum_address.dart:60,79-81,93`): `fromHex` lowercases `with0x`, computes `eip55With0x` checksum, and `isEip55ValidEthereumAddress` verifies checksum only for mixed-case input — behaviorally matching viem `getAddress`/`isAddress`. (Note: Dart's `.hex` getter emits lowercase where viem emits checksummed; both are valid on the wire.)
+- (14) Dart `lib/src/types/hex.dart:41-58` (padLeft/padRight per byte length ≈ viem `pad`), `:61-68` (concat ≈ `concatHex`), `:74-79` (slice ≈ `slice`), `:82-95` (fromBigInt/toBigInt ≈ `numberToHex`/`hexToBigInt`, both emit minimal odd-length hex for e.g. 256 → `0x100`), `:17-22` (decode left-pads odd-length input exactly like viem `hexToBytes`, `viem/src/utils/encoding/toBytes.ts` `if (hexString.length % 2) hexString = '0'+hexString`). Trivial edge deltas only: `Hex.toBigInt('0x')` returns 0 and `Hex.isValid('0x')` returns true where viem throws/rejects empty in some paths.
+- (15) Dart `lib/src/utils/message_hash.dart:52-67` (`keccak256("\x19\x01" ++ domainSeparator ++ hashStruct)`), `:73-107` (domain type built from present fields in the canonical name/version/chainId/verifyingContract/salt order), `:112-122` + `:139-163` (typeHash with recursively-collected referenced types sorted alphabetically), `:228-243` (arrays: keccak of concatenated encoded elements; nested structs: recursive hashStruct), `:246-310` (string/bytes keccak'd, bool/uint/int as uint256 with two's complement, bytesN right-padded via `encoding.dart:45`) — all matching viem `hashTypedData`/`hashStruct` semantics.
+- (17) JS `actions/smartAccount/getCallsStatus.ts:16-91` → Dart `lib/src/actions/smart_account/smart_account_actions.dart:210-259` — both derive status from `getUserOperationReceipt`: success→200, revert→500, receipt-missing→pending/100; `version: '1.0'`, `atomic: true`; receipt fields (status/logs/blockHash/blockNumber/gasUsed/transactionHash) match, Dart `CallsStatus`/`CallReceipt` types at `lib/src/types/calls_status.dart:83-159,14-68`.
+- (19) See section below (mirrors, with one cosmetic note).
+- (21) JS `types/pimlico.ts:4-17` (slow/standard/fast tiers), `:19-29` (status strings `not_found|not_submitted|submitted|rejected|reverted|included|failed`), `:31-41` (quote fields paymaster/token/postOpGas/exchangeRate/exchangeRateNativeToUsd/balanceSlot?/allowanceSlot?) → Dart `lib/src/clients/pimlico/types.dart:9-60` (same status string set incl. helpers), `:152-176` (same quote fields incl. optional `balanceSlot`/`allowanceSlot`).
+- (22) JS `types/etherspot.ts:1-12` (`skandha_getGasPrice` → maxFeePerGas/maxPriorityFeePerGas) → Dart `lib/src/clients/etherspot/etherspot_client.dart:45-58` + `lib/src/clients/etherspot/types.dart:23`.
+
+---
+
+## Finding 4 (diverges) — No paymaster-stub substitution during the ERC-20 estimation round
+
+**JS** — `experimental/pimlico/utils/prepareUserOperationForErc20Paymaster.ts:188-217`:
+during the first `prepareUserOperation` (the one carrying the dummy max
+approval), JS deliberately replaces the paymaster's `getPaymasterData` with
+`getPaymasterStubData`:
+
+```ts
+paymaster: {
+    getPaymasterData: (args) => {
+        ...
+        if (getPaymasterStubData) return getPaymasterStubData(args)
+        return getAction(bundlerClient, getPaymasterData_, ...)(args)
+    }
+}
+```
+
+So the real (signed) paymaster data is fetched exactly once — at the end
+(`...ts:341-346`) — against the final calldata.
+
+**Dart** — `lib/src/experimental/pimlico/erc20_paymaster.dart:171-178` calls the
+ordinary `smartAccountClient.prepareUserOperation(...)`, and that flow runs
+*both* `getPaymasterStubData` **and** the real `getPaymasterData`
+(`lib/src/clients/smart_account/smart_account_client.dart:278` and `:310`).
+Dart then fetches paymaster data a second time for the final calldata
+(`erc20_paymaster.dart:249-266`).
+
+**Impact**: the final returned operation is equivalent (last `getPaymasterData`
+wins in both), but Dart issues one extra `pm_getPaymasterData` round-trip per
+preparation, and the paymaster signs an intermediate operation (with the dummy
+max approval) whose signature is discarded. With rate-limited or
+signature-audited paymasters this is observable behavior, not just cost.
+
+## Finding 8 (diverges) — API shape: standalone function vs prepareUserOperation decorator
+
+**JS** — `...prepareUserOperationForErc20Paymaster.ts:35-65` is a higher-order
+decorator over viem's `prepareUserOperation`:
+
+- If `paymasterContext` has no `token`, it transparently falls back to plain
+  `prepareUserOperation` (`...ts:78-83`, `:359-369`).
+- If the caller passed raw `callData`, it recovers calls via
+  `account.decodeCalls` (`...ts:129-131`).
+- A caller-supplied `stateOverride` is *merged* with the balance override
+  (`...ts:176-186`).
+- Returns a standard `PrepareUserOperationReturnType` (`...ts:348-356`).
+
+**Dart** — `lib/src/experimental/pimlico/erc20_paymaster.dart:103-113` is a
+standalone function with required `token`, `calls`, `maxFeePerGas`,
+`maxPriorityFeePerGas` and three explicit clients:
+
+- No non-token fallback path (token is a required parameter).
+- No `callData`→calls decoding path (calls list is required; no
+  `decodeCalls` equivalent).
+- No caller `stateOverride` parameter — the balance override is the only
+  override passed (`...:152-166,177`).
+- Returns a bespoke `Erc20PaymasterResult` wrapper (`...:46-68`) carrying the
+  op plus `tokenQuote`, `maxCostInToken`, `approvalInjected`, instead of the
+  bare prepared operation.
+
+**Impact**: the core flow (findings 1–3, 5–7) mirrors, but callers cannot use
+this as a drop-in `prepareUserOperation` middleware, cannot combine it with
+their own state overrides, and cannot feed pre-encoded calldata. The extra
+metadata in the result is a usability addition with no JS counterpart.
+
+## Finding 9 (dart-only) — `estimateErc20PaymasterCost` / `Erc20CostEstimate`
+
+Dart `lib/src/experimental/pimlico/erc20_paymaster.dart:312-374` adds a
+quote-only cost estimator (same formula as finding 5) returning
+`Erc20CostEstimate{maxCostInToken, exchangeRate, postOpGas, paymasterAddress}`.
+No JS counterpart in `experimental/pimlico/index.ts:1` (which exports only
+`prepareUserOperationForErc20Paymaster`). Benign addition; flag for doc parity
+only.
+
+## Finding 10 (missing) — `AccountNotFoundError`
+
+**JS** — `errors/index.ts:3-17` defines the package's single error class,
+`AccountNotFoundError extends BaseError` ("Could not find an Account to
+execute with this Action...", `docsSlug: "account"`), thrown across actions
+(e.g. `actions/smartAccount/sendTransaction.ts`,
+`actions/erc7579/installModule.ts`) when `client.account` is undefined.
+
+**Dart** — `lib/src/errors/errors.dart:1-49` has no equivalent. Structurally
+the condition is near-impossible in Dart: `SmartAccountClient` binds the
+account at construction, so an "account not found" state cannot arise at
+action time. Verdict recorded as **missing** per the surface, but severity is
+negligible; if constructors ever accept account-less clients, a typed
+equivalent should be added rather than a bare `StateError` (compare
+`erc20_paymaster.dart:243-247`, which throws `StateError` for the analogous
+"paymaster not configured" case where JS throws a plain `Error`,
+`...prepareUserOperationForErc20Paymaster.ts:332-334`).
+
+## Finding 11 (diverges) — AA## bundler error taxonomy / revert-reason parsing
+
+**JS** — inherits viem's full typed AA error mapping: every ERC-4337 code has
+a `BaseError` subclass with a regex matcher (e.g. `InitCodeFailedError` with
+`static message = /aa10/`,
+`viem/src/account-abstraction/errors/bundler.ts:122-149,485`) and
+`getBundlerError`
+(`viem/src/account-abstraction/utils/errors/getBundlerError.ts:133`) parses
+bundler revert reasons/messages into those classes, which viem's
+`UserOperationExecutionError` machinery then surfaces with docs links and
+human-readable causes.
+
+**Dart** — `lib/src/clients/bundler/types.dart:293-328` defines a single
+`BundlerRpcError{code, message, data}` whose only AA handling is a regex
+extraction:
+
+```dart
+String? get aaErrorCode {
+    if (data == null) return null;
+    final match = RegExp(r'AA\d+').firstMatch(data.toString());
+    return match?.group(0);
+}
+```
+
+Notable gaps versus JS behavior:
+
+1. No per-code typed classes — callers must string-match `aaErrorCode`
+   themselves; no human-readable explanation is attached.
+2. The regex only scans `data`, while viem's matchers scan `details`/message
+   (`getBundlerError` matches on the error message). Bundlers that put
+   `AA23 reverted` in `message` with empty `data` yield `aaErrorCode == null`
+   in Dart.
+3. Case sensitivity: viem matches `/aa10/` against a lowercased message;
+   Dart's `AA\d+` misses lowercase `aa23` variants some bundlers emit.
+4. No execution-revert reason decoding (viem additionally decodes contract
+   revert data into `ContractFunctionRevertedError`); Dart passes `data`
+   through verbatim.
+
+## Finding 12 (dart-only) — `PermissionlessException` taxonomy
+
+Dart `lib/src/errors/errors.dart` defines `PermissionlessException` (`:2-15`,
+message + optional cause), `InvalidAddressException` (`:18-21`),
+`UnsupportedVersionException` (`:24-29`, Safe/EntryPoint combination),
+`RpcException` (`:32-44`, with optional numeric code), and
+`SignatureException` (`:47-49`). None of these exist in JS: address
+validation errors come from viem (`InvalidAddressError`), version mismatches
+throw plain `Error`s inside account constructors, and RPC errors are viem
+`RpcError`s. Dart's hierarchy is a reasonable idiom-level substitute; recorded
+dart-only for surface tracking.
+
+## Finding 16 (diverges) — EIP-712 edge cases
+
+Core hashing mirrors viem (see verdict table, row 15). Three edge behaviors
+diverge from viem's `hashTypedData`:
+
+1. **Custom `EIP712Domain` type is ignored.** viem uses
+   `types.EIP712Domain` when the caller supplies it (allowing nonstandard
+   domain field sets/ordering); Dart hardcodes the domain struct from whichever
+   of the five standard fields are non-null
+   (`lib/src/utils/message_hash.dart:73-107`) and `TypedData.types` doc says
+   the domain type "should not be included"
+   (`lib/src/types/typed_data.dart:140-144`). Same result for standard
+   domains; different result for exotic ones.
+2. **No value validation.** viem's `validateTypedData` rejects out-of-range
+   `uintN`/`intN`, oversized `bytesN`, and invalid addresses before hashing;
+   Dart encodes everything as uint256/bytes32 without range checks
+   (`message_hash.dart:246-310`), so a value that viem rejects hashes
+   "successfully" (to a different digest than any correct signer would
+   produce). Also `bytesN` size is not checked against N — any hex up to 32
+   bytes is right-padded (`message_hash.dart:274-279`,
+   `lib/src/utils/encoding.dart:45`).
+3. **Type-string hashing uses `codeUnits`, not UTF-8**
+   (`message_hash.dart:132` and `:84`): identical to viem for ASCII type
+   names, divergent for non-ASCII struct/field names (viem hashes UTF-8
+   bytes via `toHex(string)`).
+
+All three are edge-case-only; every account implementation in the package uses
+ASCII types and standard domains, so on-path behavior matches (verified digests
+are exercised by `hashTypedData` call sites, e.g.
+`lib/src/accounts/safe/safe_account.dart:876`).
+
+## Finding 18 (diverges, minor) — EIP-5792 status classification edges
+
+**JS** — `actions/smartAccount/getCallsStatus.ts:16-33`: 100–199 pending,
+200–299 success, **300–699 failure**, plus backwards-compat for legacy string
+statuses `"CONFIRMED"` → success/200 and `"PENDING"` → pending/100; anything
+else yields `status: undefined` with the raw code.
+
+**Dart** — `lib/src/types/calls_status.dart:96-105`: 100–199 pending, 200–299
+success, **everything else failure** (including codes < 100 and ≥ 700, which
+JS would classify as `undefined`); no legacy `"CONFIRMED"`/`"PENDING"` string
+handling (`statusCode` is cast `as int` at `:97`, so a legacy string payload
+throws a `TypeError` instead).
+
+Impact is confined to `CallsStatus.fromJson` on nonstandard payloads; the
+primary path (`getCallsStatus` action, finding 17) only ever produces
+100/200/500 on both sides.
+
+## Finding 19 (mirrors) — EIP-7702 authorization, recorded for evidence
+
+Hash: Dart `lib/src/types/eip7702.dart:126-143` computes
+`keccak256(0x05 || rlp([chainId, address, nonce]))` with zero values RLP-encoded
+as empty strings (`_rlpEncodeBigInt(0)` → `0x80`, `:177-180`), matching viem
+`hashAuthorization`
+(`viem/src/utils/authorization/hashAuthorization.ts:38-47`:
+`concatHex(['0x05', toRlp([chainId ? hex : '0x', address, nonce ? hex : '0x'])])`).
+The hash is signed raw (no double keccak), `eip7702.dart:105-111`.
+
+RPC tuple: Dart `toRpcFormat()` (`eip7702.dart:235-247`) emits
+`{chainId, address, nonce, yParity, r, s}` all hex-encoded with
+`yParity = v - 27`, matching viem's `formatAuthorizationList`
+(`viem/src/utils/formatters/transactionRequest.ts:92-111`). One cosmetic
+delta: Dart pads yParity to one byte (`0x00`/`0x01`) where viem's
+`numberToHex` emits `0x0`/`0x1`; both are accepted hex quantities. Dart also
+keeps a legacy `toJson()` with a `v` field (`eip7702.dart:219-226`) that has
+no viem counterpart — unused by the bundler path.
+
+## Finding 20 (missing) — passkeyServer
+
+**JS surface** (`types/passkeyServer.ts:1-125`) — `PasskeyServerRpcSchema`
+with five methods (consumed by the passkey-server client/actions elsewhere in
+the JS package):
+
+| Method | Params | Returns |
+|---|---|---|
+| `pks_startAuthentication` | `[]` | `{challenge, rpId, timeout?, userVerification? ('required'\|'preferred'\|'discouraged'), uuid}` |
+| `pks_startRegistration` | `[context]` | WebAuthn creation options: `{rp{id,name}, user{id,name,displayName}, challenge, timeout?, authenticatorSelection?{authenticatorAttachment?, requireResidentKey?, residentKey?, userVerification?}, attestation ('direct'\|'enterprise'\|'indirect'\|'none'), extensions?{appid?, credProps?, hmacCreateSecret?, minPinLength?}}` |
+| `pks_verifyRegistration` | `[credential, context]` — credential: `{id, rawId, response{clientDataJSON, attestationObject, authenticatorData?, transports?, publicKeyAlgorithm?, publicKeyType?}, authenticatorAttachment, clientExtensionResults, type:'public-key'}` | `{success, id, publicKey: Hex, userName}` |
+| `pks_verifyAuthentication` | `[credential, context]` — credential: `{id, rawId, response{clientDataJSON, authenticatorData, signature, userHandle?}, authenticatorAttachment, clientExtensionResults, type:'public-key'}` | `{success, id, publicKey: Hex, userName}` |
+| `pks_getCredentials` | `[context]` | `{id, publicKey: Hex}[]` |
+
+**Dart** — no counterpart anywhere under `lib/src/` (no `pks_` strings, no
+passkey-server client/types). This is the known-missing passkeyServer port;
+verdict **missing**. Note the Dart package does have a `webauthn_owner.dart`
+(signing side), but nothing that speaks the `pks_*` server protocol.


### PR DESCRIPTION
Adds the full parity-audit documentation under `docs/parity-audit/` — the audit that produced the fixes merged in #38–#43. Docs only, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)