### PR TITLE
docs: Kernel v4 / EntryPoint v0.9 ADR, glossary, and README

### DIFF
--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -1,0 +1,21 @@
+# Context Map
+
+This monorepo has one primary bounded context per package. System-wide
+decisions live under [`docs/adr/`](docs/adr/).
+
+## Contexts
+
+- [permissionless](packages/permissionless/CONTEXT.md) — ERC-4337 smart
+  accounts, UserOperations, bundler/paymaster clients, and shared encoding
+  utilities
+- [permissionless_passkeys](packages/permissionless_passkeys/) — WebAuthn /
+  passkey owners and Flutter helpers that plug into `permissionless` accounts
+  (no package glossary yet; terms for smart-account ownership live in
+  `permissionless`)
+
+## Relationships
+
+- **permissionless_passkeys → permissionless**: passkey credentials surface as
+  an `AccountOwner` (or equivalent owner) consumed by Kernel, Safe, and other
+  accounts in the core package. Domain language for accounts, EntryPoints, and
+  validation belongs to `permissionless`.

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ permissionless-dart/
 
 ### Core Package (`permissionless`)
 - **Safe** (Gnosis) - battle-tested multi-sig account
-- **Kernel** (ZeroDev) - modular account, ERC-7579 in v0.3.x
+- **Kernel** (ZeroDev) - modular account; ERC-7579 in v0.3.x; Kernel v4.0 on EntryPoint v0.9 (UUPS, ImmutableECDSA, Kernel7702)
 - **Nexus** (Biconomy) - ERC-7579 modular account
 - **Light** (Alchemy) - gas-efficient single-owner account
 - **Simple** (eth-infinitism) - minimal reference implementation

--- a/docs/adr/0001-entrypoint-v09-paymaster-signature-framing.md
+++ b/docs/adr/0001-entrypoint-v09-paymaster-signature-framing.md
@@ -7,7 +7,8 @@
 
 This ADR records the framing question ticket 01 was required to resolve
 against contract truth. The broader "why the Kernel v4 contracts, not
-permissionless.js, are the parity baseline" decision is a separate, later ADR.
+permissionless.js, are the parity baseline" decision is
+[ADR 0002](./0002-kernel-v4-parity-baseline.md).
 
 ## Context
 

