### PR TITLE
chore: bump melos to 8.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ final account = createKernelSmartAccount(
 
 ## Development
 
-This project uses [Melos](https://melos.invertase.dev/) 7.x with Dart pub workspaces for monorepo management (the Melos configuration lives in the root `pubspec.yaml`).
+This project uses [Melos](https://melos.invertase.dev/) 8.x with Dart pub workspaces for monorepo management (the Melos configuration lives in the root `pubspec.yaml`).
 
 ### Setup
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -388,10 +388,10 @@ packages:
     dependency: "direct dev"
     description:
       name: melos
-      sha256: "5fc1a858e3d90fdc42f2f423b95f901214bbc3d9e80c99125d9352f12453721d"
+      sha256: "78817a26b8f8dd6e5d4f85da2347da296516dae9664c894e5b887b10bc4aefa0"
       url: "https://pub.dev"
     source: hosted
-    version: "7.8.2"
+    version: "8.2.0"
   meta:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: permissionless_dart_workspace
 publish_to: none
 
 environment:
-  sdk: ">=3.5.0 <4.0.0"
+  sdk: ^3.9.0
 
 workspace:
   # packages
@@ -13,7 +13,7 @@ workspace:
   - packages/permissionless_passkeys/example
 
 dev_dependencies:
-  melos: ^7.8.2
+  melos: ^8.2.0
 
 melos:
   name: permissionless_dart

--- a/tool/changeset.dart
+++ b/tool/changeset.dart
@@ -58,8 +58,10 @@ Future<void> _run() async {
     throw Exception('title cannot be empty');
   }
 
-  stdout.writeln('\nEnter a longer description (markdown allowed). '
-      'End input with a single "." on its own line:');
+  stdout.writeln(
+    '\nEnter a longer description (markdown allowed). '
+    'End input with a single "." on its own line:',
+  );
   final note = _promptMultiline();
 
   final now = DateTime.now();
@@ -85,8 +87,9 @@ Future<void> _run() async {
 List<int> _promptPackageSelection(int packageCount) {
   stdout
     ..writeln(
-        '\nSelect affected packages by number (space or comma-separated). '
-        'Example: 1 3 4')
+      '\nSelect affected packages by number (space or comma-separated). '
+      'Example: 1 3 4',
+    )
     ..write('Selection: ');
   final line = stdin.readLineSync() ?? '';
   final tokens = line.split(RegExp(r'[,\s]+')).where((t) => t.isNotEmpty);

--- a/tool/changeset_changelog.dart
+++ b/tool/changeset_changelog.dart
@@ -52,8 +52,9 @@ void _updatePackageChangelog({
   required List<PackageChange> changes,
 }) {
   final existingFile = File(changelogPath);
-  final existing =
-      existingFile.existsSync() ? existingFile.readAsStringSync() : '';
+  final existing = existingFile.existsSync()
+      ? existingFile.readAsStringSync()
+      : '';
 
   final newSection = _buildReleaseSection(version, date, changes);
   final merged = _mergeChangelog(existing, newSection);

--- a/tool/changeset_lib.dart
+++ b/tool/changeset_lib.dart
@@ -49,11 +49,11 @@ class PackageChange {
   });
 
   factory PackageChange.fromJson(Map<String, dynamic> json) => PackageChange(
-        title: json['title'] as String,
-        bump: json['bump'] as String,
-        note: json['note'] as String,
-        changesetPath: json['changesetPath'] as String,
-      );
+    title: json['title'] as String,
+    bump: json['bump'] as String,
+    note: json['note'] as String,
+    changesetPath: json['changesetPath'] as String,
+  );
 
   final String title;
   final String bump; // patch|minor|major
@@ -61,11 +61,11 @@ class PackageChange {
   final String changesetPath;
 
   Map<String, dynamic> toJson() => {
-        'title': title,
-        'bump': bump,
-        'note': note,
-        'changesetPath': changesetPath,
-      };
+    'title': title,
+    'bump': bump,
+    'note': note,
+    'changesetPath': changesetPath,
+  };
 }
 
 // Release info for one package.
@@ -80,15 +80,15 @@ class PackageRelease {
   });
 
   factory PackageRelease.fromJson(Map<String, dynamic> json) => PackageRelease(
-        name: json['name'] as String,
-        path: json['path'] as String,
-        fromVersion: json['fromVersion'] as String,
-        toVersion: json['toVersion'] as String,
-        bump: json['bump'] as String,
-        changes: (json['changes'] as List<dynamic>)
-            .map((e) => PackageChange.fromJson(e as Map<String, dynamic>))
-            .toList(),
-      );
+    name: json['name'] as String,
+    path: json['path'] as String,
+    fromVersion: json['fromVersion'] as String,
+    toVersion: json['toVersion'] as String,
+    bump: json['bump'] as String,
+    changes: (json['changes'] as List<dynamic>)
+        .map((e) => PackageChange.fromJson(e as Map<String, dynamic>))
+        .toList(),
+  );
 
   final String name;
   final String path;
