### PR TITLE
release: permissionless 0.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Add the packages you need to your `pubspec.yaml`:
 ```yaml
 dependencies:
   # Core ERC-4337 functionality
-  permissionless: ^0.4.0
+  permissionless: ^0.4.1
 
   # Optional: WebAuthn/Passkeys support
   permissionless_passkeys: ^0.1.2

--- a/packages/permissionless/CHANGELOG.md
+++ b/packages/permissionless/CHANGELOG.md
@@ -5,6 +5,46 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2026-07-14
+
+EIP-7702 + paymaster release: a paymaster-sponsored **first** 7702 operation no
+longer fails AA34. Contributed by [@KabaDH](https://github.com/KabaDH) in
+[#50](https://github.com/LiorAgnin/permissionless.dart/pull/50); verified live
+on Sepolia against Pimlico (first-time delegation installed and gas paid in the
+ERC-20 token by an EOA holding zero ETH).
+
+### Fixed
+
+- **`eip7702Auth` is now forwarded to paymaster RPCs.** `PaymasterClient.getPaymasterStubData`
+  and `getPaymasterData` accept an optional `authorization` and serialize it as
+  `eip7702Auth` inside `params[0]`, matching viem's `formatUserOperationRequest`.
+  `prepareUserOperationWithAuth` passes the authorization to both calls, so the
+  paymaster simulates against the delegated account instead of an empty EOA.
+- **`prepareUserOperationForErc20Paymaster` no longer discards the signed
+  authorization** — it is returned as `result.authorization` for submission via
+  `sendPreparedUserOperationWithAuth`.
+- **Paymaster gas limits survive the final `pm_getPaymasterData` call.** The
+  helper now mutates only `callData` on the prepared operation instead of
+  rebuilding it field by field, mirroring permissionless.js's spread-merge.
+- **Removed a redundant (paid) `pm_getPaymasterData` call** during preparation:
+  the flow is now 1× stub + 1× estimate + a single real data call, matching
+  permissionless.js.
+
+### Added
+
+- `skipFinalPaymasterData` on `prepareUserOperationWithAuth` (default `false`)
+  to stop after the stub for flows that fetch real paymaster data themselves.
+- `example/erc20_paymaster_example.dart` — gasless ERC-20 transfer where gas is
+  paid in the token itself, including automatic first-time 7702 delegation.
+- Per-version example runners and configs for Kernel, Light, Safe, Simple, and
+  Thirdweb accounts
+  ([#45](https://github.com/LiorAgnin/permissionless.dart/pull/45)).
+
+### Changed
+
+- Bumped `web3dart` to 3.0.3
+  ([#36](https://github.com/LiorAgnin/permissionless.dart/pull/36)).
+
 ## [0.4.0] - 2026-07-12
 
 Parity release: fixes every P0/P1 divergence found by the

--- a/packages/permissionless/README.md
+++ b/packages/permissionless/README.md
@@ -53,7 +53,7 @@ Add to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  permissionless: ^0.4.0
+  permissionless: ^0.4.1
 ```
 
 Then run:

--- a/packages/permissionless/pubspec.yaml
+++ b/packages/permissionless/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   A Dart implementation of permissionless.js for ERC-4337 smart accounts.
   Supports Safe, Simple, Kernel, and Etherspot accounts with bundler and
   paymaster clients.
-version: 0.4.0
+version: 0.4.1
 homepage: https://github.com/LiorAgnin/permissionless.dart
 repository: https://github.com/LiorAgnin/permissionless.dart/tree/main/packages/permissionless
 issue_tracker: https://github.com/LiorAgnin/permissionless.dart/issues

--- a/packages/permissionless_passkeys/README.md
+++ b/packages/permissionless_passkeys/README.md
@@ -26,7 +26,7 @@ Add to your `pubspec.yaml`:
 ```yaml
 dependencies:
   permissionless_passkeys: ^0.1.2
-  permissionless: ^0.4.0  # Required peer dependency
+  permissionless: ^0.4.1  # Required peer dependency
 ```
 
 Then run:

--- a/packages/permissionless_passkeys/example/pubspec.yaml
+++ b/packages/permissionless_passkeys/example/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   flutter:
     sdk: flutter
   permissionless_passkeys: ^0.1.2
-  permissionless: ^0.4.0
+  permissionless: ^0.4.1
   web3_signers: ^1.0.0
   flutter_riverpod: ^3.3.2
   shared_preferences: ^2.3.0

--- a/packages/permissionless_passkeys/pubspec.yaml
+++ b/packages/permissionless_passkeys/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   flutter:
     sdk: flutter
   # Core ERC-4337 package (sibling in monorepo)
-  permissionless: ^0.4.0
+  permissionless: ^0.4.1
   # PassKeySigner, P256 utilities (brings: passkeys, asn1lib, pointycastle)
   # Using local fork with macOS/Windows platform support
   web3_signers: ^1.0.0


### PR DESCRIPTION
## Release: permissionless 0.4.1

Ships the EIP-7702 + ERC-20 paymaster fix (#50, thanks @KabaDH), the per-version example runners (#45), and the web3dart 3.0.3 bump (#36).

- Bump `permissionless` 0.4.0 → 0.4.1 with a Keep-a-Changelog entry
- Update all `permissionless: ^0.4.0` references to `^0.4.1` (READMEs, passkeys pubspec, passkeys example) — no passkeys release needed since `^0.4.0` already matches 0.4.1

After squash-merge: tag `permissionless-v0.4.1` on the merge commit to trigger the OIDC pub.dev publish, then create the GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)