--- a/docs/adr/0002-kernel-v4-parity-baseline.md
+++ b/docs/adr/0002-kernel-v4-parity-baseline.md
@@ -1,0 +1,101 @@
+# ADR 0002 — Kernel v4.0 parity baseline and pins
+
+- **Status:** accepted
+- **Date:** 2026-07-30
+- **Scope:** Kernel v4.0 account surface, EntryPoint v0.9 shared hashing,
+  release address constants
+
+This ADR records why Kernel v4 does not follow permissionless.js, which
+oracles define correctness, which contract addresses are pinned, and why
+userOpHash is shared. Paymaster-signature framing for EntryPoint v0.9 is
+decided in [ADR 0001](./0001-entrypoint-v09-paymaster-signature-framing.md).
+
+## Context
+
+Kernel v4.0 is a new modular account generation (ERC-7579 modules, nonce-encoded
+validation mode/type/id, enable-mode installs, permissions, three variants:
+UUPS, ImmutableECDSA, Kernel7702). It targets EntryPoint v0.9 exclusively.
+
+permissionless.dart’s historical rule is “match permissionless.js.” That rule
+does not apply here: **permissionless.js does not ship Kernel v4.** Treating
+the TypeScript package as the baseline would invent a port of something that
+does not exist, or freeze the Dart library on older Kernel lines forever.
+
+Correctness therefore needs a different ground truth: the Kernel v4.0 contracts
+and the EntryPoint v0.9 packing/hash behavior already established in the
+ecosystem (eth-infinitism contracts + current viem).
+
+## Decision
+
+### Parity baseline
+
+| Surface | Baseline | Not the baseline |
+| --- | --- | --- |
+| Kernel v4.0 account behavior (addresses, factory/salt, nonce layout, signatures, modules, enable mode, permissions, Kernel7702) | Kernel v4.0 contracts, release **v0.4.0** | permissionless.js |
+| EntryPoint v0.9 packing, `paymasterAndData`, userOpHash | eth-infinitism EntryPoint v0.9 + **viem 2.44.4** (and later) | Vendored workspace `viem/` if stale; permissionless.js |
+| Kernel v0.2.x / v0.3.x | permissionless.js (unchanged) | — |
+
+When a future permissionless.js Kernel v4 lands, a follow-up may add
+cross-SDK vectors. That is optional polish, not a blocker for this feature.
+
+### Shared userOpHash
+
+Introduce (and prefer) a shared `getUserOperationHash` /
+`getUserOperationTypedData` that branches on EntryPoint version for
+v0.6–v0.9. Kernel v4 is the first consumer of the v0.9 path; other accounts
+migrate off private hash copies so packing/hash bugs are fixed once.
+
+- EntryPoint v0.9 uses EIP-712 domain name `ERC4337`, version `1`, with primary
+  type `PackedUserOperation` (same family as v0.8).
+- Paymaster-signature framing in the packed blob follows **ADR 0001** (contract
+  truth: wire suffix `sig ‖ uint16(len) ‖ magic`; hash uses `prefix ‖ magic`).
+- Safe’s SafeOp digest remains a separate account-specific path; it is not
+  replaced by the shared utility.
+
+### Release address pins
+
+**EntryPoint v0.9** (canonical eth-infinitism, same address on all chains):
+
+- `0x433709009B8330FDa32311DF1C2AFA402eD8D009`
+
+**Kernel release v0.4.0** CREATE2 predictions (deterministic deployer
+`0x4e59b44847b379578588920cA78FbF26c0B4956C`, salt 0; recorded in release
+metadata `releases/v0.4.0.json`). No confirmed public multi-chain deployment
+table is assumed; addresses are permissionless and stable where the recipe
+has been run. Per-account overrides exist for private or forked deployments.
+
+| Contract | Address |
+| --- | --- |
+| KernelUUPS | `0xC842fE2aC44046AE3cEf033A16c67a9BC287cbD2` |
+| KernelImmutableECDSA | `0x6F0999265B6E1dFbe875F104548b875a99A65d37` |
+| KernelFactory | `0xA299A4eFee7BBFb2Ea5668b30218C45fff78356c` |
+| Staker | `0x58E2fD56990250b0eE784d15905C9856209226aE` |
+| Kernel7702 | `0x36312BA78010247390C6677a59807Fe7878e9B59` |
+
+No library default is pinned for an external ECDSA or WebAuthn **validator
+module** address: Kernel v4 release artifacts do not yet publish production
+validator deployments for every path. Callers that need an external root
+validator supply the module address explicitly. ImmutableECDSA does not
+require one (immutable fallback signer in the clone).
+
+## Consequences
+
+- Contributors looking for “the JS Kernel v4 port” will not find one; they
+  should read the contracts and this ADR instead of permissionless.js.
+- Golden vectors for EntryPoint v0.9 and Kernel v4 are generated from pinned
+  contracts (and viem where it agrees) and committed so offline tests do not
+  require Foundry.
+- Changing a pin is a deliberate release decision: update constants, regenerate
+  fixtures, and revise this ADR (or supersede it).
+- Existing Kernel v0.2/v0.3 and EntryPoint v0.6–v0.8 behavior remains
+  permissionless.js–aligned and non-breaking when v0.9/v4 are added.
+
+## References
+
+- [ADR 0001](./0001-entrypoint-v09-paymaster-signature-framing.md) — EntryPoint
+  v0.9 paymaster signature framing
+- Kernel v4.0 release metadata (`releases/v0.4.0.json` in the workspace Kernel
+  v4.0 tree)
+- eth-infinitism `account-abstraction` EntryPoint v0.9
+- viem account-abstraction EntryPoint v0.9 (`getUserOperationHash`,
+  `toPackedUserOperation`)

