### PR TITLE
release: permissionless 0.4.0 + permissionless_passkeys 0.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ Add the packages you need to your `pubspec.yaml`:
 ```yaml
 dependencies:
   # Core ERC-4337 functionality
-  permissionless: ^0.3.0
+  permissionless: ^0.4.0
 
   # Optional: WebAuthn/Passkeys support
-  permissionless_passkeys: ^0.1.1
+  permissionless_passkeys: ^0.1.2
 ```
 
 ### Basic Usage
@@ -29,86 +29,91 @@ dependencies:
 ```dart
 import 'package:permissionless/permissionless.dart';
 
-// Create a bundler client
-final bundlerClient = BundlerClient(
-  chain: Chain.sepolia,
-  bundlerUrl: 'https://api.pimlico.io/v2/sepolia/rpc?apikey=YOUR_KEY',
+// Create an owner and a smart account
+final owner = PrivateKeyOwner('0x...');
+final account = createSafeSmartAccount(
+  owners: [owner],
+  version: SafeVersion.v1_4_1,
+  entryPointVersion: EntryPointVersion.v07,
+  chainId: BigInt.from(11155111), // Sepolia
 );
 
-// Create a simple smart account
-final account = SimpleSmartAccount(
-  SimpleSmartAccountConfig(
-    owner: privateKeyToAccount(privateKey),
-    chainId: Chain.sepolia.id,
-    publicClient: publicClient,
-  ),
+// Create clients
+final publicClient = createPublicClient(url: 'https://rpc.example.com');
+final bundler = createPimlicoClient(
+  url: 'https://api.pimlico.io/v2/sepolia/rpc?apikey=YOUR_KEY',
+  entryPoint: EntryPointAddresses.v07,
 );
 
 // Send a user operation
-final hash = await bundlerClient.sendUserOperation(
+final client = SmartAccountClient(
   account: account,
+  bundler: bundler,
+  publicClient: publicClient,
+);
+final hash = await client.sendUserOperation(
   calls: [
     Call(
       to: recipientAddress,
       value: BigInt.from(1000000000000000), // 0.001 ETH
+      data: '0x',
     ),
   ],
+  maxFeePerGas: BigInt.from(20000000000),
+  maxPriorityFeePerGas: BigInt.from(1000000000),
 );
 ```
 
 ### With Passkeys
 
 ```dart
+import 'package:permissionless/permissionless.dart';
 import 'package:permissionless_passkeys/permissionless_passkeys.dart';
 
-// Register a passkey
-final signer = PassKeySigner(options: PassKeysOptions(
-  namespace: 'myapp.com',
-  name: 'My App',
-  sharedWebauthnSigner: SafeWebAuthnSigners.sharedSigner,
-));
-final passkey = await signer.register('user@example.com', 'User Name');
-final credential = WebAuthnCredential.fromPassKeyPair(passkey);
+// Register a passkey (triggers biometric prompt)
+final credential = await createPasskeyCredential(
+  rpId: 'myapp.com',
+  rpName: 'My Application',
+  userName: 'user@example.com',
+);
 
-// Create a WebAuthn-authenticated smart account
-final account = WebAuthnSafeSmartAccount(
-  WebAuthnSafeSmartAccountConfig(
-    owner: WebAuthnOwner(credential: credential, rpId: 'myapp.com'),
-    credential: credential,
-    chainId: Chain.sepolia.id,
-    publicClient: publicClient,
-  ),
+// Create a WebAuthn account and use it as a smart account owner
+final webAuthnAccount = createWebAuthnAccount(
+  credential: credential,
+  rpId: 'myapp.com',
+);
+final account = createKernelSmartAccount(
+  owner: webAuthnAccount, // WebAuthnAccount IS an AccountOwner
+  chainId: BigInt.from(11155111),
+  version: KernelVersion.v0_3_1,
 );
 ```
 
 ## Development
 
