### PR TITLE
feat(eip7702): ERC-20 paymaster support for EIP-7702 first-time delegation

### DIFF
--- a/packages/permissionless/README.md
+++ b/packages/permissionless/README.md
@@ -557,10 +557,18 @@ final result = await prepareUserOperationForErc20Paymaster(
 print('Max cost: ${result.maxCostInToken} tokens');
 print('Approval injected: ${result.approvalInjected}');
 
-// Sign and send
+// Sign and send. For an EIP-7702 account whose delegation is not yet
+// active, result.authorization is non-null and the delegation is installed
+// by this same operation — one code path covers both cases.
 final signedOp = await client.signUserOperation(result.userOperation);
-final hash = await client.sendPreparedUserOperation(signedOp);
+final hash = await client.sendPreparedUserOperationWithAuth(
+  signedOp,
+  result.authorization,
+);
 ```
+
+See `example/erc20_paymaster_example.dart` for a complete gasless ERC-20
+transfer (the sender needs no ETH at all).
 
 ## ERC-20 State Overrides
 

--- a/packages/permissionless/example/erc20_paymaster_example.dart
+++ b/packages/permissionless/example/erc20_paymaster_example.dart
@@ -1,0 +1,212 @@
+// Example: Gasless ERC-20 transfer — pay gas with the token itself
+//
+// This example demonstrates sending an ERC-20 transfer where the gas fee is
+// paid in the same ERC-20 token via Pimlico's ERC-20 paymaster. The sender
+// needs NO ETH at all:
+// 1. Creating an EIP-7702 Simple account (account address == owner's EOA)
+// 2. Preparing the op with prepareUserOperationForErc20Paymaster
+// 3. Automatic first-time delegation: if the EOA is not yet delegated, the
+//    helper returns an EIP-7702 authorization and the delegation is installed
+//    by this very same transaction
+// 4. Signing and sending — one code path for the first and all subsequent ops
+//
+// USAGE:
+//   dart run example/erc20_paymaster_example.dart
+//
+// Reads PIMLICO_API_KEY / TEST_PRIVATE_KEY / SEPOLIA_RPC_URL from the
+// environment or a nearby `.env` file (see example_config.dart).
+//
+// REQUIREMENTS:
+// - A bundler/paymaster that supports EntryPoint v0.8 and EIP-7702 (Pimlico)
+// - A chain with EIP-7702 enabled (Sepolia after the Prague upgrade)
+// - The sender EOA holds enough of the token for transfer + gas
+//   (or use Erc20PaymasterConfig(balanceOverride: true) on a testnet)
+//
+// KEY FEATURES:
+// - No ETH needed on the sender: gas is paid in the ERC-20 token
+// - Exact-amount approval for the paymaster is injected automatically
+//   (skipped when a sufficient allowance is already in place)
+// - USDT-on-mainnet quirk (reset approval to 0 first) is handled internally
+// - First-time delegation and subsequent transfers share the same code path
+
+import 'package:permissionless/permissionless.dart';
+
+import 'example_config.dart';
+
+void main(List<String> args) async {
+  print('='.padRight(60, '='));
+  print('Gasless ERC-20 Transfer (ERC-20 Paymaster + EIP-7702)');
+  print('='.padRight(60, '='));
+
+  // ================================================================
+  // SETUP: Configuration
+  // ================================================================
+
+  final config = ExampleConfig.load();
+  const chainId = 11155111; // Sepolia
+  final rpcUrl = config.sepoliaRpcUrl;
+  final pimlicoUrl = config.sepoliaPimlicoUrl;
+
+  // The ERC-20 token used BOTH for the transfer and for the gas payment.
+  // Sepolia USDC (6 decimals). Must be supported by the Pimlico paymaster —
+  // check with pimlico.getTokenQuotes([token]).
+  final token =
+      EthereumAddress.fromHex('0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238');
+  const tokenDecimals = 6;
+
+  // Recipient and amount of the main transfer (in the token's base units).
+  final recipient =
+      EthereumAddress.fromHex('0x57Be4787b25ed040b69677B57D7Db565e174Aa97');
+  final amount = BigInt.from(1000000); // 1.000000 USDC
+
+  // NOTE: Use a fresh key without an existing EIP-7702 delegation to a
+  // different delegate (check eth_getCode: a 0xef0100... prefix means an
+  // active delegation).
+  final owner = PrivateKeyEip7702Owner(config.privateKey);
+
+  // ================================================================
+  // 1. Create the EIP-7702 account and clients
+  // ================================================================
+  //
+  // EIP-7702: the account address IS the owner's EOA address. No new address —
+  // code is delegated via a signed authorization instead of a factory deploy.
+
+  final publicClient = createPublicClient(url: rpcUrl);
+
+  final account = createEip7702SimpleSmartAccount(
+    owner: owner,
+    chainId: BigInt.from(chainId),
+    publicClient: publicClient,
+  );
+
+  final pimlico = createPimlicoClient(
+    url: pimlicoUrl,
+    entryPoint: EntryPointAddresses.v08,
+  );
+
+  final paymaster = createPaymasterClient(url: pimlicoUrl);
+
+  final client = SmartAccountClient(
+    account: account,
+    bundler: pimlico,
+    publicClient: publicClient, // required for EIP-7702 delegation checks
+    paymaster: paymaster, // required for the ERC-20 paymaster helper
+  );
+
+  final accountAddress = await account.getAddress();
+  print('\nSender (EOA == account): ${accountAddress.checksummed}');
+  print('Recipient:               ${recipient.checksummed}');
+  print('Token:                   ${token.checksummed}');
+
+  // Whether the delegation is already active. Informational only — the
+  // helper detects this itself and handles both cases transparently.
+  final isDelegated = await publicClient.isDeployed(accountAddress);
+  print(
+    'Delegation active:       $isDelegated'
+    '${isDelegated ? '' : ' (will be installed by this transaction)'}',
+  );
+
+  try {
+    // ==============================================================
+    // 2. Prepare the gasless op with the ERC-20 paymaster helper
+    // ==============================================================
+    //
+    // One call replaces the whole manual flow: token quote → dummy approval
+    // for estimation → maxCostInToken math → exact-amount approval injection
+    // (skipped if the current allowance suffices) → final paymaster data.
+    //
+    // If the EOA is not delegated yet, the helper also creates and returns
+    // the EIP-7702 authorization (result.authorization) — nothing extra to do.
+    //
+    // You can batch more calls here (e.g. several transfers) — the helper
+    // injects the gas approval in front of YOUR calls.
+    //
+    // NOTE: an unsupported token makes the helper throw ArgumentError —
+    // check support upfront with pimlico.getTokenQuotes([token]).
+
+    final gasPrices = await pimlico.getUserOperationGasPrice();
+
+    final result = await prepareUserOperationForErc20Paymaster(
+      smartAccountClient: client,
+      pimlicoClient: pimlico,
+      publicClient: publicClient,
+      token: token,
+      calls: [
+        encodeErc20Transfer(token: token, to: recipient, amount: amount),
+      ],
+      maxFeePerGas: gasPrices.fast.maxFeePerGas,
+      maxPriorityFeePerGas: gasPrices.fast.maxPriorityFeePerGas,
+      // On a testnet without a real token balance you can simulate one for
+      // gas estimation: Erc20PaymasterConfig(balanceOverride: true).
+    );
+
+    String fmt(BigInt raw) {
+      final unit = BigInt.from(10).pow(tokenDecimals);
+      final frac = (raw % unit).toString().padLeft(tokenDecimals, '0');
+      return '${raw ~/ unit}.$frac';
+    }
+
+    print('\n--- Cost Breakdown (in token) ---');
+    print('Transfer to recipient:  ${fmt(amount)}');
+    print('Max gas cost (token):   ${fmt(result.maxCostInToken)}');
+    print('Total (max):            ${fmt(amount + result.maxCostInToken)}');
+    print('Approval injected:      ${result.approvalInjected}');
+    print(
+      'First-time delegation:  ${result.needsAuthorization}'
+      '${result.needsAuthorization ? ' (authorization attached)' : ''}',
+    );
+
+    // ==============================================================
+    // 3. Sign and send — one path for the first and subsequent ops
+    // ==============================================================
+    //
+    // sendPreparedUserOperationWithAuth branches internally:
+    // - authorization != null (first 7702 op): the bundler receives it as
+    //   the `eip7702Auth` field and the delegation is installed on-chain
+    // - authorization == null (already delegated): standard submission
+
+    print('\n--- Signing and Sending ---');
+    final signedOp = await client.signUserOperation(result.userOperation);
+    final hash = await client.sendPreparedUserOperationWithAuth(
+      signedOp,
+      result.authorization,
+    );
+    print('UserOperation hash: $hash');
+
+    // ==============================================================
+    // 4. Wait for confirmation
+    // ==============================================================
+
+    print('\n--- Waiting for Confirmation ---');
+    final status = await pimlico.waitForUserOperationStatus(
+      hash,
+      timeout: const Duration(seconds: 90),
+    );
+
+    print('Status: ${status.status}');
+    if (status.transactionHash != null) {
+      print('Transaction hash: ${status.transactionHash}');
+      print('View on Etherscan:');
+      print('  https://sepolia.etherscan.io/tx/${status.transactionHash}');
+    }
+  } on BundlerRpcError catch (e) {
+    print('\nBundler/paymaster error: ${e.message}');
+    print('\nThis may be because:');
+    print('  - The bundler does not support EntryPoint v0.8 / EIP-7702');
+    print('  - The sender does not hold enough of the token');
+    print('    (transfer amount + max gas cost)');
+    print('  - The paymaster does not support this token on this chain');
+  } finally {
+    client.close();
+    pimlico.close();
+    publicClient.close();
+  }
+
+  print('\n${'='.padRight(60, '=')}');
+  print('Key takeaways:');
+  print('  - Sender needs ZERO ETH: gas is paid in the ERC-20 token');
+  print('  - One helper call prepares approval + paymaster data');
+  print('  - First-time 7702 delegation is handled by the same code path');
+  print('  - Send via sendPreparedUserOperationWithAuth(op, authorization)');
+  print('='.padRight(60, '='));
+}

--- a/packages/permissionless/lib/src/clients/paymaster/paymaster_client.dart
+++ b/packages/permissionless/lib/src/clients/paymaster/paymaster_client.dart
@@ -1,6 +1,7 @@
 import 'package:http/http.dart' as http;
 
 import '../../types/address.dart';
+import '../../types/eip7702.dart';
 import '../../types/hex.dart';
 import '../../types/user_operation.dart';
 import '../bundler/rpc_client.dart';
@@ -51,16 +52,22 @@ class PaymasterClient {
   ///
   /// If `isFinal` is true in the response, the stub data can be
   /// used directly for submission without calling `getPaymasterData`.
+  ///
+  /// For EIP-7702 first-time delegation, pass [authorization] so the signed
+  /// authorization is forwarded to the paymaster as the `eip7702Auth` field
+  /// (viem parity: the paymaster signs its data over the same op the account
+  /// signs and the bundler receives).
   Future<PaymasterStubData> getPaymasterStubData({
     required UserOperation userOp,
     required EthereumAddress entryPoint,
     required BigInt chainId,
     PaymasterContext? context,
+    Eip7702Authorization? authorization,
   }) async {
     // viem always sends 4 positional params (context may be null) and ensures
     // gas fields default to 0x0 when missing.
     final params = <dynamic>[
-      _userOpJsonForPaymaster(userOp),
+      _userOpJsonForPaymaster(userOp, authorization),
       entryPoint.hex,
       '0x${chainId.toRadixString(16)}',
       context?.toJson(),
@@ -74,16 +81,20 @@ class PaymasterClient {
   ///
   /// Call this after gas estimation with the fully populated UserOperation.
   /// The returned data contains the paymaster signature.
+  ///
+  /// For EIP-7702 first-time delegation, pass [authorization] so the signed
+  /// authorization is forwarded to the paymaster as the `eip7702Auth` field.
   Future<PaymasterData> getPaymasterData({
     required UserOperation userOp,
     required EthereumAddress entryPoint,
     required BigInt chainId,
     PaymasterContext? context,
+    Eip7702Authorization? authorization,
   }) async {
     // viem always sends 4 positional params (context may be null) and ensures
     // gas fields default to 0x0 when missing.
     final params = <dynamic>[
-      _userOpJsonForPaymaster(userOp),
+      _userOpJsonForPaymaster(userOp, authorization),
       entryPoint.hex,
       '0x${chainId.toRadixString(16)}',
       context?.toJson(),
@@ -95,8 +106,18 @@ class PaymasterClient {
 
   /// Builds paymaster request body matching viem's formatUserOperationRequest
   /// defaults: gas fields fall back to `0x0` when absent.
-  Map<String, dynamic> _userOpJsonForPaymaster(UserOperation userOp) {
+  ///
+  /// When [authorization] is provided (EIP-7702 first op), it is added as the
+  /// separate `eip7702Auth` field — matching viem, which forwards the
+  /// authorization to `pm_getPaymaster*` alongside the op fields.
+  Map<String, dynamic> _userOpJsonForPaymaster(
+    UserOperation userOp,
+    Eip7702Authorization? authorization,
+  ) {
     final json = userOp.toJson();
+    if (authorization != null) {
+      json['eip7702Auth'] = authorization.toRpcFormat();
+    }
     json['callGasLimit'] = json['callGasLimit'] ?? '0x0';
     json['verificationGasLimit'] = json['verificationGasLimit'] ?? '0x0';
     json['preVerificationGas'] = json['preVerificationGas'] ?? '0x0';

--- a/packages/permissionless/lib/src/clients/smart_account/smart_account_client.dart
+++ b/packages/permissionless/lib/src/clients/smart_account/smart_account_client.dart
@@ -254,6 +254,12 @@ class SmartAccountClient {
   /// estimation. This is useful for ERC-20 paymaster scenarios where you need
   /// to simulate having sufficient token balance before the account is funded.
   ///
+  /// [skipFinalPaymasterData] skips the trailing `pm_getPaymasterData` call:
+  /// the returned op keeps the stub paymaster data (gas fields are still
+  /// estimated). Use it when the caller re-requests final paymaster data
+  /// itself over modified calldata (e.g. the ERC-20 paymaster helper) —
+  /// this avoids a paid paymaster round-trip whose result would be discarded.
+  ///
   /// Example:
   /// ```dart
   /// final prepared = await client.prepareUserOperationWithAuth(
@@ -284,6 +290,7 @@ class SmartAccountClient {
     PaymasterContext? paymasterContext,
     EthereumAddress? sender,
     List<StateOverride>? stateOverride,
+    bool skipFinalPaymasterData = false,
   }) async {
     if (calls == null && callData == null) {
       throw ArgumentError(
@@ -369,7 +376,9 @@ class SmartAccountClient {
       signature: signature ?? account.getStubSignature(),
     );
 
-    // Apply paymaster stub data if using paymaster
+    // Apply paymaster stub data if using paymaster.
+    // The EIP-7702 authorization (when present) is forwarded so the paymaster
+    // sees the same `eip7702Auth` context as the bundler (viem parity).
     PaymasterStubData? stubData;
     if (paymaster != null) {
       stubData = await paymaster!.getPaymasterStubData(
@@ -377,6 +386,7 @@ class SmartAccountClient {
         entryPoint: account.entryPoint,
         chainId: account.chainId,
         context: resolvedContext,
+        authorization: authorization,
       );
       userOp = userOp.withPaymasterStub(stubData);
     }
@@ -414,13 +424,20 @@ class SmartAccountClient {
       );
     }
 
-    // Get final paymaster data if using paymaster and not final
-    if (paymaster != null && stubData != null && !stubData.isFinal) {
+    // Get final paymaster data if using paymaster and not final.
+    // Skipped when the caller re-requests final data itself (see doc above) —
+    // mirrors permissionless.js, where the prepare step substitutes stub data
+    // and the single real pm_getPaymasterData happens at the end of the helper.
+    if (paymaster != null &&
+        stubData != null &&
+        !stubData.isFinal &&
+        !skipFinalPaymasterData) {
       final finalData = await paymaster!.getPaymasterData(
         userOp: userOp,
         entryPoint: account.entryPoint,
         chainId: account.chainId,
         context: resolvedContext,
+        authorization: authorization,
       );
       userOp = userOp.withPaymasterData(finalData);
     }

--- a/packages/permissionless/lib/src/experimental/pimlico/erc20_paymaster.dart
+++ b/packages/permissionless/lib/src/experimental/pimlico/erc20_paymaster.dart
@@ -6,12 +6,14 @@
 /// **Warning:** This is experimental and the API may change.
 library;
 
+import '../../clients/paymaster/paymaster_client.dart';
 import '../../clients/paymaster/types.dart';
 import '../../clients/pimlico/pimlico_client.dart';
 import '../../clients/pimlico/types.dart';
 import '../../clients/public/public_client.dart';
 import '../../clients/smart_account/smart_account_client.dart';
 import '../../types/address.dart';
+import '../../types/eip7702.dart';
 import '../../types/user_operation.dart';
 import '../../utils/erc20.dart';
 
@@ -52,6 +54,7 @@ class Erc20PaymasterResult {
     required this.tokenQuote,
     required this.maxCostInToken,
     required this.approvalInjected,
+    this.authorization,
   });
 
   /// The prepared UserOperation ready for signing.
@@ -65,6 +68,18 @@ class Erc20PaymasterResult {
 
   /// Whether an approval call was injected.
   final bool approvalInjected;
+
+  /// EIP-7702 authorization for first-time delegation, if required.
+  ///
+  /// Non-null only for EIP-7702 accounts whose delegation is not yet active.
+  /// Submit the signed op via
+  /// `SmartAccountClient.sendPreparedUserOperationWithAuth` (or
+  /// `BundlerClient.sendUserOperationWithAuthorization`) so the bundler
+  /// receives it as the `eip7702Auth` field.
+  final Eip7702Authorization? authorization;
+
+  /// Whether this operation requires EIP-7702 authorization on submission.
+  bool get needsAuthorization => authorization != null;
 }
 
 /// Prepares a UserOperation for ERC-20 paymaster gas payment.
@@ -91,9 +106,16 @@ class Erc20PaymasterResult {
 ///   maxPriorityFeePerGas: feeData.maxPriorityFeePerGas,
 /// );
 ///
-/// // Sign and send the prepared operation
+/// // Sign and send the prepared operation.
+/// // For EIP-7702 first-time delegation, result.authorization is non-null
+/// // and must be submitted alongside the op (the delegation is installed by
+/// // this same operation). sendPreparedUserOperationWithAuth handles both
+/// // cases: with a null authorization it falls back to standard submission.
 /// final signedOp = await client.signUserOperation(result.userOperation);
-/// final hash = await client.sendPreparedUserOperation(signedOp);
+/// final hash = await client.sendPreparedUserOperationWithAuth(
+///   signedOp,
+///   result.authorization,
+/// );
 ///
 /// print('Max cost: ${result.maxCostInToken} tokens');
 /// print('Approval injected: ${result.approvalInjected}');
@@ -165,17 +187,29 @@ Future<Erc20PaymasterResult> prepareUserOperationForErc20Paymaster({
     );
   }
 
-  // 4. Prepare initial UserOperation with dummy approval
+  // 4. Prepare initial UserOperation with dummy approval.
+  //
+  // Auth-aware variant: for an EIP-7702 account with inactive delegation this
+  // also produces the signed authorization, which must accompany every
+  // paymaster/bundler request (as `eip7702Auth`) and the final submission.
+  //
+  // skipFinalPaymasterData: the op is re-signed by the paymaster at step 9
+  // over the final calldata, so the prepare-time pm_getPaymasterData result
+  // would be discarded. Stub data + gas estimation are enough here
+  // (permissionless.js parity: its prepare step substitutes stub data).
   final paymasterContext = PaymasterContext(token: token);
 
-  final initialUserOp = await smartAccountClient.prepareUserOperation(
+  final prepared = await smartAccountClient.prepareUserOperationWithAuth(
     calls: callsWithDummyApproval,
     maxFeePerGas: maxFeePerGas,
     maxPriorityFeePerGas: maxPriorityFeePerGas,
     nonce: nonce,
     paymasterContext: paymasterContext,
     stateOverride: stateOverride,
+    skipFinalPaymasterData: true,
   );
+  final initialUserOp = prepared.userOp;
+  final authorization = prepared.authorization;
 
   // 5. Calculate maximum cost in tokens
   final userOperationMaxGas = initialUserOp.preVerificationGas +
@@ -246,50 +280,34 @@ Future<Erc20PaymasterResult> prepareUserOperationForErc20Paymaster({
     );
   }
 
+  // Send the FULL prepared op with only callData replaced (permissionless.js
+  // parity: it mutates userOperation.callData and spreads the whole op).
+  // The stub paymaster fields and the estimated paymaster gas limits must be
+  // present — Pimlico's ERC-20 mode rejects the request without them
+  // ("paymasterValidationGasLimit is required for erc20 mode").
   final finalPaymasterData = await paymaster.getPaymasterData(
-    userOp: UserOperationV07(
-      sender: initialUserOp.sender,
-      nonce: initialUserOp.nonce,
-      factory: initialUserOp.factory,
-      factoryData: initialUserOp.factoryData,
-      callData: finalCallData,
-      callGasLimit: initialUserOp.callGasLimit,
-      verificationGasLimit: initialUserOp.verificationGasLimit,
-      preVerificationGas: initialUserOp.preVerificationGas,
-      maxFeePerGas: initialUserOp.maxFeePerGas,
-      maxPriorityFeePerGas: initialUserOp.maxPriorityFeePerGas,
-      signature: initialUserOp.signature,
-    ),
+    userOp: initialUserOp.copyWith(callData: finalCallData),
     entryPoint: smartAccountClient.account.entryPoint,
     chainId: smartAccountClient.account.chainId,
     context: paymasterContext,
+    // EIP-7702 first op: the paymaster must sign over the same op the account
+    // signs/sends, so it needs the same `eip7702Auth` context as stub/estimate.
+    authorization: authorization,
   );
 
-  // 10. Build final UserOperation
-  final finalUserOp = UserOperationV07(
-    sender: initialUserOp.sender,
-    nonce: initialUserOp.nonce,
-    factory: initialUserOp.factory,
-    factoryData: initialUserOp.factoryData,
-    callData: finalCallData,
-    callGasLimit: initialUserOp.callGasLimit,
-    verificationGasLimit: initialUserOp.verificationGasLimit,
-    preVerificationGas: initialUserOp.preVerificationGas,
-    maxFeePerGas: initialUserOp.maxFeePerGas,
-    maxPriorityFeePerGas: initialUserOp.maxPriorityFeePerGas,
-    paymaster: finalPaymasterData.paymaster,
-    paymasterVerificationGasLimit:
-        finalPaymasterData.paymasterVerificationGasLimit,
-    paymasterPostOpGasLimit: finalPaymasterData.paymasterPostOpGasLimit,
-    paymasterData: finalPaymasterData.paymasterData,
-    signature: smartAccountClient.account.getStubSignature(),
-  );
+  // 10. Build final UserOperation (permissionless.js parity:
+  // `{...userOperation, ...paymasterData}` — response fields override, gas
+  // limits estimated earlier survive if the response omits them).
+  final finalUserOp = initialUserOp
+      .copyWith(callData: finalCallData)
+      .withPaymasterData(finalPaymasterData);
 
   return Erc20PaymasterResult(
     userOperation: finalUserOp,
     tokenQuote: quote,
     maxCostInToken: maxCostInToken,
     approvalInjected: approvalInjected,
+    authorization: authorization,
   );
 }
 

--- a/packages/permissionless/test/clients/smart_account/smart_account_client_test.dart
+++ b/packages/permissionless/test/clients/smart_account/smart_account_client_test.dart
@@ -558,6 +558,173 @@ void main() {
         expect(userOp.maxFeePerGas, equals(BigInt.from(2000)));
         expect(userOp.maxPriorityFeePerGas, equals(BigInt.from(200)));
       });
+
+      test(
+          'skipFinalPaymasterData: only stub is requested, '
+          'stub data retained on the op', () async {
+        final bundler = createBundlerClient(
+          url: 'http://localhost:3000/rpc',
+          entryPoint: EntryPointAddresses.v07,
+          httpClient: createBundlerMock(),
+        );
+        final paymaster = createPaymasterClient(
+          url: 'http://localhost:3001/rpc',
+          httpClient: createPaymasterMock(),
+        );
+
+        final client = SmartAccountClient(
+          account: account,
+          bundler: bundler,
+          paymaster: paymaster,
+          publicClient: createPublicClientMock(),
+        );
+
+        final prepared = await client.prepareUserOperationWithAuth(
+          calls: [
+            Call(
+              to: EthereumAddress.fromHex(
+                '0x1234567890123456789012345678901234567890',
+              ),
+              value: BigInt.zero,
+            ),
+          ],
+          maxFeePerGas: BigInt.from(1000000000),
+          maxPriorityFeePerGas: BigInt.from(1000000000),
+          skipFinalPaymasterData: true,
+        );
+
+        // No paid pm_getPaymasterData: stub only.
+        expect(paymasterRequests.length, equals(1));
+        expect(
+          paymasterRequests[0]['method'],
+          equals('pm_getPaymasterStubData'),
+        );
+
+        // Stub paymaster data retained; gas still estimated.
+        expect(prepared.userOp.paymasterData, equals('0xabcdef0123456789'));
+        expect(prepared.userOp.callGasLimit, greaterThan(BigInt.zero));
+      });
+    });
+
+    group('EIP-7702 paymaster forwarding', () {
+      // Public client mock for a not-yet-delegated 7702 EOA:
+      // - eth_getCode → '0x' (not deployed → needs authorization)
+      // - eth_getTransactionCount → '0x0' (EOA nonce for the authorization)
+      // - eth_call → 0 (account nonce via EntryPoint.getNonce)
+      PublicClient create7702PublicClientMock() {
+        final mock = MockClient((request) async {
+          final body = jsonDecode(request.body) as Map<String, dynamic>;
+          final method = body['method'] as String;
+          final result = switch (method) {
+            'eth_getCode' => '0x',
+            'eth_getTransactionCount' => '0x0',
+            'eth_call' =>
+              '0x0000000000000000000000000000000000000000000000000000000000000000',
+            _ => null,
+          };
+          return http.Response(
+            jsonEncode({'jsonrpc': '2.0', 'id': body['id'], 'result': result}),
+            200,
+          );
+        });
+        return PublicClient(
+          rpcClient: JsonRpcClient(
+            url: Uri.parse('http://localhost:8545'),
+            httpClient: mock,
+          ),
+        );
+      }
+
+      SmartAccountClient create7702Client({PaymasterClient? paymaster}) {
+        final bundler = createBundlerClient(
+          url: 'http://localhost:3000/rpc',
+          entryPoint: EntryPointAddresses.v08,
+          httpClient: createBundlerMock(),
+        );
+        final publicClient = create7702PublicClientMock();
+        final eip7702Account = createEip7702SimpleSmartAccount(
+          owner: PrivateKeyEip7702Owner(testPrivateKey),
+          chainId: BigInt.from(11155111),
+          publicClient: publicClient,
+        );
+        return SmartAccountClient(
+          account: eip7702Account,
+          bundler: bundler,
+          paymaster: paymaster,
+          publicClient: publicClient,
+        );
+      }
+
+      final call = Call(
+        to: EthereumAddress.fromHex(
+          '0x1234567890123456789012345678901234567890',
+        ),
+        value: BigInt.zero,
+      );
+
+      test('paymaster requests carry eip7702Auth for a first 7702 op',
+          () async {
+        final paymaster = createPaymasterClient(
+          url: 'http://localhost:3001/rpc',
+          httpClient: createPaymasterMock(),
+        );
+        final client = create7702Client(paymaster: paymaster);
+
+        final prepared = await client.prepareUserOperationWithAuth(
+          calls: [call],
+          maxFeePerGas: BigInt.from(1000000000),
+          maxPriorityFeePerGas: BigInt.from(1000000000),
+        );
+
+        expect(prepared.needsAuthorization, isTrue);
+
+        // Both pm_getPaymasterStubData and pm_getPaymasterData must carry
+        // eip7702Auth — the paymaster signs its data over the same op the
+        // account signs and the bundler receives (viem parity).
+        expect(paymasterRequests, hasLength(2));
+        for (final req in paymasterRequests) {
+          final userOpJson =
+              (req['params'] as List<dynamic>)[0] as Map<String, dynamic>;
+          expect(
+            userOpJson.containsKey('eip7702Auth'),
+            isTrue,
+            reason: '${req['method']} must forward eip7702Auth',
+          );
+          // The EIP-7702 factory marker stays in its short wire form.
+          expect(userOpJson['factory'], equals('0x7702'));
+        }
+      });
+
+      test('non-7702 paymaster requests carry NO eip7702Auth', () async {
+        final paymaster = createPaymasterClient(
+          url: 'http://localhost:3001/rpc',
+          httpClient: createPaymasterMock(),
+        );
+        final client = SmartAccountClient(
+          account: account,
+          bundler: createBundlerClient(
+            url: 'http://localhost:3000/rpc',
+            entryPoint: EntryPointAddresses.v07,
+            httpClient: createBundlerMock(),
+          ),
+          paymaster: paymaster,
+          publicClient: createPublicClientMock(),
+        );
+
+        final prepared = await client.prepareUserOperationWithAuth(
+          calls: [call],
+          maxFeePerGas: BigInt.from(1000000000),
+          maxPriorityFeePerGas: BigInt.from(1000000000),
+        );
+
+        expect(prepared.needsAuthorization, isFalse);
+        expect(paymasterRequests, isNotEmpty);
+        for (final req in paymasterRequests) {
+          final userOpJson =
+              (req['params'] as List<dynamic>)[0] as Map<String, dynamic>;
+          expect(userOpJson.containsKey('eip7702Auth'), isFalse);
+        }
+      });
     });
 
     group('signUserOperation', () {

--- a/packages/permissionless/test/experimental/pimlico/erc20_paymaster_test.dart
+++ b/packages/permissionless/test/experimental/pimlico/erc20_paymaster_test.dart
@@ -1,0 +1,335 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:permissionless/permissionless.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('prepareUserOperationForErc20Paymaster', () {
+    const testPrivateKey =
+        '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
+
+    final token =
+        EthereumAddress.fromHex('0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238');
+    final recipient =
+        EthereumAddress.fromHex('0x1234567890123456789012345678901234567890');
+
+    late List<Map<String, dynamic>> bundlerRequests;
+    late List<Map<String, dynamic>> paymasterRequests;
+    late List<Map<String, dynamic>> pimlicoRequests;
+
+    setUp(() {
+      bundlerRequests = [];
+      paymasterRequests = [];
+      pimlicoRequests = [];
+    });
+
+    MockClient createBundlerMock() => MockClient((request) async {
+          final body = jsonDecode(request.body) as Map<String, dynamic>;
+          bundlerRequests.add(body);
+          final method = body['method'] as String;
+          final result = switch (method) {
+            'eth_estimateUserOperationGas' => {
+                'preVerificationGas': '0x5208',
+                'verificationGasLimit': '0x186a0',
+                'callGasLimit': '0x186a0',
+              },
+            _ => null,
+          };
+          return http.Response(
+            jsonEncode({'jsonrpc': '2.0', 'id': body['id'], 'result': result}),
+            200,
+          );
+        });
+
+    MockClient createPaymasterMock() => MockClient((request) async {
+          final body = jsonDecode(request.body) as Map<String, dynamic>;
+          paymasterRequests.add(body);
+          final method = body['method'] as String;
+          final result = switch (method) {
+            'pm_getPaymasterStubData' => {
+                'paymaster': '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+                'paymasterData': '0xabcdef0123456789',
+                'paymasterVerificationGasLimit': '0xc350',
+                'paymasterPostOpGasLimit': '0x4e20',
+                'isFinal': false,
+              },
+            'pm_getPaymasterData' => {
+                'paymaster': '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+                'paymasterData': '0xfedcba9876543210',
+                'paymasterVerificationGasLimit': '0xc350',
+                'paymasterPostOpGasLimit': '0x4e20',
+              },
+            _ => null,
+          };
+          return http.Response(
+            jsonEncode({'jsonrpc': '2.0', 'id': body['id'], 'result': result}),
+            200,
+          );
+        });
+
+    // Pimlico mock: chain id + a single USDC-like token quote.
+    MockClient createPimlicoMock() => MockClient((request) async {
+          final body = jsonDecode(request.body) as Map<String, dynamic>;
+          pimlicoRequests.add(body);
+          final method = body['method'] as String;
+          final result = switch (method) {
+            'eth_chainId' => '0xaa36a7',
+            'pimlico_getTokenQuotes' => {
+                'quotes': [
+                  {
+                    'token': token.hex,
+                    'paymaster': '0x888888888888Ec68A58AB8094Cc1AD20Ba3D2402',
+                    'postOpGas': '0x124f8',
+                    // 1e18: 1 token wei per 1 wei of gas (keeps math simple)
+                    'exchangeRate': '0xde0b6b3a7640000',
+                  },
+                ],
+              },
+            _ => null,
+          };
+          return http.Response(
+            jsonEncode({'jsonrpc': '2.0', 'id': body['id'], 'result': result}),
+            200,
+          );
+        });
+
+    // Public client mock:
+    // - eth_getCode → '0x' unless [isDeployed] (7702: not yet delegated)
+    // - eth_getTransactionCount → '0x0' (EOA nonce for the authorization)
+    // - eth_call → 0 (serves both EntryPoint.getNonce and ERC-20 allowance)
+    PublicClient createPublicClientMock({bool isDeployed = false}) {
+      final mock = MockClient((request) async {
+        final body = jsonDecode(request.body) as Map<String, dynamic>;
+        final method = body['method'] as String;
+        final result = switch (method) {
+          'eth_getCode' => isDeployed ? '0x6080604052' : '0x',
+          'eth_getTransactionCount' => '0x0',
+          'eth_call' =>
+            '0x0000000000000000000000000000000000000000000000000000000000000000',
+          _ => null,
+        };
+        return http.Response(
+          jsonEncode({'jsonrpc': '2.0', 'id': body['id'], 'result': result}),
+          200,
+        );
+      });
+      return PublicClient(
+        rpcClient: JsonRpcClient(
+          url: Uri.parse('http://localhost:8545'),
+          httpClient: mock,
+        ),
+      );
+    }
+
+    PimlicoClient createPimlico() => createPimlicoClient(
+          url: 'http://localhost:3002/rpc',
+          entryPoint: EntryPointAddresses.v08,
+          httpClient: createPimlicoMock(),
+        );
+
+    final call = Call(to: recipient, value: BigInt.zero);
+
+    test(
+        'EIP-7702 first op: returns authorization, forwards eip7702Auth '
+        'to every paymaster request incl. the final pm_getPaymasterData',
+        () async {
+      final publicClient = createPublicClientMock();
+      final account = createEip7702SimpleSmartAccount(
+        owner: PrivateKeyEip7702Owner(testPrivateKey),
+        chainId: BigInt.from(11155111),
+        publicClient: publicClient,
+      );
+      final client = SmartAccountClient(
+        account: account,
+        bundler: createBundlerClient(
+          url: 'http://localhost:3000/rpc',
+          entryPoint: EntryPointAddresses.v08,
+          httpClient: createBundlerMock(),
+        ),
+        paymaster: createPaymasterClient(
+          url: 'http://localhost:3001/rpc',
+          httpClient: createPaymasterMock(),
+        ),
+        publicClient: publicClient,
+      );
+
+      final result = await prepareUserOperationForErc20Paymaster(
+        smartAccountClient: client,
+        pimlicoClient: createPimlico(),
+        publicClient: publicClient,
+        token: token,
+        calls: [call],
+        maxFeePerGas: BigInt.from(1000000000),
+        maxPriorityFeePerGas: BigInt.from(1000000000),
+      );
+
+      // The authorization must be surfaced to the caller for submission.
+      expect(result.needsAuthorization, isTrue);
+      expect(result.authorization, isNotNull);
+
+      // First 7702 op carries the EIP-7702 factory marker.
+      expect(
+        isEip7702FactoryMarker(result.userOperation.factory),
+        isTrue,
+      );
+
+      // Zero allowance → approval must be injected.
+      expect(result.approvalInjected, isTrue);
+
+      // Paid-RPC economy (permissionless.js parity): exactly one stub call
+      // during prepare and exactly ONE real pm_getPaymasterData — the final
+      // one over the final calldata (step 9). The prepare-time data call is
+      // skipped via skipFinalPaymasterData.
+      final dataRequests = paymasterRequests
+          .where((r) => r['method'] == 'pm_getPaymasterData')
+          .toList();
+      expect(dataRequests.length, equals(1));
+      expect(
+        paymasterRequests
+            .where((r) => r['method'] == 'pm_getPaymasterStubData')
+            .length,
+        equals(1),
+      );
+
+      // Every paymaster request — including the final pm_getPaymasterData
+      // issued by the helper itself (step 9) — must carry eip7702Auth and
+      // the short factory marker.
+      for (final req in paymasterRequests) {
+        final userOpJson =
+            (req['params'] as List<dynamic>)[0] as Map<String, dynamic>;
+        expect(
+          userOpJson.containsKey('eip7702Auth'),
+          isTrue,
+          reason: '${req['method']} must forward eip7702Auth',
+        );
+        expect(userOpJson['factory'], equals('0x7702'));
+      }
+
+      // The final pm_getPaymasterData must carry the FULL prepared op —
+      // stub paymaster fields and paymaster gas limits included. Pimlico's
+      // ERC-20 mode rejects the request without the limits
+      // ("paymasterValidationGasLimit is required for erc20 mode").
+      final dataOpJson =
+          (dataRequests.single['params'] as List<dynamic>)[0]
+              as Map<String, dynamic>;
+      expect(dataOpJson['paymasterVerificationGasLimit'], isNotNull);
+      expect(dataOpJson['paymasterPostOpGasLimit'], isNotNull);
+      expect(dataOpJson['paymaster'], isNotNull);
+    });
+
+    test('non-7702 (Safe, deployed): no authorization, no eip7702Auth on wire',
+        () async {
+      final publicClient = createPublicClientMock(isDeployed: true);
+      final account = createSafeSmartAccount(
+        owners: [PrivateKeyOwner(testPrivateKey)],
+        chainId: BigInt.from(11155111),
+        address: recipient,
+      );
+      final client = SmartAccountClient(
+        account: account,
+        bundler: createBundlerClient(
+          url: 'http://localhost:3000/rpc',
+          entryPoint: EntryPointAddresses.v07,
+          httpClient: createBundlerMock(),
+        ),
+        paymaster: createPaymasterClient(
+          url: 'http://localhost:3001/rpc',
+          httpClient: createPaymasterMock(),
+        ),
+        publicClient: publicClient,
+      );
+
+      final result = await prepareUserOperationForErc20Paymaster(
+        smartAccountClient: client,
+        pimlicoClient: createPimlico(),
+        publicClient: publicClient,
+        token: token,
+        calls: [call],
+        maxFeePerGas: BigInt.from(1000000000),
+        maxPriorityFeePerGas: BigInt.from(1000000000),
+      );
+
+      expect(result.needsAuthorization, isFalse);
+      expect(result.authorization, isNull);
+
+      // Non-7702 flow: no eip7702Auth anywhere.
+      for (final req in paymasterRequests) {
+        final userOpJson =
+            (req['params'] as List<dynamic>)[0] as Map<String, dynamic>;
+        expect(
+          userOpJson.containsKey('eip7702Auth'),
+          isFalse,
+          reason: '${req['method']} must not carry eip7702Auth for non-7702',
+        );
+      }
+
+      // Paymaster data applied to the final op.
+      expect(result.userOperation.paymaster, isNotNull);
+      expect(result.userOperation.paymasterData, isNotNull);
+
+      // Exactly one paid pm_getPaymasterData for the whole flow (step 9).
+      expect(
+        paymasterRequests
+            .where((r) => r['method'] == 'pm_getPaymasterData')
+            .length,
+        equals(1),
+      );
+    });
+
+    test('throws ArgumentError when token is not supported', () async {
+      final publicClient = createPublicClientMock(isDeployed: true);
+      final account = createSafeSmartAccount(
+        owners: [PrivateKeyOwner(testPrivateKey)],
+        chainId: BigInt.from(11155111),
+        address: recipient,
+      );
+      final client = SmartAccountClient(
+        account: account,
+        bundler: createBundlerClient(
+          url: 'http://localhost:3000/rpc',
+          entryPoint: EntryPointAddresses.v07,
+          httpClient: createBundlerMock(),
+        ),
+        paymaster: createPaymasterClient(
+          url: 'http://localhost:3001/rpc',
+          httpClient: createPaymasterMock(),
+        ),
+        publicClient: publicClient,
+      );
+
+      // Pimlico mock returning an empty quotes list.
+      final emptyQuotesPimlico = createPimlicoClient(
+        url: 'http://localhost:3002/rpc',
+        entryPoint: EntryPointAddresses.v07,
+        httpClient: MockClient((request) async {
+          final body = jsonDecode(request.body) as Map<String, dynamic>;
+          final method = body['method'] as String;
+          final result = switch (method) {
+            'eth_chainId' => '0xaa36a7',
+            'pimlico_getTokenQuotes' => {'quotes': <dynamic>[]},
+            _ => null,
+          };
+          return http.Response(
+            jsonEncode({'jsonrpc': '2.0', 'id': body['id'], 'result': result}),
+            200,
+          );
+        }),
+      );
+
+      await expectLater(
+        prepareUserOperationForErc20Paymaster(
+          smartAccountClient: client,
+          pimlicoClient: emptyQuotesPimlico,
+          publicClient: publicClient,
+          token: token,
+          calls: [call],
+          maxFeePerGas: BigInt.from(1000000000),
+          maxPriorityFeePerGas: BigInt.from(1000000000),
+        ),
+        throwsArgumentError,
+      );
+    });
+  });
+}

--- a/packages/permissionless/test/experimental/pimlico/erc20_paymaster_test.dart
+++ b/packages/permissionless/test/experimental/pimlico/erc20_paymaster_test.dart
@@ -10,10 +10,12 @@ void main() {
     const testPrivateKey =
         '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
 
-    final token =
-        EthereumAddress.fromHex('0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238');
-    final recipient =
-        EthereumAddress.fromHex('0x1234567890123456789012345678901234567890');
+    final token = EthereumAddress.fromHex(
+      '0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238',
+    );
+    final recipient = EthereumAddress.fromHex(
+      '0x1234567890123456789012345678901234567890',
+    );
 
     late List<Map<String, dynamic>> bundlerRequests;
     late List<Map<String, dynamic>> paymasterRequests;
@@ -132,151 +134,150 @@ void main() {
     final call = Call(to: recipient, value: BigInt.zero);
 
     test(
-        'EIP-7702 first op: returns authorization, forwards eip7702Auth '
-        'to every paymaster request incl. the final pm_getPaymasterData',
-        () async {
-      final publicClient = createPublicClientMock();
-      final account = createEip7702SimpleSmartAccount(
-        owner: PrivateKeyEip7702Owner(testPrivateKey),
-        chainId: BigInt.from(11155111),
-        publicClient: publicClient,
-      );
-      final client = SmartAccountClient(
-        account: account,
-        bundler: createBundlerClient(
-          url: 'http://localhost:3000/rpc',
-          entryPoint: EntryPointAddresses.v08,
-          httpClient: createBundlerMock(),
-        ),
-        paymaster: createPaymasterClient(
-          url: 'http://localhost:3001/rpc',
-          httpClient: createPaymasterMock(),
-        ),
-        publicClient: publicClient,
-      );
-
-      final result = await prepareUserOperationForErc20Paymaster(
-        smartAccountClient: client,
-        pimlicoClient: createPimlico(),
-        publicClient: publicClient,
-        token: token,
-        calls: [call],
-        maxFeePerGas: BigInt.from(1000000000),
-        maxPriorityFeePerGas: BigInt.from(1000000000),
-      );
-
-      // The authorization must be surfaced to the caller for submission.
-      expect(result.needsAuthorization, isTrue);
-      expect(result.authorization, isNotNull);
-
-      // First 7702 op carries the EIP-7702 factory marker.
-      expect(
-        isEip7702FactoryMarker(result.userOperation.factory),
-        isTrue,
-      );
-
-      // Zero allowance → approval must be injected.
-      expect(result.approvalInjected, isTrue);
-
-      // Paid-RPC economy (permissionless.js parity): exactly one stub call
-      // during prepare and exactly ONE real pm_getPaymasterData — the final
-      // one over the final calldata (step 9). The prepare-time data call is
-      // skipped via skipFinalPaymasterData.
-      final dataRequests = paymasterRequests
-          .where((r) => r['method'] == 'pm_getPaymasterData')
-          .toList();
-      expect(dataRequests.length, equals(1));
-      expect(
-        paymasterRequests
-            .where((r) => r['method'] == 'pm_getPaymasterStubData')
-            .length,
-        equals(1),
-      );
-
-      // Every paymaster request — including the final pm_getPaymasterData
-      // issued by the helper itself (step 9) — must carry eip7702Auth and
-      // the short factory marker.
-      for (final req in paymasterRequests) {
-        final userOpJson =
-            (req['params'] as List<dynamic>)[0] as Map<String, dynamic>;
-        expect(
-          userOpJson.containsKey('eip7702Auth'),
-          isTrue,
-          reason: '${req['method']} must forward eip7702Auth',
+      'EIP-7702 first op: returns authorization, forwards eip7702Auth '
+      'to every paymaster request incl. the final pm_getPaymasterData',
+      () async {
+        final publicClient = createPublicClientMock();
+        final account = createEip7702SimpleSmartAccount(
+          owner: PrivateKeyEip7702Owner(testPrivateKey),
+          chainId: BigInt.from(11155111),
+          publicClient: publicClient,
         );
-        expect(userOpJson['factory'], equals('0x7702'));
-      }
-
-      // The final pm_getPaymasterData must carry the FULL prepared op —
-      // stub paymaster fields and paymaster gas limits included. Pimlico's
-      // ERC-20 mode rejects the request without the limits
-      // ("paymasterValidationGasLimit is required for erc20 mode").
-      final dataOpJson =
-          (dataRequests.single['params'] as List<dynamic>)[0]
-              as Map<String, dynamic>;
-      expect(dataOpJson['paymasterVerificationGasLimit'], isNotNull);
-      expect(dataOpJson['paymasterPostOpGasLimit'], isNotNull);
-      expect(dataOpJson['paymaster'], isNotNull);
-    });
-
-    test('non-7702 (Safe, deployed): no authorization, no eip7702Auth on wire',
-        () async {
-      final publicClient = createPublicClientMock(isDeployed: true);
-      final account = createSafeSmartAccount(
-        owners: [PrivateKeyOwner(testPrivateKey)],
-        chainId: BigInt.from(11155111),
-        address: recipient,
-      );
-      final client = SmartAccountClient(
-        account: account,
-        bundler: createBundlerClient(
-          url: 'http://localhost:3000/rpc',
-          entryPoint: EntryPointAddresses.v07,
-          httpClient: createBundlerMock(),
-        ),
-        paymaster: createPaymasterClient(
-          url: 'http://localhost:3001/rpc',
-          httpClient: createPaymasterMock(),
-        ),
-        publicClient: publicClient,
-      );
-
-      final result = await prepareUserOperationForErc20Paymaster(
-        smartAccountClient: client,
-        pimlicoClient: createPimlico(),
-        publicClient: publicClient,
-        token: token,
-        calls: [call],
-        maxFeePerGas: BigInt.from(1000000000),
-        maxPriorityFeePerGas: BigInt.from(1000000000),
-      );
-
-      expect(result.needsAuthorization, isFalse);
-      expect(result.authorization, isNull);
-
-      // Non-7702 flow: no eip7702Auth anywhere.
-      for (final req in paymasterRequests) {
-        final userOpJson =
-            (req['params'] as List<dynamic>)[0] as Map<String, dynamic>;
-        expect(
-          userOpJson.containsKey('eip7702Auth'),
-          isFalse,
-          reason: '${req['method']} must not carry eip7702Auth for non-7702',
+        final client = SmartAccountClient(
+          account: account,
+          bundler: createBundlerClient(
+            url: 'http://localhost:3000/rpc',
+            entryPoint: EntryPointAddresses.v08,
+            httpClient: createBundlerMock(),
+          ),
+          paymaster: createPaymasterClient(
+            url: 'http://localhost:3001/rpc',
+            httpClient: createPaymasterMock(),
+          ),
+          publicClient: publicClient,
         );
-      }
 
-      // Paymaster data applied to the final op.
-      expect(result.userOperation.paymaster, isNotNull);
-      expect(result.userOperation.paymasterData, isNotNull);
+        final result = await prepareUserOperationForErc20Paymaster(
+          smartAccountClient: client,
+          pimlicoClient: createPimlico(),
+          publicClient: publicClient,
+          token: token,
+          calls: [call],
+          maxFeePerGas: BigInt.from(1000000000),
+          maxPriorityFeePerGas: BigInt.from(1000000000),
+        );
 
-      // Exactly one paid pm_getPaymasterData for the whole flow (step 9).
-      expect(
-        paymasterRequests
+        // The authorization must be surfaced to the caller for submission.
+        expect(result.needsAuthorization, isTrue);
+        expect(result.authorization, isNotNull);
+
+        // First 7702 op carries the EIP-7702 factory marker.
+        expect(isEip7702FactoryMarker(result.userOperation.factory), isTrue);
+
+        // Zero allowance → approval must be injected.
+        expect(result.approvalInjected, isTrue);
+
+        // Paid-RPC economy (permissionless.js parity): exactly one stub call
+        // during prepare and exactly ONE real pm_getPaymasterData — the final
+        // one over the final calldata (step 9). The prepare-time data call is
+        // skipped via skipFinalPaymasterData.
+        final dataRequests = paymasterRequests
             .where((r) => r['method'] == 'pm_getPaymasterData')
-            .length,
-        equals(1),
-      );
-    });
+            .toList();
+        expect(dataRequests.length, equals(1));
+        expect(
+          paymasterRequests
+              .where((r) => r['method'] == 'pm_getPaymasterStubData')
+              .length,
+          equals(1),
+        );
+
+        // Every paymaster request — including the final pm_getPaymasterData
+        // issued by the helper itself (step 9) — must carry eip7702Auth and
+        // the short factory marker.
+        for (final req in paymasterRequests) {
+          final userOpJson =
+              (req['params'] as List<dynamic>)[0] as Map<String, dynamic>;
+          expect(
+            userOpJson.containsKey('eip7702Auth'),
+            isTrue,
+            reason: '${req['method']} must forward eip7702Auth',
+          );
+          expect(userOpJson['factory'], equals('0x7702'));
+        }
+
+        // The final pm_getPaymasterData must carry the FULL prepared op —
+        // stub paymaster fields and paymaster gas limits included. Pimlico's
+        // ERC-20 mode rejects the request without the limits
+        // ("paymasterValidationGasLimit is required for erc20 mode").
+        final dataOpJson = (dataRequests.single['params'] as List<dynamic>)[0]
+            as Map<String, dynamic>;
+        expect(dataOpJson['paymasterVerificationGasLimit'], isNotNull);
+        expect(dataOpJson['paymasterPostOpGasLimit'], isNotNull);
+        expect(dataOpJson['paymaster'], isNotNull);
+      },
+    );
+
+    test(
+      'non-7702 (Safe, deployed): no authorization, no eip7702Auth on wire',
+      () async {
+        final publicClient = createPublicClientMock(isDeployed: true);
+        final account = createSafeSmartAccount(
+          owners: [PrivateKeyOwner(testPrivateKey)],
+          chainId: BigInt.from(11155111),
+          address: recipient,
+        );
+        final client = SmartAccountClient(
+          account: account,
+          bundler: createBundlerClient(
+            url: 'http://localhost:3000/rpc',
+            entryPoint: EntryPointAddresses.v07,
+            httpClient: createBundlerMock(),
+          ),
+          paymaster: createPaymasterClient(
+            url: 'http://localhost:3001/rpc',
+            httpClient: createPaymasterMock(),
+          ),
+          publicClient: publicClient,
+        );
+
+        final result = await prepareUserOperationForErc20Paymaster(
+          smartAccountClient: client,
+          pimlicoClient: createPimlico(),
+          publicClient: publicClient,
+          token: token,
+          calls: [call],
+          maxFeePerGas: BigInt.from(1000000000),
+          maxPriorityFeePerGas: BigInt.from(1000000000),
+        );
+
+        expect(result.needsAuthorization, isFalse);
+        expect(result.authorization, isNull);
+
+        // Non-7702 flow: no eip7702Auth anywhere.
+        for (final req in paymasterRequests) {
+          final userOpJson =
+              (req['params'] as List<dynamic>)[0] as Map<String, dynamic>;
+          expect(
+            userOpJson.containsKey('eip7702Auth'),
+            isFalse,
+            reason: '${req['method']} must not carry eip7702Auth for non-7702',
+          );
+        }
+
+        // Paymaster data applied to the final op.
+        expect(result.userOperation.paymaster, isNotNull);
+        expect(result.userOperation.paymasterData, isNotNull);
+
+        // Exactly one paid pm_getPaymasterData for the whole flow (step 9).
+        expect(
+          paymasterRequests
+              .where((r) => r['method'] == 'pm_getPaymasterData')
+              .length,
+          equals(1),
+        );
+      },
+    );
 
     test('throws ArgumentError when token is not supported', () async {
       final publicClient = createPublicClientMock(isDeployed: true);


### PR DESCRIPTION
## Summary

A paymaster-sponsored **first** EIP-7702 operation could not succeed: the signed authorization never reached the paymaster, and `prepareUserOperationForErc20Paymaster` did not support first-time delegation at all. This PR adds the missing pieces, making a **gasless ERC-20 transfer with zero ETH on the sender** work end-to-end — including the very first transaction, which installs the delegation and pays gas in the token in one op.

## Problem

For a first-time 7702 delegation with a paymaster, the paymaster must sign its data over the same op context the account signs and the bundler receives — including the signed authorization. The bundler requests already carry `eip7702Auth` (`*WithAuthorization` methods), but `pm_getPaymasterStubData` / `pm_getPaymasterData` did not → the paymaster sponsored first op fails validation (AA34). viem forwards the authorization to `pm_getPaymaster*` alongside the op fields.

On top of that, the ERC-20 helper:
- dropped the authorization (step 4 used the non-auth `prepareUserOperation`) and did not return it, so the caller could not submit the op with `eip7702Auth`;
- rebuilt the op field-by-field for the final `pm_getPaymasterData`, losing the paymaster gas limits — Pimlico's ERC-20 mode rejects such requests (`paymasterValidationGasLimit is required for erc20 mode`);
- performed a redundant paid `pm_getPaymasterData` during prepare whose result was discarded.

## Changes

- **`PaymasterClient.getPaymasterStubData` / `getPaymasterData`**: optional `Eip7702Authorization? authorization`, serialized as the `eip7702Auth` field (viem parity).
- **`prepareUserOperationWithAuth`**: forwards the created authorization to both paymaster calls; new opt-in `skipFinalPaymasterData` flag (op keeps stub paymaster data, gas still estimated) for wrappers that re-request final data themselves.
- **`prepareUserOperationForErc20Paymaster`**:
  - uses `prepareUserOperationWithAuth` (+ `skipFinalPaymasterData`) — each op costs exactly 1 × stub + 1 × estimate + 1 × data, same as permissionless.js;
  - sends the **full** prepared op with only `callData` replaced to the final `pm_getPaymasterData` and forwards the authorization (js parity: mutate `callData`, spread the whole op);
  - builds the final op via `copyWith` + `withPaymasterData` (`{...userOperation, ...paymasterData}` spread-merge semantics);
  - returns the authorization via `Erc20PaymasterResult.authorization` /`needsAuthorization`. One code path covers the first and all subsequent ops:

    ```dart
    final result = await prepareUserOperationForErc20Paymaster(...);
    final signed = await client.signUserOperation(result.userOperation);
    final hash = await client.sendPreparedUserOperationWithAuth(
      signed,
      result.authorization, // null → standard submission
    );
    ```

- **New `example/erc20_paymaster_example.dart`** — the README's examples table already linked this file, but it never existed. Complete gasless ERC-20 transfer (zero ETH on the sender), using the shared `ExampleConfig`. README ERC-20 snippet updated accordingly.

## Breaking changes

None. All API changes are additive (optional named parameters / new result fields); defaults preserve existing behavior for every current caller. Non-7702 accounts are unaffected (covered by tests).

## Testing

- 926 unit tests pass, `dart analyze` adds zero issues over `main`.
- New tests pin the wire contract: first 7702 op → both paymaster requests carry `eip7702Auth`; the final `pm_getPaymasterData` carries the full op incl. paymaster gas limits; exactly one paid data call per op; non-7702 baseline carries no `eip7702Auth`; `skipFinalPaymasterData` → stub-only; unsupported token → `ArgumentError`.
- Verified on Sepolia against live Pimlico **on this branch**: the first 7702 op (delegation install + ERC-20 transfer + gas paid in USDC, zero ETH on the sender) and a subsequent op (no authorization, residual allowance reused) both succeeded.

## References

- viem: the authorization accompanies the op into `getPaymasterData` / `sendUserOperation` (formatted as `eip7702Auth`).
- permissionless.js `experimental/pimlico/utils/prepareUserOperationForErc20Paymaster.ts`: stub substituted during prepare; single real `pm_getPaymasterData` over the full op (only `callData` mutated) at the end.