--- a/packages/permissionless/CONTEXT.md
+++ b/packages/permissionless/CONTEXT.md
@@ -1,0 +1,117 @@
+# permissionless
+
+Dart ERC-4337 smart-account SDK: accounts, UserOperations, clients, and
+encoding utilities for account abstraction.
+
+## Language
+
+### EntryPoint and UserOperations
+
+**EntryPoint**:
+The singleton ERC-4337 contract that validates and executes UserOperations.
+_Avoid_: bundler, paymaster
+
+**EntryPoint version**:
+A published EntryPoint contract generation (v0.6, v0.7, v0.8, v0.9) with its
+own canonical address and UserOperation layout rules.
+_Avoid_: “latest EntryPoint” without a version
+
+**UserOperation**:
+The ERC-4337 operation a smart account submits through a bundler to an
+EntryPoint.
+_Avoid_: transaction, call (a single target invocation inside a UserOperation)
+
+**Packed UserOperation**:
+The EntryPoint v0.7+ field layout that packs gas and paymaster data into fewer
+slots than v0.6.
+_Avoid_: “v0.9 UserOperation” as a separate shape when fields match the packed
+era
+
+**userOpHash**:
+The digest the account signs for a UserOperation under a given EntryPoint
+version and chain.
+_Avoid_: transaction hash; the bundler’s submitted UserOperation hash (a
+different identifier)
+
+**Paymaster signature**:
+Optional paymaster-authored bytes on EntryPoint v0.9 that let the user and
+paymaster sign concurrently.
+_Avoid_: account signature; paymaster data (sponsorship payload without the
+parallel-sign artifact)
+
+### Kernel v4
+
+**Kernel v4**:
+ZeroDev’s Kernel line that targets EntryPoint v0.9 and uses nonce-encoded
+validation with ERC-7579-style modules.
+_Avoid_: Kernel v0.3.x; “Kernel” alone when the major line matters
+
+**UUPS (KernelUUPS)**:
+The upgradeable Kernel v4 proxy variant.
+_Avoid_: ImmutableECDSA; Kernel7702
+
+**ImmutableECDSA**:
+The Kernel v4 variant with an immutable fallback ECDSA signer set at
+deployment.
+_Avoid_: UUPS; Kernel7702
+
+**Kernel7702**:
+The Kernel v4 implementation used as an EIP-7702 delegation target so an EOA
+gains modular Kernel features without a separate factory-deployed proxy.
+_Avoid_: UUPS; ImmutableECDSA
+
+**Validation mode**:
+How Kernel v4 selects standard vs enable behavior and chain-bound vs
+replayable hashing for a UserOperation.
+_Avoid_: validation type
+
+**Validation type**:
+Which kind of entity authorizes the UserOperation: root/fallback, validator,
+or permission.
+_Avoid_: validation mode; module type
+
+**Validation id**:
+The identity of the non-root authorizing entity (a validator or a
+PermissionId).
+_Avoid_: nonce key; sequence
+
+**PermissionId**:
+The identity of a Kernel v4 permission composed of policies plus one signer.
+_Avoid_: session key; validator id
+
+**Enable mode**:
+A validation mode that installs modules atomically with the first validation
+of a UserOperation.
+_Avoid_: a separate module-install UserOperation without enable framing
+
+**Install package**:
+A single module-install unit (type, module, module data, internal data) used
+at account initialize, batch install, and enable mode.
+_Avoid_: “module” alone when the full install unit is meant
+
+**Permission**:
+A Kernel v4 authorization path under a PermissionId: policies plus a signer
+that validate together.
+_Avoid_: validator; owner
+
+### Shared account vocabulary
+
+**Smart account**:
+A contract account that validates UserOperations (and often ERC-1271
+signatures) per its implementation rules.
+_Avoid_: wallet; account abstraction (the broader design space)
+
+**Account owner**:
+The local signing principal the SDK uses to produce signatures for a smart
+account (EOA key, passkey, etc.).
+_Avoid_: validator; signer module
+
+**Bundler**:
+An ERC-4337 RPC service that accepts UserOperations and submits them to the
+EntryPoint.
+_Avoid_: EntryPoint; paymaster
+
+**Paymaster**:
+A contract or service that sponsors gas for a UserOperation under EntryPoint
+rules.
+_Avoid_: bundler; paymaster signature