@@ -98,13 +98,13 @@ class PackageRelease {
   final List<PackageChange> changes;
 
   Map<String, dynamic> toJson() => {
-        'name': name,
-        'path': path,
-        'fromVersion': fromVersion,
-        'toVersion': toVersion,
-        'bump': bump,
-        'changes': changes.map((c) => c.toJson()).toList(),
-      };
+    'name': name,
+    'path': path,
+    'fromVersion': fromVersion,
+    'toVersion': toVersion,
+    'bump': bump,
+    'changes': changes.map((c) => c.toJson()).toList(),
+  };
 }
 
 // Top-level release meta for all packages in this release.
@@ -116,22 +116,22 @@ class ReleaseMeta {
   });
 
   factory ReleaseMeta.fromJson(Map<String, dynamic> json) => ReleaseMeta(
-        created: json['created'] as String,
-        date: json['date'] as String,
-        packages: (json['packages'] as List<dynamic>)
-            .map((e) => PackageRelease.fromJson(e as Map<String, dynamic>))
-            .toList(),
-      );
+    created: json['created'] as String,
+    date: json['date'] as String,
+    packages: (json['packages'] as List<dynamic>)
+        .map((e) => PackageRelease.fromJson(e as Map<String, dynamic>))
+        .toList(),
+  );
 
   final String created; // ISO timestamp
   final String date; // YYYY-MM-DD
   final List<PackageRelease> packages;
 
   Map<String, dynamic> toJson() => {
-        'created': created,
-        'date': date,
-        'packages': packages.map((p) => p.toJson()).toList(),
-      };
+    'created': created,
+    'date': date,
+    'packages': packages.map((p) => p.toJson()).toList(),
+  };
 }
 
 // Discover packages under ./packages/*/pubspec.yaml
@@ -148,11 +148,7 @@ List<PackageInfo> discoverPackages() {
 
     final name = _readPubspecName(pubspec) ?? _basename(entity.path);
     packages.add(
-      PackageInfo(
-        name: name,
-        path: entity.path,
-        pubspecPath: pubspec.path,
-      ),
+      PackageInfo(name: name, path: entity.path, pubspecPath: pubspec.path),
     );
   }
 


### PR DESCRIPTION
## Summary
- Bump melos `^7.8.2` → `^8.2.0` (workspace-root dev dependency).
- Raise the workspace-root SDK constraint to `^3.9.0` — melos 8 requires it. Published packages' constraints are unchanged, so consumers are unaffected.
- Reformat `tool/*.dart`: the new root SDK floor switches `dart format` to the tall style for root-package files (pure formatting, no logic changes).
- README: Melos 7.x → 8.x.

## Safety assessment
Melos 8.0.0's two breaking changes are inert for this repo:
- **`melos version` retains/increments `+build` numbers** — our package versions (0.4.0, 0.1.2) have none.
- **`exec` configured via `command.exec`** — we have no such config; scripts pass CLI flags to `melos exec`.

8.2.0's `melos analyze --fatal-infos` default doesn't apply — our `analyze` script calls `dart analyze` directly. CI never invokes melos (plain `dart pub get` / `dart analyze` / `flutter test`).

## Verification
- `dart pub get` resolves cleanly; lock pins melos 8.2.0.
- `melos list` shows all 3 workspace packages.
- `melos run analyze` ✓, `melos run format:check` ✓ (after tool/ reformat).
- `melos exec -- dart test -P quick` → 920 tests pass; `melos exec --flutter -- flutter test` → 54 tests pass.
- `melos version` dry-run on a throwaway branch: correctly reports nothing to version for chore-only commits; with a probe `feat:` commit it proposed permissionless 0.4.0→0.4.1 + cascading passkeys 0.1.2→0.1.3, changelog generated with `linkToCommits` working, no `+build` surprises. Branch discarded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)