-This project uses [Melos](https://melos.invertase.dev/) 6.x for monorepo management. I use Melos 6.x rather than 7.x due to [known conflicts](https://pub.dev/packages/multi_step_widgets/versions/0.3.0+1/changelog) between Melos 7's pub workspaces and path dependencies.
+This project uses [Melos](https://melos.invertase.dev/) 7.x with Dart pub workspaces for monorepo management (the Melos configuration lives in the root `pubspec.yaml`).
 
 ### Setup
 
 ```bash
-# Install dependencies (Melos is a dev dependency)
+# Install dependencies (resolves the whole pub workspace; Melos is a dev dependency)
 dart pub get
-
-# Bootstrap the workspace (links local packages via pubspec_overrides.yaml)
-dart run melos bootstrap
 ```
 
 ### Common Commands
 
 ```bash
 # Run tests across all packages
-dart run melos test
+dart run melos run test
 
 # Run static analysis
-dart run melos analyze
+dart run melos run analyze
 
 # Format code
-dart run melos format
+dart run melos run format
 
 # Clean build artifacts
-dart run melos clean
+dart run melos run clean
 ```
 
 ### Installing Melos Globally (Optional)
@@ -136,20 +141,22 @@ permissionless-dart/
 │       ├── lib/
 │       ├── test/
 │       └── example/
-├── melos.yaml                    # Monorepo configuration
+├── pubspec.yaml                  # Pub workspace + Melos configuration
 └── README.md
 ```
 
 ## Supported Account Types
 
 ### Core Package (`permissionless`)
-- **SimpleSmartAccount** - Minimal ERC-4337 account
-- **SafeSmartAccount** - Safe (Gnosis Safe) smart account
-- **KernelSmartAccount** - ZeroDev Kernel smart account
+- **Safe** (Gnosis) - battle-tested multi-sig account
+- **Kernel** (ZeroDev) - modular account, ERC-7579 in v0.3.x
+- **Nexus** (Biconomy) - ERC-7579 modular account
+- **Light** (Alchemy) - gas-efficient single-owner account
+- **Simple** (eth-infinitism) - minimal reference implementation
+- **Thirdweb**, **Trust (Barz)**, **Etherspot**, **Biconomy (deprecated)**
 
 ### Passkeys Package (`permissionless_passkeys`)
-- **WebAuthnSafeSmartAccount** - Safe with WebAuthn shared signer
-- **WebAuthnKernelSmartAccount** - Kernel with WebAuthn validator (v0.3.x)
+- **WebAuthnAccount** - passkey credential as an `AccountOwner` for Kernel (WebAuthn validator) and Safe (shared WebAuthn signer) accounts
 
 ## Supported Chains
 

--- a/packages/permissionless/CHANGELOG.md
+++ b/packages/permissionless/CHANGELOG.md
@@ -5,7 +5,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.4.0] - 2026-07-12
+
+Parity release: fixes every P0/P1 divergence found by the
+[Dart-vs-JS parity audit](https://github.com/LiorAgnin/permissionless.dart/tree/main/docs/parity-audit)
+and aligns behavior with permissionless.js across accounts, clients, and actions.
+
+### Breaking changes
+
+- **Safe default threshold** is now `owners.length` (all owners must sign), matching
+  permissionless.js `toSafeSmartAccount`. Previously defaulted to `1`.
+  Multi-owner Safes created without an explicit `threshold` produce a different
+  setup calldata and therefore a **different counterfactual address**.
+  Pass `threshold: BigInt.one` to keep the previous 1-of-n default.
+- **Thirdweb salt is now UTF-8-encoded** (was hex-decoded), matching permissionless.js
+  `toHex(salt)`. Any account created with a non-default `salt` gets different
+  `factoryData` and a **different counterfactual address**. The old decoding was a
+  parity bug — addresses it produced never matched the TypeScript SDK's.
+- **ERC-1271 `signMessage` / `signTypedData` outputs changed across accounts**
+  (Light, Thirdweb, Trust, Etherspot, Biconomy, Kernel, Safe). Previous releases
+  double-prefixed digests (EIP-712 wrapper digest signed via `personal_sign`),
+  skipped validator prefixes (Kernel), or omitted the SafeMessage wrapper and
+  eth_sign V adjustment (Safe) — producing signatures that failed on-chain
+  `isValidSignature`. Signatures now byte-match permissionless.js.
+- **ERC-7579 `revertOnError` execution-mode bit polarity flipped** to match the JS
+  encoding; execution modes built with `revertOnError` now encode the correct
+  `ModeSelector` byte.
+- **ERC-7579 query actions** (`supportsModule`, `supportsExecutionMode`,
+  `isModuleInstalled`, `getAccountId`) no longer swallow errors to `false`/`''`.
+  On call failure they retry with the account's `factory`/`factoryData`
+  (counterfactual path), matching permissionless.js; other errors propagate.
 
 ### Added
 
@@ -25,21 +54,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Safe default threshold** is now `owners.length` (all owners must sign), matching
-  permissionless.js `toSafeSmartAccount`. Previously defaulted to `1`.
-  **Breaking:** multi-owner Safes created without an explicit `threshold` produce a
-  different setup calldata and therefore a **different counterfactual address**.
-  Pass `threshold: BigInt.one` to keep the previous 1-of-n default.
 - **Safe batch `encodeCalls`** routes through **MultiSendCallOnly** (not MultiSend),
   matching permissionless.js safety property (no inner delegatecalls).
 - **Safe stub signatures** byte-match permissionless.js (ECDSA ecrecover-path dummy
   and WebAuthn dummy with realistic authenticatorData / long clientDataFields).
-- **ERC-7579 query actions** (`supportsModule`, `supportsExecutionMode`,
-  `isModuleInstalled`, `getAccountId`) no longer swallow errors to `false`/`''`.
-  On call failure they retry with the account's `factory`/`factoryData`
-  (counterfactual path), matching permissionless.js; other errors propagate.
+- **`writeContract`** now encodes calldata via web3dart's ABI encoder instead of a
+  hand-rolled encoder that mis-encoded dynamic `bytes` and lacked support for
+  strings, arrays, and tuples.
 
 ### Fixed
+
+- **Four wrong hard-coded ERC-7579 selectors** (`utils/erc7579.dart`):
+  `uninstallModule` (`0xa4d6f1d2` → `0xa71763a8`), `isModuleInstalled`
+  (`0x6d61fe70` → `0x112d3a7d`), `supportsModule` (`0x12d79da3` → `0xf2dc691d`),
+  and `accountId` (`0x7b60424a` → `0x9cfd7cff`). Previously, uninstall calldata
+  reverted and queries silently returned `false`/`''`.
+- **Kernel v0.2.4 `execute`/`executeBatch`** now use the Kernel v2 selectors
+  (`0x51945447`/`0x34fcd5be`) with matching parameter encoding; the previous
+  SimpleAccount-style calldata reverted on every v0.2.4 call.
+- **Nexus `signUserOperation`** returns the bare 65-byte signature, matching
+  permissionless.js. Previously the K1 validator address was prepended (85 bytes),
+  causing AA24 signature errors on-chain (Nexus selects the validator via the
+  nonce key).
+- **Pimlico client actions** aligned with the Pimlico API:
+  `validateSponsorshipPolicies` sends `pm_validateSponsorshipPolicies` (was a
+  nonexistent `pimlico_*` method), `estimateErc20PaymasterCost` computes the cost
+  locally from quotes (was calling a nonexistent RPC method), and
+  `sendCompressedUserOperation` sends the correct 3-parameter shape.
+- **Safe v1.5.0 `MULTI_SEND_CALL_ONLY` address** corrected to
+  `0xA83c336B20401Af773B6219BA5027174338D1836`.
+- **Simple account EntryPoint-version encode/sign paths**: v0.6 `executeBatch`
+  emits the v0.6 selector `0x18dfb3c7` (`address[],bytes[]`) instead of the v0.7
+  3-array form, and v0.8 non-7702 batching/signing follow the v0.8 shapes.
+- **EntryPoint v0.6 `signUserOperation`** is now implemented for accounts that
+  accept a v0.6 configuration (previously configured-but-unimplemented: accounts
+  derived v0.6 addresses, then threw or mis-packed at signing).
 
 - **Safe CREATE2 address derivation** fetches `proxyCreationCode()` from the configured
   SafeProxyFactory via `publicClient` when available, with fallback to the verified

--- a/packages/permissionless/README.md
+++ b/packages/permissionless/README.md
@@ -30,7 +30,8 @@ Build account abstraction applications in Dart with support for multiple smart a
 - **SmartAccountClient** - High-level account operations
 - **PimlicoClient** - Pimlico-specific bundler extensions
 - **EtherspotClient** - Etherspot (Skandha) bundler extensions
-- **PublicClient** - Standard Ethereum RPC
+- **PasskeyServerClient** - Passkey server `pks_*` RPC methods
+- **PublicClient** - Standard Ethereum RPC (incl. deployless `eth_call` for counterfactual accounts)
 
 ### Utilities
 
@@ -52,7 +53,7 @@ Add to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  permissionless: ^0.3.0
+  permissionless: ^0.4.0
 ```
 
 Then run:
@@ -60,6 +61,24 @@ Then run:
 ```bash
 dart pub get
 ```
+
+### Upgrading from 0.3.x
+
+Version 0.4.0 fixes every P0/P1 divergence found by the
+[Dart-vs-JS parity audit](https://github.com/LiorAgnin/permissionless.dart/tree/main/docs/parity-audit).
+Two changes affect **counterfactual addresses**:
+
+- **Safe default threshold** is now `owners.length` (was `1`). Multi-owner Safes
+  created without an explicit `threshold` derive a different address. Pass
+  `threshold: BigInt.one` to keep the previous 1-of-n default and address.
+- **Thirdweb salts** are now UTF-8-encoded like permissionless.js (was
+  hex-decoded), so non-default salts derive different (now JS-compatible)
+  addresses.
+
+ERC-1271 `signMessage`/`signTypedData` outputs also changed across accounts —
+previous releases produced signatures that failed on-chain `isValidSignature`;
+they now byte-match permissionless.js. See the
+[CHANGELOG](CHANGELOG.md) for the full list.
 
 ## Quick Start
 
@@ -407,6 +426,46 @@ final nonce = await publicClient.getAccountNonce(
 // Make a contract call
 final result = await publicClient.call(
   Call(to: contractAddress, data: callData),
+);
+
+// Deployless call against an undeployed (counterfactual) account —
+// deploys via the factory inside eth_call, then executes the call
+final result = await publicClient.call(
+  Call(to: accountAddress, data: callData),
+  factory: factoryAddress,
+  factoryData: factoryData,
+);
+```
+
+### PasskeyServerClient
+
+Talk to a passkey server (e.g. Pimlico's) via the `pks_*` RPC methods:
+
+```dart
+final passkeyServer = createPasskeyServerClient(
+  url: 'https://passkeys.example.com',
+);
+
+// Registration ceremony
+final options = await passkeyServer.startRegistration(
+  context: {'userName': 'alice@example.com'},
+);
+// ... create the credential via platform WebAuthn (see permissionless_passkeys) ...
+final verified = await passkeyServer.verifyRegistration(
+  credential: registrationCredential,
+  context: {'userName': 'alice@example.com'},
+);
+
+// Authentication ceremony
+final authOptions = await passkeyServer.startAuthentication();
+final authResult = await passkeyServer.verifyAuthentication(
+  credential: authenticationCredential,
+  uuid: credentialUuid,
+);
+
+// List credentials
+final credentials = await passkeyServer.getCredentials(
+  context: {'userName': 'alice@example.com'},
 );
 ```
 

--- a/packages/permissionless/pubspec.yaml
+++ b/packages/permissionless/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   A Dart implementation of permissionless.js for ERC-4337 smart accounts.
   Supports Safe, Simple, Kernel, and Etherspot accounts with bundler and
   paymaster clients.
-version: 0.3.0
+version: 0.4.0
 homepage: https://github.com/LiorAgnin/permissionless.dart
 repository: https://github.com/LiorAgnin/permissionless.dart/tree/main/packages/permissionless
 issue_tracker: https://github.com/LiorAgnin/permissionless.dart/issues

--- a/packages/permissionless_passkeys/CHANGELOG.md
+++ b/packages/permissionless_passkeys/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2] - 2026-07-12
+
+### Changed
+
+- Bumped `permissionless` dependency constraint to `^0.4.0` (was `^0.3.0`).
+  permissionless 0.4.0 fixes the parity-audit P0/P1 bugs, including the
+  WebAuthn-relevant Safe stub signatures and ERC-1271 signing paths — see its
+  [changelog](https://pub.dev/packages/permissionless/changelog) and note its
+  breaking changes (Safe default threshold, counterfactual addresses).
+- Bumped `web3dart` dependency constraint to `^3.0.3` (was `^3.0.2`).
+
 ## [0.1.1] - 2026-04-21
 
 ### Changed

--- a/packages/permissionless_passkeys/README.md
+++ b/packages/permissionless_passkeys/README.md
@@ -25,8 +25,8 @@ Add to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  permissionless_passkeys: ^0.1.1
-  permissionless: ^0.3.0  # Required peer dependency
+  permissionless_passkeys: ^0.1.2
+  permissionless: ^0.4.0  # Required peer dependency
 ```
 
 Then run:

--- a/packages/permissionless_passkeys/example/pubspec.yaml
+++ b/packages/permissionless_passkeys/example/pubspec.yaml
@@ -12,8 +12,8 @@ resolution: workspace
 dependencies:
   flutter:
     sdk: flutter
-  permissionless_passkeys: ^0.1.0
-  permissionless: ^0.3.0
+  permissionless_passkeys: ^0.1.2
+  permissionless: ^0.4.0
   web3_signers: ^1.0.0
   flutter_riverpod: ^3.3.2
   shared_preferences: ^2.3.0

--- a/packages/permissionless_passkeys/pubspec.yaml
+++ b/packages/permissionless_passkeys/pubspec.yaml
@@ -2,7 +2,7 @@ name: permissionless_passkeys
 description: >-
   WebAuthn/Passkeys support for permissionless.dart ERC-4337 smart accounts.
   Enables biometric authentication with Kernel and Safe accounts using P256 signatures.
-version: 0.1.1
+version: 0.1.2
 homepage: https://github.com/LiorAgnin/permissionless.dart
 repository: https://github.com/LiorAgnin/permissionless.dart/tree/main/packages/permissionless_passkeys
 issue_tracker: https://github.com/LiorAgnin/permissionless.dart/issues
@@ -23,7 +23,7 @@ dependencies:
   flutter:
     sdk: flutter
   # Core ERC-4337 package (sibling in monorepo)
-  permissionless: ^0.3.0
+  permissionless: ^0.4.0
   # PassKeySigner, P256 utilities (brings: passkeys, asn1lib, pointycastle)
   # Using local fork with macOS/Windows platform support
   web3_signers: ^1.0.0


### PR DESCRIPTION
Prepares both packages for publishing after the parity-fix wave (PRs #38–#45).

## permissionless 0.4.0
- Rolls `[Unreleased]` into `## [0.4.0] - 2026-07-12` with a leading **Breaking changes** section (Safe default threshold, Thirdweb salt encoding, ERC-1271 signing rework, ERC-7579 `revertOnError` polarity, ERC-7579 query error propagation)
- Backfills changelog entries for the P0 fixes from #38–#40 (ERC-7579 selectors, Kernel v0.2.4 selectors, Nexus signature, Pimlico actions, Safe v1.5.0 MultiSendCallOnly address, Simple EP-version paths, EP v0.6 signing)
- README: `^0.4.0` snippet, "Upgrading from 0.3.x" note, PasskeyServerClient + deployless `PublicClient.call` docs

## permissionless_passkeys 0.1.2
- `permissionless: ^0.4.0`, `web3dart: ^3.0.3` (constraint-only release, mirrors 0.1.1)
- Example app constraints bumped to match

## Root README
- Version snippets bumped; replaced stale code samples that referenced nonexistent APIs (`Chain.sepolia`, `WebAuthnSafeSmartAccount`, …) with the real ones; fixed the outdated "Melos 6.x" claim (workspace uses Melos 7.x + pub workspaces)

## Validation
- `dart analyze` clean (exit 0), `dart format` clean
- 920 core tests (`-P quick`) + 53 passkeys tests pass
- `dart pub publish --dry-run` passes for both packages
- `tool/changeset_readme_sync.dart --check` passes

After merge: tag `permissionless-v0.4.0` and `permissionless_passkeys-v0.1.2` to trigger the OIDC publish workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)