--- a/packages/permissionless/README.md
+++ b/packages/permissionless/README.md
@@ -8,17 +8,17 @@ Build account abstraction applications in Dart with support for multiple smart a
 
 ### Smart Accounts
 
-| Account       | Provider       | EntryPoint | ERC-7579   | Description                      |
-| ------------- | -------------- | ---------- | ---------- | -------------------------------- |
-| **Safe**      | Gnosis         | v0.6, v0.7 | Optional*  | Battle-tested multi-sig account  |
-| **Kernel**    | ZeroDev        | v0.6, v0.7 | v0.3.x     | Modular account with plugins     |
-| **Nexus**     | Biconomy       | v0.7       | Yes        | ERC-7579 modular account         |
-| **Light**     | Alchemy        | v0.6, v0.7 | No         | Gas-efficient single-owner       |
-| **Simple**    | eth-infinitism | v0.6, v0.7 | No         | Minimal reference implementation |
-| **Thirdweb**  | Thirdweb       | v0.6, v0.7 | No         | SDK ecosystem integration        |
-| **Trust**     | Trust Wallet   | v0.6       | No         | Diamond architecture (Barz)      |
-| **Etherspot** | Etherspot      | v0.7       | Internal** | ModularEtherspotWallet           |
-| **Biconomy**  | Biconomy       | v0.6       | No         | *Deprecated - use Nexus*         |
+| Account       | Provider       | EntryPoint        | ERC-7579   | Description                      |
+| ------------- | -------------- | ----------------- | ---------- | -------------------------------- |
+| **Safe**      | Gnosis         | v0.6, v0.7        | Optional*  | Battle-tested multi-sig account  |
+| **Kernel**    | ZeroDev        | v0.6, v0.7, v0.9  | v0.3.x, v4 | Modular account (plugins / modules) |
+| **Nexus**     | Biconomy       | v0.7              | Yes        | ERC-7579 modular account         |
+| **Light**     | Alchemy        | v0.6, v0.7        | No         | Gas-efficient single-owner       |
+| **Simple**    | eth-infinitism | v0.6, v0.7, v0.8  | No         | Minimal reference implementation |
+| **Thirdweb**  | Thirdweb       | v0.6, v0.7        | No         | SDK ecosystem integration        |
+| **Trust**     | Trust Wallet   | v0.6              | No         | Diamond architecture (Barz)      |
+| **Etherspot** | Etherspot      | v0.7              | Internal** | ModularEtherspotWallet           |
+| **Biconomy**  | Biconomy       | v0.6              | No         | *Deprecated - use Nexus*         |
 
 \* Safe requires `erc7579LaunchpadAddress` configuration to enable ERC-7579 module management.
 \** Etherspot uses ERC-7579 call encoding internally but module management actions are not exposed in permissionless.js.
@@ -166,7 +166,7 @@ final account = createSafeSmartAccount(
 
 ### Kernel Account
 
-ZeroDev's modular smart account with plugin support:
+ZeroDev's modular smart account with plugin/module support:
 
 ```dart
 final owner = PrivateKeyKernelOwner('0x...');
@@ -181,6 +181,13 @@ final account = createKernelSmartAccount(
 **Features:**
 - v0.2.x (v0.2.1-v0.2.4): EntryPoint v0.6, custom execute
 - v0.3.x (v0.3.0-beta, v0.3.1, v0.3.2, v0.3.3): EntryPoint v0.7, ERC-7579 compliant, external ECDSA validator
+- v4.0: EntryPoint v0.9 only — UUPS, ImmutableECDSA, and Kernel7702 variants; nonce-encoded validation (root / validator / permission); enable-mode installs; permissions (policies + signer)
+
+Kernel v4 is **not** ported from permissionless.js (which has no Kernel v4
+surface yet). Correctness is pinned to the Kernel v4.0 contracts and
+EntryPoint v0.9 packing/hash rules — see
+[ADR 0002](../../docs/adr/0002-kernel-v4-parity-baseline.md) and the
+[glossary](CONTEXT.md).
 
 ### Nexus Account (Biconomy)
 
@@ -471,7 +478,7 @@ final credentials = await passkeyServer.getCredentials(
 
 ## ERC-7579 Actions
 
-For ERC-7579 compliant accounts (Kernel v0.3.x, Safe 7579, Nexus):
+For ERC-7579 compliant accounts (Kernel v0.3.x / v4.0, Safe 7579, Nexus):
 
 ```dart
 // Install a module
@@ -593,10 +600,16 @@ final allowanceOverride = erc20AllowanceOverride(
 
 ## EntryPoint Versions
 
-| Version | Address         | Accounts                                                                            |
-| ------- | --------------- | ----------------------------------------------------------------------------------- |
-| v0.6    | `0x5FF1...2789` | Safe v1.4.1, Kernel v0.2.4, Light v1.1.0, Trust                                     |
-| v0.7    | `0x0000...0070` | Safe v1.4.1/v1.5.0, Kernel v0.3.1, Nexus, Light v2.0.0, Simple, Thirdweb, Etherspot |
+| Version | Address                                    | Accounts                                                                                     |
+| ------- | ------------------------------------------ | -------------------------------------------------------------------------------------------- |
+| v0.6    | `0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789` | Safe v1.4.1, Kernel v0.2.4, Light v1.1.0, Trust                                              |
+| v0.7    | `0x0000000071727De22E5E9d8BAf0edAc6f37da032` | Safe v1.4.1/v1.5.0, Kernel v0.3.x, Nexus, Light v2.0.0, Simple, Thirdweb, Etherspot         |
+| v0.8    | `0x4337084d9e255ff0702461cf8895ce9e3b5ff108` | Simple (EIP-7702 path) and other v0.8-capable accounts                                       |
+| v0.9    | `0x433709009B8330FDa32311DF1C2AFA402eD8D009` | Kernel v4.0 (UUPS, ImmutableECDSA, Kernel7702); optional paymaster signature on packed ops |
+
+EntryPoint v0.9 paymaster-signature framing and the shared userOpHash utility
+are recorded in [ADR 0001](../../docs/adr/0001-entrypoint-v09-paymaster-signature-framing.md)
+and [ADR 0002](../../docs/adr/0002-kernel-v4-parity-baseline.md).
 
 ## Examples
 


### PR DESCRIPTION
## Summary

Ticket **#10** from the Kernel v4 + EntryPoint v0.9 workstream: document decisions and surface the feature in the public docs.

- **ADR 0001** — link the existing EntryPoint v0.9 paymaster-signature framing decision to ADR 0002 (file already present from ticket 01)
- **ADR 0002** — Kernel v4.0 parity baseline (contracts + viem EP v0.9, **not** permissionless.js), release address pins, shared `userOpHash`
- **Glossary** — `CONTEXT-MAP.md` + `packages/permissionless/CONTEXT.md` (Kernel v4 / EP v0.9 vocabulary)
- **README** — account matrix and EntryPoint table include Kernel v4.0 and EntryPoint v0.9

## Stack

Stacked on `worktree-kernel-v4-permissions` (PR #61 tip / Kernel7702 + session-key work).

```
#53 EP v0.9 primitives
  └ #56 ImmutableECDSA
    └ #57 UUPS
      └ #58 validation / non-root
        └ #59 enable-mode
          └ #60 modules
            └ #61 permissions / Kernel7702 tip
              └ **this PR (docs)**
```

## Test plan

- [x] Docs-only change; relative links resolve
- [x] `dart test -P quick` green on prior stack commits (no production code in this PR)
- [ ] CI on draft PR